### PR TITLE
Add Modal component

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,11 @@
+image: node0.10
+publish:
+   npm:
+     email: $$npm_drone_email
+     password: $$npm_drone_password
+     registry: https://registry.npmjs.org
+     username: $$npm_drone_username
+     when:
+       branch: master
+script:
+- npm install npm@2.7.0 -g

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,4 +8,4 @@ publish:
      when:
        branch: master
 script:
-- npm install npm@2.7.0 -g
+- nvm install v5.7.1 &> /dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+*~
+.DS_Store
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # Clever Components
+
+## Install
+
+Install the NPM package and save it to your project using
+
+```
+npm install --save-dev clever-components
+```
+
+To use a component, you'll need to be working with React and Webpack. Components that include their own styles may require you to install Webpack's style loaders. If this is configured correctly, you can simply `require` these components like any other package:
+
+```javascript
+var Modal = require('clever-components').Modal; // ES5
+
+import {Modal} from 'clever-components'; // ES6
+```
+
+## Components
+
+### Modal
+
+This component wraps your content and displays it in a modal with a shadow box.
+
+**Options**
+
+| Prop | Type | Description | Default |
+|----|----|----|----|
+| title | String | Header text for the modal | None |
+| closeModal | Function | Called when user clicks outside modal |None
+| width (optional) | Number | Width of the modal | 400px |
+
+
+**Usage Example**
+
+```jsx
+{this.state.showModal &&
+  <Modal title="My Modal" closeModal={myCloseHandler}>
+    <div>My Modal Content</div>
+  </Modal> }
+```
+In this example, the function `myCloseHandler` could hide the modal by updating the state of your component:
+
+```javascript
+var myCloseHandler = function() {
+  this.setState({showModal: false});
+}
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./src');

--- a/index.js
+++ b/index.js
@@ -1,1 +1,3 @@
-module.exports = require('./src');
+module.exports = {
+  Modal: require("./src/Modal/Modal")
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "clever-components",
+  "version": "0.0.1",
+  "description": "A library of helpful React components",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Clever/components.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Clever/components/issues"
+  },
+  "homepage": "https://github.com/Clever/components",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,11 +6,20 @@
     "type": "git",
     "url": "git+https://github.com/Clever/components.git"
   },
+  "main": "index.js",
   "bugs": {
     "url": "https://github.com/Clever/components/issues"
   },
   "homepage": "https://github.com/Clever/components",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
+  },
+  "devDependencies": {
+    "css-loader": "^0.23.1",
+    "jsx-loader": "^0.13.2",
+    "less": "^2.6.1",
+    "less-loader": "^2.2.2",
+    "react": "^0.14.7",
+    "style-loader": "^0.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -18,7 +18,7 @@ var Modal = React.createClass({
           }}>
           <div className="Modal--window--container">
             <h2>{this.props.title}</h2>
-            {this.props.content}
+            {this.props.children}
           </div>
         </div>
       </div>

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -1,0 +1,29 @@
+var React = require('react');
+
+require("./Modal.less");
+
+var DEFAULT_WIDTH = 400;
+
+var Modal = React.createClass({
+  render: function() {
+    var width = this.props.width || DEFAULT_WIDTH;
+    return (
+      <div className="Modal">
+        <div className="Modal--background" onClick={this.props.closeModal}/>
+        <div
+          className="Modal--window"
+          style={{
+            width: width + "px",
+            marginLeft: "-" + (width / 2) + "px"
+          }}>
+          <div className="Modal--window--container">
+            <h2>{this.props.title}</h2>
+            {this.props.content}
+          </div>
+        </div>
+      </div>
+    );
+  }
+});
+
+module.exports = Modal;

--- a/src/Modal/Modal.less
+++ b/src/Modal/Modal.less
@@ -1,0 +1,32 @@
+.Modal {
+  position: fixed;
+  z-index: 200;
+}
+
+.Modal--background {
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  background: #000;
+  opacity: 0.6;
+  filter: alpha(opacity=60);
+}
+
+.Modal--window {
+  top: 50%;
+  left: 50%;
+  margin-top: 60px;
+  position: fixed;
+  background: #fff;
+  border: 6px solid #3b4349;
+  border-radius: 4px;
+}
+
+.Modal--window--container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  padding: 35px 45px;
+}


### PR DESCRIPTION
**Summary**
This PR adds the reusable Modal component that @kshen0 made and some additional config for this repo, such as dev dependencies and a .gitignore. Made one change to the modal by using `this.props.children` instead of `this.props.content` so that you can just wrap the content with the Modal tags:
```html
<Modal>
  <div>Your content here</div>
</Modal>
```
**Follow up tasks**
* Add tests for this component
* Add a ⓧ to close the modal and support for the escape key

**Gotchas**
To use this component in your project, you need to have Webpack configured. The dependencies needed for loading JSX and LESS are in the devDependencies of this repo, so Webpack should be able to find them. This is still very much a work in progress, though, so let us know if you encounter problems.
