### PR TITLE
Convert to ES5 before publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,15 @@ MOCHA_JSX := node_modules/mocha/bin/mocha --compilers jsx:babel-register --recur
 
 test: lint
 	NODE_ENV=test $(MOCHA_JSX) $@
+
+BABEL := node_modules/babel-cli/bin/babel.js
+
+build:
+	@rm -rf dist
+	@echo '✓ Clean out dist directory'
+	@cp -r src dist
+	@echo '✓ Copy /src to /dist'
+	@$(BABEL) dist -d dist > ._babel_tmp && rm ._babel_tmp
+	@echo '✓ Convert ES6 to ES5'
+	@find ./dist -name "*.jsx" | xargs -d"\n" rm
+	@echo '✓ Remove JSX files'

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ var myCloseHandler = function() {
 
 ### How to add a component
 * Add a new folder to `/src` with your component
-* Add a test in `/test` named `[component]_test.js`
+* Add a test in `/test` named `[component]_test.jsx`
 * Create an example of how to use your component in code
 * Add a working/live example of your component to the docs
-* Export your component in `index.js`
+* Export your component in `src/index.js`
 * Open a PR and assign it to someone in [@frontend](https://github.com/orgs/Clever/teams/front-end)
 

--- a/index.js
+++ b/index.js
@@ -1,2 +1,0 @@
-export {Modal} from "./src/Modal/Modal";
-export {Button} from "./src/Button/Button";

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "git+https://github.com/Clever/components.git"
   },
-  "main": "index.js",
+  "main": "dist/index.js",
   "bugs": {
     "url": "https://github.com/Clever/components/issues"
   },
@@ -21,6 +21,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.7.2",
+    "babel-cli": "^6.0.0",
     "css-loader": "^0.23.1",
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,2 @@
+export {Modal} from "./Modal/Modal";
+export {Button} from "./Button/Button";

--- a/test/Modal_test.jsx
+++ b/test/Modal_test.jsx
@@ -5,7 +5,7 @@ var React = require("react");
 var sinon = require("sinon");
 var TestUtils = require("react-addons-test-utils");
 
-import {Modal} from "../";
+import {Modal} from "../src";
 
 describe("Modal", function () {
   var exampleModal = (

--- a/test_drone.sh
+++ b/test_drone.sh
@@ -6,3 +6,4 @@ npm cache clean
 npm install
 
 make test
+make build


### PR DESCRIPTION
We've been seeing some issues across the board when importing and testing components. Most of these problems stem from the way babel-loader and babel-register ignore `node_modules` by default. 

This PR adds a build step prior to publishing that will create an ES5 version of the components in `dist/`. The process of contributing and using this repo remain the same, but there should be significantly less confusion about how to configure webpack. 