### PR TITLE
fix propType errors with single elements

### DIFF
--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -66,5 +66,5 @@ Modal.propTypes = {
   width: React.PropTypes.number,
   title: React.PropTypes.string.isRequired,
   closeModal: React.PropTypes.func.isRequired,
-  children: React.PropTypes.arrayOf(React.PropTypes.element).isRequired,
+  children: React.PropTypes.node.isRequired,
 };


### PR DESCRIPTION
When a single element is used in a Modal, it would complain that you didn't supply an Array; node type allows for single or multiple children elements.

Docs: https://facebook.github.io/react/docs/reusable-components.html