### PR TITLE
Fix spacing in modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *~
 .DS_Store
 npm-debug.log
+dist

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -37,9 +37,9 @@ export class Modal extends React.Component {
       width: `${this.props.width}px`,
       marginLeft: `-${this.props.width / 2}px`,
     };
-    // The content is 80% of the window height (same as the max height of the modal) less 75px (the height of the header and padding)
+    // The content is max 90% of the window height less 70px (height of the header)
     let contentStyle = {
-      maxHeight: (this.state.windowHeight * 0.8) - 75,
+      maxHeight: (this.state.windowHeight * 0.9) - 70,
     };
     return (
       <div className="Modal">

--- a/src/Modal/Modal.less
+++ b/src/Modal/Modal.less
@@ -27,16 +27,16 @@
   border: 6px solid #3b4349;
   border-radius: 4px;
   font-family: "Proxima Nova";
-  max-height: 80%;
-  box-sizing: border-box;
-  padding-top: 35px;
 }
 
 .Modal--header{
-  padding: 0 45px;
+  height: 70px;
+  padding: 35px 45px 10px;
+  box-sizing: border-box;
 
   h2{
-    margin:0;
+    padding: 0;
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
Makes the max-height taller and fixes an overflow issue caused by the header size being slightly less than it should have been given it was using `border-box`. Tested in chrome and firefox.