### PR TITLE
Remove inline loaders and fix Modal test

### DIFF
--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-require("!style!css!less!./Button.less");
+require("./Button.less");
 
 export class Button extends React.Component {
   constructor(props) {

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -1,6 +1,6 @@
 var React = require("react");
 
-require("!style!css!less!./Modal.less");
+require("./Modal.less");
 
 const DEFAULT_WIDTH = 400;
 

--- a/test/Modal_test.js
+++ b/test/Modal_test.js
@@ -1,3 +1,5 @@
+/*eslint func-names: "off"*/
+
 var assert = require("assert");
 var React = require("react");
 var sinon = require("sinon");
@@ -5,7 +7,7 @@ var TestUtils = require("react-addons-test-utils");
 
 import {Modal} from "../";
 
-describe("Modal", () => {
+describe("Modal", function() {
   var exampleModal = (
     <Modal title="My Title">
       <div>Example Content</div>


### PR DESCRIPTION
The inline loaders added in https://github.com/Clever/components/pull/4 caused new tests to fail. Fixing that revealed an issue in the test file where `this` was undefined and was fixed by changing `() =>` back to `function()`.