### PR TITLE
Add helper script and update readme

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,8 @@
   "presets": [
     "es2015",
     "react"
+  ],
+  "plugins": [
+    "transform-object-assign"
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,36 @@
-JS_FILES := $(shell find . -name "*.js" -not -path "./node_modules/*" -not -name "bundle.js")
-JSX_FILES := $(shell find . -name "*.jsx" -not -path "./node_modules/*")
-
-.PHONY: test lint
-
-lint:
-	./node_modules/.bin/eslint $(JS_FILES) $(JSX_FILES)
-
-MOCHA_JSX := node_modules/mocha/bin/mocha --compilers jsx:babel-register --recursive --require ignore-styles --require jsdom-global/register
-
-test: lint
-	NODE_ENV=test $(MOCHA_JSX) $@
-
+JS_FILES := $(shell find . -name "*.js" -not -path "./node_modules/*" -not -path "./dist/*" -not -name "bundle.js")
+JSX_FILES := $(shell find . -name "*.jsx" -not -path "./node_modules/*" -not -path "./dist/*")
+TESTS := $(shell find test -name "*_test*")
+LINT := ./node_modules/.bin/eslint
+MOCHA := node_modules/mocha/bin/mocha
+MOCHA_OPTIONS := --compilers jsx:babel-register --recursive --require ignore-styles --require jsdom-global/register
 BABEL := node_modules/babel-cli/bin/babel.js
 
-build:
-	@rm -rf dist
+.PHONY: test lint clean es5 build new $(TESTS)
+
+clean:
 	@echo '✓ Clean out dist directory'
+	@rm -rf dist
+
+es5:
 	@cp -r src dist
 	@echo '✓ Copy /src to /dist'
 	@$(BABEL) dist -d dist > ._babel_tmp && rm ._babel_tmp
 	@echo '✓ Convert ES6 to ES5'
 	@find ./dist -name "*.jsx" | xargs -n1 rm
 	@echo '✓ Remove JSX files'
+
+build: clean es5
+
+lint:
+	@echo "Linting files..."
+	@$(LINT) $(JS_FILES) $(JSX_FILES)
+
+test: lint
+	@echo "Running unit tests..."
+	@NODE_ENV=test $(MOCHA) $(MOCHA_OPTIONS) $@
+
+$(TESTS):
+	@echo "Running tests for $@"
+	@$(LINT) $@
+	@NODE_ENV=test $(MOCHA) $(MOCHA_OPTIONS) $@

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Clever Front End Components
 
+**Jump to** [Modal](#modal), [Button](#button)
+
 ## Install
 
 Install the NPM package and save it to your project using
@@ -16,7 +18,27 @@ var Modal = require('clever-components').Modal; // ES5
 import {Modal} from 'clever-components'; // ES6
 ```
 
-## Components
+## Contributing
+
+### How to add a component
+* Run `./bin/new_component <your component>` to autogenerate source and test stubs
+* Document your component in the readme with PropTypes and a usage example
+* Add a working example of your component in /docs
+* Open a PR and assign it to someone in [@frontend](https://github.com/orgs/Clever/teams/front-end)
+
+#### When to add a component
+
+* Rule of 3: Copy and pasting it more than once? Is it being used in a few places? Yes, componentize it!
+* It's in our desired components list
+  * **Definitely Want**: ~~Buttons~~, ~~Modals~~, form elements, flash messages, alerts, tables
+  * **Eventually**: Header, Navbar, Breadcrumbs, Pagination
+
+## Testing
+Run the entire test suite with `make test` or a single component with `make test/<component>_test.jsx`
+
+## Component Reference
+
+Check out our [live examples](http://clever.github.io/components)!
 
 ### Modal
 
@@ -71,36 +93,3 @@ This is a set of button components with various sizes and types.
 <Button value="Go Back" type="secondary" href="/previousPage" />
 <Button value="Save Changes" type="primary" size="regular" onClick={saveChanges} />
 ```
-
-## Contributing
-
-### When to add a component
-
-* Rule of 3ish - Copy and pasting it more than once? Is it being used in a few places? Yes, componentize it!
-* It's in our desired components list
-
-#### Desired components
-
-**Definitely Want**
-* ~~Buttons~~ (done)
-* ~~Modals~~ (done)
-* Form elements - input, select, radio, checkbox, textarea
-* Flash messages
-* Alerts - sub type of Modal
-* Tables
-
-**Someday Want**
-
-* Header
-* Navbar
-* Breadcrumbs
-* Pagination
-
-### How to add a component
-* Add a new folder to `/src` with your component
-* Add a test in `/test` named `[component]_test.jsx`
-* Create an example of how to use your component in code
-* Add a working/live example of your component to the docs
-* Export your component in `src/index.js`
-* Open a PR and assign it to someone in [@frontend](https://github.com/orgs/Clever/teams/front-end)
-

--- a/bin/example_component.jsx.txt
+++ b/bin/example_component.jsx.txt
@@ -2,6 +2,12 @@ import React from "react";
 
 import "./COMPONENT_NAME.less";
 
+/*
+  Add a description of your component here.
+
+  If your component can be expressed without state,
+  use the stateless function syntax instead!
+*/
 export default class COMPONENT_NAME extends React.Component {
   constructor(props) {
     super(props);

--- a/bin/example_component.jsx.txt
+++ b/bin/example_component.jsx.txt
@@ -1,0 +1,21 @@
+import React from "react";
+
+import "./COMPONENT_NAME.less";
+
+export default class COMPONENT_NAME extends React.Component {
+  constructor(props) {
+    super(props);
+    // Set state and bind methods here
+  }
+
+  /* Insert any additional lifecycle methods,
+     event handlers, and helper methods here */
+
+  render() {
+    // Fill in render method here
+  }
+}
+
+COMPONENT_NAME.propTypes = {
+  // List required and optional proptypes
+}

--- a/bin/example_stylesheet.less.txt
+++ b/bin/example_stylesheet.less.txt
@@ -1,0 +1,11 @@
+.COMPONENT_NAME {
+ /*
+    Use namespaced classes that begin with "COMPONENT_NAME"
+    to avoid clashing with global styles. If possible, avoid
+    over-nesting selectors and instead use clear class names
+    that convey the purpose and/or state of the element:
+
+    .COMPONENT_NAME--container
+    .COMPONENT_NAME--input-disabled
+ */
+}

--- a/bin/example_test.jsx.txt
+++ b/bin/example_test.jsx.txt
@@ -1,0 +1,21 @@
+import assert from "assert";
+import React from "react";
+import sinon from "sinon";
+import {shallow} from "enzyme";
+import {COMPONENT_NAME} from "../src";
+
+describe("COMPONENT_NAME", () => {
+  it("renders (something)", () => {
+    /*
+       Write tests here that assert qualities about
+       COMPONENT_NAME's type, classes, properties,
+       and event handling.
+
+       Refer to enzyme's API and examples for Mocha:
+       http://airbnb.io/enzyme/
+
+       Refer to sinon's API for mocking event functions:
+       http://sinonjs.org/docs/
+    */
+  });
+});

--- a/bin/new_component
+++ b/bin/new_component
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Use relative directory
+cd "${BASH_SOURCE%/*}"
+
+NAME=$1
+IDX_FILE=../src/index.js
+SRC_FILE=../src/$NAME/$NAME.jsx
+LESS_FILE=../src/$NAME/$NAME.less
+TEST_FILE=../test/${NAME}_test.jsx
+
+# Error if directory cannot be created
+mkdir ../src/$NAME 2>/dev/null
+if [[ $? -ne 0 ]] ; then
+  echo "Error: '$NAME' already exists!"
+  exit 1
+fi
+
+# Add component to index.js and create stub files
+echo "export {$NAME} from \"./$NAME/$NAME\";" >> $IDX_FILE
+sed "s/COMPONENT_NAME/$NAME/" ./example_component.jsx.txt > $SRC_FILE
+sed "s/COMPONENT_NAME/$NAME/" ./example_stylesheet.less.txt > $LESS_FILE
+sed "s/COMPONENT_NAME/$NAME/" ./example_test.jsx.txt > $TEST_FILE
+
+GREEN='\033[0;32m'
+DEFAULT='\033[0m'
+
+echo "Successfully created component '$NAME'"
+echo -e "Component: $GREEN'src/$NAME/$NAME.jsx'$DEFAULT"
+echo -e "Less file: $GREEN'src/$NAME/$NAME.less'$DEFAULT"
+echo -e "Unit test: $GREEN'test/${NAME}_test.jsx'$DEFAULT"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-core": "^6.7.4",
     "babel-eslint": "^6.0.2",
     "babel-loader": "^6.2.4",
+    "babel-plugin-transform-object-assign": "^6.5.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.7.2",

--- a/test_drone.sh
+++ b/test_drone.sh
@@ -7,3 +7,4 @@ npm install
 
 make test
 make build
+rm -rf bin


### PR DESCRIPTION
Wrote a helper script called `new_component` that automatically generates helpful stubs for your component. For example, running
```bash
./bin/new_component FooBar
```
would create FooBar.jsx, FooBar.less, and FooBar_test.jsx and also export `FooBar` in index.js for you. I also added a `make clean` command and a command to run tests for a specific component. 