### PR TITLE
Add CopyableInput component

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ This component is a `text input`.
 | required (optional) | Bool   | Marks input as required and adds indicator. | false
 | disabled (optional) | Bool   | Sets element as disabled. | false
 | readOnly (optional) | Bool   | Sets element as read only. | false
+| enableShow (optional) | Bool  | Displays a show/hide link that reveals passwords | false
 
 **Usage Example**
 
@@ -229,5 +230,4 @@ This is a special [TextInput](#textinput) that allows the user to show/hide the 
 
 | Prop             | Type     | Description                           | Default
 |------------------|----------|---------------------------------------|---------
-| enableShow | Bool | Display a Show/Hide toggle link | False
-| enableCopy | Bool | Display a Copy link | False
+| enableCopy (optional) | Bool | Display a Copy link | True

--- a/README.md
+++ b/README.md
@@ -221,3 +221,13 @@ var onChangeText = function(event) {
 }
 ```
 
+### CopyableInput
+
+This is a special [TextInput](#textinput) that allows the user to show/hide the value of the input and copy to clipboard. Ideal for passwords.
+
+**Options (in addition to TextInput props)**
+
+| Prop             | Type     | Description                           | Default
+|------------------|----------|---------------------------------------|---------
+| enableShow | Bool | Display a Show/Hide toggle link | False
+| enableCopy | Bool | Display a Copy link | False

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -6,6 +6,7 @@ import {
   Button,
   ConfirmationButton,
   TextInput,
+  CopyableInput,
   Modal,
   ModalButton,
 } from "../src/";
@@ -19,7 +20,8 @@ class Demo extends React.Component {
         placeholderInput: "",
         requiredInput: "testing",
         errorInput: "hello@gmail",
-        passwordInput: "",
+        passwordInput: "surprise!",
+        copyableInput: "1234-1234-1234-1234",
       },
     };
     this.openModal = this.openModal.bind(this);
@@ -45,11 +47,15 @@ class Demo extends React.Component {
       modalElement = (<Modal title="Hello Modal" closeModal={this.closeModal}>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eu felis non risus accumsan euismod sit amet in dolor. Proin nec massa enim. Vestibulum posuere nulla non leo aliquet pulvinar. Pellentesque id augue a nunc mollis pharetra eu quis enim. Aenean rhoncus fermentum mauris, id euismod tortor semper at. Morbi viverra lectus non risus facilisis, a blandit urna gravida. Suspendisse mollis convallis sapien, et fermentum justo tristique sed. In sit amet lacus dui. </p>
         <p>Curabitur tincidunt congue mi vel pretium. Etiam semper ut tortor ac feugiat. Fusce maximus id lacus gravida aliquet. Suspendisse potenti. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Suspendisse eros ante, vehicula in dictum eu, luctus sit amet dui. Ut quam libero, cursus sit amet tortor eget, feugiat laoreet turpis. Praesent nec nulla ut urna feugiat pulvinar eget eu enim.</p>
+        <footer>
+          <Button value="Never mind" type="link" onClick={this.closeModal} />
+          <Button value="Sounds good" type="primary" onClick={this.closeModal} />
+        </footer>
       </Modal>);
     }
 
     return (
-      <div>
+      <div style={{fontFamily: "Proxima Nova"}}>
         <h1>TextInputs</h1>
         <div style={{width: "300px"}}>
           <TextInput
@@ -59,7 +65,7 @@ class Demo extends React.Component {
             onChange={(event) => this.onChangeText(event, "placeholderInput")}
             value={this.state.inputValues.placeholderInput}
           />
-          <br></br>
+          <br />
           <TextInput
             label="Required Form Input"
             name="TextInputName"
@@ -68,7 +74,7 @@ class Demo extends React.Component {
             value={this.state.inputValues.requiredInput}
             required
           />
-          <br></br>
+          <br />
           <TextInput
             label="Required Form Error"
             name="TextInputName"
@@ -77,30 +83,38 @@ class Demo extends React.Component {
             error="Enter a valid email address"
             required
           />
-          <br></br>
+          <br />
           <TextInput
             label="Form Readonly"
             name="TextInputName"
             value="Readonly value"
             readOnly
           />
-          <br></br>
+          <br />
           <TextInput
             label="Form Disabled"
             name="TextInputName"
             value="Disabled value"
             disabled
           />
-          <br></br>
+          <br />
           <TextInput
             label="Password Form Input"
             name="TextInputName"
             type="password"
             onChange={(event) => this.onChangeText(event, "passwordInput")}
             value={this.state.inputValues.passwordInput}
-            required
+            enableShow
           />
-          <br></br>
+          <br />
+          <CopyableInput
+            label="Copyable Text Input"
+            name="CopyableInput"
+            onChange={(event) => this.onChangeText(event, "copyableInput")}
+            value={this.state.inputValues.copyableInput}
+            enableCopy
+          />
+          <br />
         </div>
         <h1>Button</h1>
         <h2>Button Sizing</h2>

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -22,6 +22,7 @@ class Demo extends React.Component {
         errorInput: "hello@gmail",
         passwordInput: "surprise!",
         copyableInput: "1234-1234-1234-1234",
+        copyablePwd: "🙈 🙉 🙊",
       },
     };
     this.openModal = this.openModal.bind(this);
@@ -113,6 +114,16 @@ class Demo extends React.Component {
             onChange={(event) => this.onChangeText(event, "copyableInput")}
             value={this.state.inputValues.copyableInput}
             enableCopy
+          />
+          <br />
+          <CopyableInput
+            label="Copyable Password"
+            name="CopyablePassword"
+            onChange={(event) => this.onChangeText(event, "copyablePwd")}
+            value={this.state.inputValues.copyablePwd}
+            type="password"
+            enableCopy
+            enableShow
           />
           <br />
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",
@@ -38,6 +38,7 @@
     "mocha": "^2.4.5",
     "react": "^0.14.8",
     "react-addons-test-utils": "^0.14.8",
+    "react-copy-to-clipboard": "^4.2.1",
     "react-dom": "^0.14.7",
     "sinon": "^1.17.3",
     "style-loader": "^0.13.0",

--- a/src/CopyableInput/CopyableInput.jsx
+++ b/src/CopyableInput/CopyableInput.jsx
@@ -60,6 +60,9 @@ export class CopyableInput extends React.Component {
 }
 
 CopyableInput.propTypes = Object.assign({}, TextInput.propTypes, {
-  enableShow: React.PropTypes.bool,
   enableCopy: React.PropTypes.bool,
 });
+
+CopyableInput.defaultPropTypes = {
+  enableCopy: true,
+};

--- a/src/CopyableInput/CopyableInput.jsx
+++ b/src/CopyableInput/CopyableInput.jsx
@@ -1,7 +1,7 @@
-import * as React from "react";
+import React from "react";
 import {TextInput} from "..";
 
-import * as CopyToClipboard from "react-copy-to-clipboard";
+import CopyToClipboard from "react-copy-to-clipboard";
 
 import "./CopyableInput.less";
 
@@ -15,16 +15,15 @@ export class CopyableInput extends React.Component {
     super(props);
     this.state = {hidden: true};
 
-    this.toggle = this.toggle.bind(this);
+    this.toggleHidden = this.toggleHidden.bind(this);
     this.copyPassword = this.copyPassword.bind(this);
   }
 
-  toggle() {
+  toggleHidden() {
     this.setState({hidden: !this.state.hidden});
   }
 
-  copyPassword(e) {
-    e.preventDefault();
+  copyPassword() {
     this.setState({copied: true});
   }
 
@@ -48,7 +47,7 @@ export class CopyableInput extends React.Component {
             </button>
           }
           {this.props.enableCopy &&
-             <CopyToClipboard text={this.props.value || ""} onCopy={this.copyPassword} >
+             <CopyToClipboard text={this.props.value || ""} onCopy={this.copyPassword}>
                <button type="button" className="CopyableInput--link">
                  {this.state.copied ? "Copied!" : "Copy"}
                </button>

--- a/src/CopyableInput/CopyableInput.jsx
+++ b/src/CopyableInput/CopyableInput.jsx
@@ -42,7 +42,7 @@ export class CopyableInput extends React.Component {
         />
         <div className="CopyableInput--links">
           {this.props.enableShow &&
-            <button type="button" className="CopyableInput--link" onClick={this.toggle}>
+            <button type="button" className="CopyableInput--link" onClick={this.toggleHidden}>
               {this.state.hidden ? "Show" : "Hide"}
             </button>
           }

--- a/src/CopyableInput/CopyableInput.jsx
+++ b/src/CopyableInput/CopyableInput.jsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import {TextInput} from "..";
+
+import * as CopyToClipboard from "react-copy-to-clipboard";
+
+import "./CopyableInput.less";
+
+/**
+ * This is a text input that takes optional props
+ * enableShow and enableCopy that allow the user
+ * to show/hide and copy the value of the input.
+ */
+export class CopyableInput extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {hidden: true};
+
+    this.toggle = this.toggle.bind(this);
+    this.copyPassword = this.copyPassword.bind(this);
+  }
+
+  toggle() {
+    this.setState({hidden: !this.state.hidden});
+  }
+
+  copyPassword(e) {
+    e.preventDefault();
+    this.setState({copied: true});
+  }
+
+  render() {
+    const type = this.props.type === "password" && this.state.hidden ? "password" : "text";
+    return (
+      <div className="CopyableInput">
+        <TextInput
+          type={type}
+          value={this.props.value}
+          name={this.props.name}
+          placeholder={this.props.placeholder}
+          readOnly={this.props.readOnly}
+          label={this.props.label}
+          onChange={this.props.onChange}
+        />
+        <div className="CopyableInput--links">
+          {this.props.enableShow &&
+            <button type="button" className="CopyableInput--link" onClick={this.toggle}>
+              {this.state.hidden ? "Show" : "Hide"}
+            </button>
+          }
+          {this.props.enableCopy &&
+             <CopyToClipboard text={this.props.value || ""} onCopy={this.copyPassword} >
+               <button type="button" className="CopyableInput--link">
+                 {this.state.copied ? "Copied!" : "Copy"}
+               </button>
+             </CopyToClipboard>
+          }
+        </div>
+      </div>
+    );
+  }
+}
+
+CopyableInput.propTypes = Object.assign({}, TextInput.propTypes, {
+  enableShow: React.PropTypes.bool,
+  enableCopy: React.PropTypes.bool,
+});

--- a/src/CopyableInput/CopyableInput.less
+++ b/src/CopyableInput/CopyableInput.less
@@ -1,0 +1,32 @@
+.CopyableInput {
+  position: relative;
+}
+
+.CopyableInput--links {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  margin: -8px 7px;
+
+  .CopyableInput--link {
+    border: 0;
+    background: none;
+    color: #4274F6;
+    font-size: 12px;
+    border-right: 1px solid #dddddd;
+
+    &:last-child {
+      border: 0;
+    }
+  }
+
+  .CopyableInput--link:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .CopyableInput--link:focus {
+    outline: none;
+    text-decoration: underline;
+  }
+}

--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -5,9 +5,10 @@ require("./TextInput.less");
 export class TextInput extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {inFocus: false};
+    this.state = {inFocus: false, hidden: true};
     this.onFocus = this.onFocus.bind(this);
     this.onBlur = this.onBlur.bind(this);
+    this.toggleHidden = this.toggleHidden.bind(this);
   }
 
   onFocus() {
@@ -18,8 +19,12 @@ export class TextInput extends React.Component {
     this.setState({inFocus: false});
   }
 
+  toggleHidden() {
+    this.setState({hidden: !this.state.hidden});
+  }
+
   render() {
-    var wrapperClass = "TextInput";
+    let wrapperClass = "TextInput";
 
     // add additional wrapper classes
     if (this.props.error) wrapperClass += " TextInput--hasError";
@@ -39,7 +44,7 @@ export class TextInput extends React.Component {
     }
 
     // note on the upper right corner
-    var inputNote;
+    let inputNote;
     if (this.props.required) {
       inputNote = <span className="TextInput--required">required</span>;
     }
@@ -47,13 +52,7 @@ export class TextInput extends React.Component {
       inputNote = <span className="TextInput--error">{this.props.error}</span>;
     }
 
-    var type = "text";
-    if (this.props.type) {
-      type = this.props.type;
-      if (this.props.type === "password") {
-        wrapperClass += " TextInput--password";
-      }
-    }
+    let type = (this.props.type === "password" && this.state.hidden) ? "password" : "text";
 
     return (
       <div className={wrapperClass}>
@@ -74,6 +73,11 @@ export class TextInput extends React.Component {
           disabled={this.props.disabled}
           required={this.props.required}
         />
+        {this.props.enableShow &&
+          <button type="button" className="TextInput--link" onClick={this.toggleHidden}>
+            {this.state.hidden ? "Show" : "Hide"}
+          </button>
+        }
       </div>
     );
   }
@@ -90,4 +94,5 @@ TextInput.propTypes = {
   required: React.PropTypes.bool,
   disabled: React.PropTypes.bool,
   readOnly: React.PropTypes.bool,
+  enableShow: React.PropTypes.bool,
 };

--- a/src/TextInput/TextInput.less
+++ b/src/TextInput/TextInput.less
@@ -114,4 +114,9 @@
     outline: none;
     text-decoration: underline;
   }
+
+  // Hides the IE copy and clear buttons
+  input::-ms-reveal, input::-ms-clear {
+    display: none;
+  }
 }

--- a/src/TextInput/TextInput.less
+++ b/src/TextInput/TextInput.less
@@ -88,4 +88,30 @@
   textarea:focus, input:focus{
     outline: none;
   }
+
+  .TextInput--link {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    margin: -8px 7px;
+    border: 0;
+    background: none;
+    color: #4274F6;
+    font-size: 12px;
+    border-right: 1px solid #dddddd;
+
+    &:last-child {
+      border: 0;
+    }
+  }
+
+  .TextInput--link:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .TextInput--link:focus {
+    outline: none;
+    text-decoration: underline;
+  }
 }

--- a/src/TextInput/TextInput.less
+++ b/src/TextInput/TextInput.less
@@ -81,8 +81,8 @@
 
   &.TextInput--readonly {
     color: #191926;
-    background: transparent;
-    border: 1px solid transparent;
+    background: rgba(255,255,255,0.5);
+    border: 1px solid rgba(226,230,235,0.5);
   }
 
   textarea:focus, input:focus{

--- a/src/index.js
+++ b/src/index.js
@@ -3,3 +3,4 @@ export {Button} from "./Button/Button";
 export {ModalButton} from "./ModalButton/ModalButton";
 export {ConfirmationButton} from "./ConfirmationButton/ConfirmationButton";
 export {TextInput} from "./TextInput/TextInput";
+export {CopyableInput} from "./CopyableInput/CopyableInput";

--- a/test/TextInput_test.jsx
+++ b/test/TextInput_test.jsx
@@ -152,4 +152,19 @@ describe("TextInput", () => {
     textInput.find("input").simulate("focus");
     assert(textInput.hasClass("TextInput--inFocus"));
   });
+
+  it("toggles between type 'password' and 'text' when Show is clicked", () => {
+    const textInput = shallow(
+      <TextInput
+        name="TextInputPlaceholder"
+        type="password"
+        enableShow
+      />
+    );
+    assert.equal(textInput.find("input[type='password']").length, 1);
+    assert.equal(textInput.find("input[type='text']").length, 0);
+    textInput.find("button.TextInput--link").simulate("click");
+    assert.equal(textInput.find("input[type='password']").length, 0);
+    assert.equal(textInput.find("input[type='text']").length, 1);
+  });
 });


### PR DESCRIPTION
This adds a new CopyableInput component that allows the user to copy the content of the input to the clipboard. Under the hood it uses react-copy-to-clipboard. This also adds a show/hide button to TextInput.

To do:
- [x] Hide the default clear/reveal icons in IE and Edge with ms-clear and ms-reveal 
- [x] change the style of the readonly TextInput to have a light background and border.