### PR TITLE
onClick optional

### DIFF
--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -42,5 +42,5 @@ Button.propTypes = {
   href: React.PropTypes.string,
   target: React.PropTypes.oneOf(["_self", "_blank"]),
   disabled: React.PropTypes.bool,
-  onClick: React.PropTypes.function,
+  onClick: React.PropTypes.func,
 };


### PR DESCRIPTION
`React.propTypes.function` seems to make a prop required.

Changing it to `React.propTypes.func` makes it optional, which is correct for `onClick`.