### PR TITLE
Modal extends React.Component

### DIFF
--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -4,7 +4,7 @@ require("./Modal.less");
 
 const DEFAULT_WIDTH = 400;
 
-export class Modal {
+export class Modal extends React.Component {
   render() {
     const width = this.props.width || DEFAULT_WIDTH;
     return (

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -5,6 +5,12 @@ require("./Modal.less");
 const DEFAULT_WIDTH = 400;
 
 export class Modal extends React.Component {
+  propTypes: {
+    children: React.PropTypes.array,
+    closeModal: React.PropTypes.func,
+    title: React.PropTypes.string,
+    width: React.PropTypes.number,
+  },
   render() {
     const width = this.props.width || DEFAULT_WIDTH;
     return (


### PR DESCRIPTION
Console warns unless the Modal class extends React.Component