### PR TITLE
Add Button type options and custom styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ var myCloseHandler = function() {
 }
 ```
 
+### Button
+
+This is a set of button components with various sizes and types.
+
+**Options**
+
+| Prop | Type | Description | Default |
+|----|----|----|----|
+| value | String | The text that appears on the button | None
+| type | String | One of `primary`, `secondary`, `destructive`, `link` | `secondary`
+| size | String | One of "large", "regular", "small" | `regular`
+| onClick (optional) | Function | Called when the user clicks on the button | None
+| href (optional) | String | If provided, causes the button to behave as a link | None
+| target (optional) | String | For links, either "_self" or "_blank" | "_blank"
+| disabled | Bool | User interaction is disabled when true | false
+| submit | Bool | Behaves as a submit button when true | false
+| style | Object | Add custom styles (e.g. margin) if you must | None
+
+**Usage Example**
+
+```jsx
+<Button value="Go Back" type="secondary" href="/previousPage" />
+<Button value="Save Changes" type="primary" size="regular" onClick={saveChanges} />
+```
+
 ## Contributing
 
 ### When to add a component

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ This component wraps your content and displays it in a modal with a shadow box.
 
 **Options**
 
-| Prop | Type | Description | Default |
-|----|----|----|----|
-| title | String | Header text for the modal | None |
-| closeModal | Function | Called when user clicks outside modal |None
-| width (optional) | Number | Width of the modal | 400px |
+| Prop             | Type     | Description                           | Default
+|------------------|----------|---------------------------------------|---------
+| title            | String   | Header text for the modal             | None
+| closeModal       | Function | Called when user clicks outside modal | None
+| width (optional) | Number   | Width of the modal                    | 400px
 
 
 **Usage Example**
@@ -53,17 +53,17 @@ This is a set of button components with various sizes and types.
 
 **Options**
 
-| Prop | Type | Description | Default |
-|----|----|----|----|
-| value | String | The text that appears on the button | None
-| type | String | One of `primary`, `secondary`, `destructive`, `link` | `secondary`
-| size | String | One of "large", "regular", "small" | `regular`
-| onClick (optional) | Function | Called when the user clicks on the button | None
-| href (optional) | String | If provided, causes the button to behave as a link | None
-| target (optional) | String | For links, either "_self" or "_blank" | "_blank"
-| disabled | Bool | User interaction is disabled when true | false
-| submit | Bool | Behaves as a submit button when true | false
-| style | Object | Add custom styles (e.g. margin) if you must | None
+| Prop                | Type     | Description                                          | Default
+|---------------------|----------|------------------------------------------------------|---------
+| value               | String   | The text that appears on the button                  | None
+| type                | String   | One of `primary`, `secondary`, `destructive`, `link` | `secondary`
+| size                | String   | One of "large", "regular", "small"                   | `regular`
+| onClick (optional)  | Function | Called when the user clicks on the button            | None
+| href (optional)     | String   | If provided, causes the button to behave as a link   | None
+| target (optional)   | String   | For links, either "_self" or "_blank"                | "_blank"
+| disabled (optional) | Bool     | User interaction is disabled when true               | false
+| submit (optional)   | Bool     | Behaves as a submit button when true                 | false
+| style (optional)    | Object   | Add custom styles (e.g. margin) if you must          | None
 
 **Usage Example**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -13,7 +13,7 @@ export function Button(props) {
   if (props.href == null || props.disabled) {
     // use <button>s for all disabled links and things with no href prop (buttons)
     return (
-      <button className={classes} onClick={props.onClick} disabled={props.disabled}>
+      <button type="button" className={classes} onClick={props.onClick} disabled={props.disabled}>
         {props.value}
       </button>
     );
@@ -32,7 +32,7 @@ Button.defaultProps = {
 };
 
 Button.propTypes = {
-  type: React.PropTypes.oneOf(["primary", "secondary", "destructive"]),
+  type: React.PropTypes.oneOf(["primary", "secondary", "destructive", "link"]),
   size: React.PropTypes.oneOf(["large", "regular", "small"]),
   value: React.PropTypes.string.isRequired,
   href: React.PropTypes.string,

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -7,19 +7,30 @@ export function Button(props) {
     throw new Error("Small destructive buttons are not supported");
   }
 
+  if (props.href && props.onClick) {
+    throw new Error("Buttons cannot have both href and onClick options");
+  }
+
+  if (props.href && props.submit) {
+    throw new Error("Buttons with href do not support the submit option");
+  }
+
   let classes = "Button ";
   classes += `Button--${props.type} `;
   classes += `Button--${props.size} `;
+
+  let type = props.submit ? "submit" : "button";
+
   if (props.href == null || props.disabled) {
     // use <button>s for all disabled links and things with no href prop (buttons)
     return (
-      <button type="button" className={classes} onClick={props.onClick} disabled={props.disabled}>
+      <button type={type} className={classes} onClick={props.onClick} disabled={props.disabled} style={props.style}>
         {props.value}
       </button>
     );
   }
   return (
-    <a className={classes} target={props.target} href={props.href}>
+    <a className={classes} target={props.target} href={props.href} style={props.style}>
       {props.value}
     </a>
   );
@@ -39,4 +50,6 @@ Button.propTypes = {
   target: React.PropTypes.oneOf(["_self", "_blank"]),
   disabled: React.PropTypes.bool,
   onClick: React.PropTypes.func,
+  submit: React.PropTypes.bool,
+  style: React.PropTypes.object,
 };

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -75,6 +75,18 @@ a, button {
     }
   }
 
+  &.Button--link {
+    background-color: none;
+    color: #4274F6;
+
+    &:hover,
+    &:focus,
+    &:active {
+      background-color: none;
+      color: #345CC4;
+    }
+  }
+
   &.Button--small {
     padding: 10px 15px 5px 15px;
     font-size: 10px;


### PR DESCRIPTION
This adds a "link" button type that's useful for patterns where we have a primary button with a secondary action that doesn't need to be a button like this:



![screen shot 2016-04-14 at 3 16 07 pm](https://cloud.githubusercontent.com/assets/1131461/14545433/d7d399dc-0253-11e6-9324-6dc93c459590.png)

This also adds `type="button"` to all buttons so that they don't automatically act as submit buttons in forms. Because we already use `type`, then if you do want `type="submit"` you can set `submit` and it will handle it:

```jsx
<Button value="Submit" type="primary" onClick={handleClick} submit /> 
```

Additionally, support for custom styles is now allowed for convenience until we come to a consensus on spacing and style guidelines: 
```jsx
<Button style={{marginRight: 10}} ...  />
```

Also updated the readme to include all of this