### PR TITLE
Remove modal top position

### DIFF
--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -5,17 +5,22 @@ require("./Modal.less");
 var DEFAULT_WIDTH = 400;
 
 var Modal = React.createClass({
+  propTypes: {
+    closeModal: React.PropTypes.func.isRequired,
+    title: React.PropTypes.string,
+    width: React.PropTypes.number,
+  },
   render: function() {
     var width = this.props.width || DEFAULT_WIDTH;
+    var modalStyles = {
+      width: width + "px",
+      marginLeft: "-" + (width / 2) + "px"
+    };
+
     return (
       <div className="Modal">
         <div className="Modal--background" onClick={this.props.closeModal}/>
-        <div
-          className="Modal--window"
-          style={{
-            width: width + "px",
-            marginLeft: "-" + (width / 2) + "px"
-          }}>
+        <div className="Modal--window" style={modalStyles}>
           <div className="Modal--window--container">
             <h2>{this.props.title}</h2>
             {this.props.children}

--- a/src/Modal/Modal.less
+++ b/src/Modal/Modal.less
@@ -15,7 +15,6 @@
 }
 
 .Modal--window {
-  top: 50%;
   left: 50%;
   margin-top: 60px;
   position: fixed;


### PR DESCRIPTION
Having both `top` and `margin-top` CSS attributes on the Modal window pushes the modal pretty far down the page. This PR removes the `top` attribute.