### PR TITLE
add babel-polyfill to build process

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,4 @@
     "es2015",
     "react"
   ],
-  "plugins": [
-    "transform-object-assign"
-  ]
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-eslint": "^6.0.2",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-object-assign": "^6.5.0",
+    "babel-polyfill": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "babel-core": "^6.7.4",
     "babel-eslint": "^6.0.2",
     "babel-loader": "^6.2.4",
-    "babel-plugin-transform-object-assign": "^6.5.0",
     "babel-polyfill": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  entry: "./docs/docs.jsx",
+  entry: ["babel-polyfill", "./docs/docs.jsx"],
   output: {
     path:     "docs",
     filename: "bundle.js",


### PR DESCRIPTION
Allows ES6 methods like `String.startsWith` and `Object.assign`

docs: https://babeljs.io/docs/usage/polyfill/

Either this or #27. If we shouldn't use Babel polyfill for a library, then #27 is the one to do; but this catches all ES6 functionality, whereas #27 we'd have to be careful not to include any ES6 functions on builtin prototypes, which can be annoying