### PR TITLE
Easier imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,2 @@
-module.exports = {
-  Modal: require("./src/Modal/Modal")
-}
+export { Modal } from './src/Modal/Modal';
+export { Button } from './src/Button/Button';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-require('./Button.less');
+require('!style!css!less!./Button.less');
 
 export class Button extends React.Component {
   constructor(props) {

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -4,7 +4,7 @@ require("./Modal.less");
 
 var DEFAULT_WIDTH = 400;
 
-var Modal = React.createClass({
+export var Modal = React.createClass({
   render: function() {
     var width = this.props.width || DEFAULT_WIDTH;
     return (
@@ -25,5 +25,3 @@ var Modal = React.createClass({
     );
   }
 });
-
-module.exports = Modal;

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -1,6 +1,6 @@
 var React = require('react');
 
-require("./Modal.less");
+require("!style!css!less!./Modal.less");
 
 var DEFAULT_WIDTH = 400;
 


### PR DESCRIPTION
I added Button to `index.js` and changed this file to use the ES6 export syntax. This will simplify the import syntax for consumers -- for example, you can write:
```javascript
import {Button} from "clever-components"; // ES6
```
or
```javascript
var Button = require("clever-components").Button // ES5
```
instead of writing
```javascript
var Button = require("clever-components/src/Button/Button").default
```
Todo: Confirm that this works outside of Chrome. 