### PR TITLE
use indexOf instead of startsWith

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -41,7 +41,7 @@ export function prefixKeys(obj, prefix, capitalizeFirst = true) {
  */
 export function unprefixKeys(obj, prefixToRemove, lowercaseFirst = true) {
   return Object.keys(obj).reduce((prev, key) => {
-    if (key.startsWith(prefixToRemove)) {
+    if (key.indexOf(prefixToRemove) === 0) {
       const sansPrefix = key.slice(prefixToRemove.length);
       const newKey = lowercaseFirst ? sansPrefix.charAt(0).toLowerCase() +
         sansPrefix.slice(1) : sansPrefix;


### PR DESCRIPTION
We should come up with a way to know that we're not using any ES6 features that we can't if we take this route...

Here is a list of existent transforms for babel (don't think `startsWith` is one of them): https://babeljs.io/docs/plugins/#transform-plugins

Either this or #26 