### PR TITLE
Fix disabled link button styling.

### DIFF
--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -138,6 +138,8 @@ class Demo extends React.Component {
         <Button type="secondary" size="regular" value="Secondary" />
         <Button type="destructive" size="regular" value="Destructive" />
         <Button disabled size="regular" value="Disabled" />
+        <Button type="link" href="http://clever.com" value="Link" />
+        <Button disabled type="link" href="http://clever.com" value="Disabled Link" />
         <h2>Button-as-Link</h2>
         <Button type="primary" size="regular" href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />
         <Button type="secondary" size="regular" href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -1,3 +1,4 @@
+@import "../colors.less";
 @import "../fonts.less";
 
 a, button {
@@ -23,6 +24,12 @@ a, button {
       border: none;
       border: 1px solid #D7D9D9;
       border-bottom: 3px solid #A4A6A6;
+
+      &.Button--link {
+        background: none;
+        border: none;
+        color: @neutral_gray;
+      }
     }
 
     &:hover,


### PR DESCRIPTION
Remove background and borders from link buttons in the disabled state.

**Before:**
![screen shot 2016-08-04 at 9 24 56 pm](https://cloud.githubusercontent.com/assets/16216084/17426156/026423a4-5a8a-11e6-8668-daa1a65dcb89.png)


**After:**
![screen shot 2016-08-04 at 9 24 38 pm](https://cloud.githubusercontent.com/assets/16216084/17426152/fe489e4e-5a89-11e6-8d4a-4c2616903bfa.png)

