### PR TITLE
Support className prop; Fix inconsistent heights

### DIFF
--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -16,7 +16,10 @@ export function Button(props) {
   }
 
   let classes = `Button Button--${props.type} Button--${props.size}`;
-  let type = props.submit ? "submit" : "button";
+  if (props.className) {
+    classes += ` ${props.className}`;
+  }
+  const type = props.submit ? "submit" : "button";
 
   if (props.href == null || props.disabled) {
     // use <button>s for all disabled links and things with no href prop (buttons)
@@ -40,6 +43,7 @@ Button.defaultProps = {
 };
 
 Button.propTypes = {
+  className: React.PropTypes.string,
   type: React.PropTypes.oneOf(["primary", "secondary", "destructive", "link"]),
   size: React.PropTypes.oneOf(["large", "regular", "small"]),
   value: React.PropTypes.string.isRequired,

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -21,6 +21,7 @@ a, button {
       color: #4B4B59;
       background-color: #D7D9D9;
       border: none;
+      border: 1px solid #D7D9D9;
       border-bottom: 3px solid #A4A6A6;
     }
 
@@ -34,6 +35,7 @@ a, button {
   &.Button--primary {
     background-color: #4274F6;
     color: #FAFCFC;
+    border: 1px solid #4274F6;
     border-bottom: 3px solid #345CC4;
 
     &:hover,
@@ -41,6 +43,7 @@ a, button {
     &:active {
       background-color: #3B68DD;
       color: #FAFCFC;
+      border: 1px solid #3B68DD;
       border-bottom: 3px solid #2E51AC;
     }
   }
@@ -64,6 +67,7 @@ a, button {
   &.Button--destructive {
     background-color: #EB3B49;
     color: #FAFCFC;
+    border: 1px solid #EB3B49;
     border-bottom: 3px solid #BC2F3A;
 
     &:hover,
@@ -71,6 +75,7 @@ a, button {
     &:active {
       background-color: #D33541;
       color: #FAFCFC;
+      border: 1px solid #D33541;
       border-bottom: 3px solid #A42933;
     }
   }

--- a/test/Button_test.jsx
+++ b/test/Button_test.jsx
@@ -15,10 +15,13 @@ describe("Button", () => {
       if (size === "small" && type === "destructive") return;
 
       it(`renders a ${size}, ${type} button with the correct classes`, () => {
-        const button = shallow(<Button size={size} type={type} value="A button" />);
+        const button = shallow(
+          <Button size={size} type={type} value="A button" className="customClass" />
+        );
         assert(button.hasClass("Button"));
         assert(button.hasClass(`Button--${size}`));
         assert(button.hasClass(`Button--${type}`));
+        assert(button.hasClass("customClass"));
       });
     });
   });


### PR DESCRIPTION
- Noticed while using Button that it doesn't support the className prop. Adding
  support for additional class names to be specified.

- There's also a 1px difference in the button heights that I can't unsee ;P
  Due to the fact that the secondary button has a border and the others don't.
![button-heights](https://cloud.githubusercontent.com/assets/16216084/16815283/0f7c9308-48ee-11e6-8f08-c206e0975d45.gif)
