### PR TITLE
Enable usage of SegmentedControl as a controlled component.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/SegmentedControl/SegmentedControl.jsx
+++ b/src/SegmentedControl/SegmentedControl.jsx
@@ -22,7 +22,7 @@ export class SegmentedControl extends React.Component {
     if (value && !onSelect) {
       throw new Error(
         "`onSelect` prop required when using SegmentedControl as a controlled component. "
-        + "Either provide the `onChange` prop, or replace `value` with `defaultValue` for an "
+        + "Either provide the `onSelect` prop, or replace `value` with `defaultValue` for an "
         + "uncontrolled SegmentedControl.\n"
         + "More info: https://fb.me/react-controlled-components"
       );
@@ -46,11 +46,7 @@ export class SegmentedControl extends React.Component {
       return;
     }
 
-    // Update internal state only if being used as an uncontrolled component.
-    if (!this.props.value) {
-      this.setState({selected: value});
-    }
-
+    this.setState({selected: value});
     if (this.props.onSelect) {
       this.props.onSelect(value);
     }

--- a/src/SegmentedControl/SegmentedControl.jsx
+++ b/src/SegmentedControl/SegmentedControl.jsx
@@ -8,8 +8,32 @@ import "./SegmentedControl.less";
  * allows the user to select one of those options.
  */
 export class SegmentedControl extends React.Component {
+  static validateProps(props) {
+    const {defaultValue, onSelect, value} = props;
+
+    if (value && defaultValue) {
+      throw new Error(
+        "SegmentedControl must either be controlled or uncontrolled "
+        + "(specify either the `value` prop, or the `defaultValue` prop, but not both).\n"
+        + "More info: https://fb.me/react-controlled-components"
+      );
+    }
+
+    if (value && !onSelect) {
+      throw new Error(
+        "`onSelect` prop required when using SegmentedControl as a controlled component. "
+        + "Either provide the `onChange` prop, or replace `value` with `defaultValue` for an "
+        + "uncontrolled SegmentedControl.\n"
+        + "More info: https://fb.me/react-controlled-components"
+      );
+    }
+
+    return props;
+  }
+
   constructor(props) {
-    super(props);
+    super(SegmentedControl.validateProps(props));
+
     this.state = {selected: props.defaultValue || null};
   }
 
@@ -22,19 +46,23 @@ export class SegmentedControl extends React.Component {
       return;
     }
 
-    this.setState({selected: value});
+    // Update internal state only if being used as an uncontrolled component.
+    if (!this.props.value) {
+      this.setState({selected: value});
+    }
+
     if (this.props.onSelect) {
       this.props.onSelect(value);
     }
   }
 
   getValue() {
-    return this.state.selected;
+    return this.props.value || this.state.selected;
   }
 
   render() {
-    const {className, disabled, options} = this.props;
-    const {selected} = this.state;
+    const {className, disabled, options, value} = this.props;
+    const selected = value || this.state.selected;
     const cssClass = SegmentedControl.cssClass;
 
     let idx = -1;
@@ -50,13 +78,13 @@ export class SegmentedControl extends React.Component {
 
       idx = idx + 1;
       return (
-        <span
+        <button
           className={classes.join(" ")}
           onClick={() => this.onSelect(option)}
           key={idx}
         >
           {option.content}
-        </span>
+        </button>
       );
     });
 
@@ -78,6 +106,7 @@ SegmentedControl.propTypes = {
     value: PropTypes.string.isRequired,
   })).isRequired,
   onSelect: PropTypes.func,
+  value: PropTypes.string,
 };
 
 SegmentedControl.cssClass = {

--- a/src/SegmentedControl/SegmentedControl.less
+++ b/src/SegmentedControl/SegmentedControl.less
@@ -32,6 +32,7 @@
     &:active {
       background-color: @neutral_off_white;
       border-color: @primary_blue;
+      outline: none;
       position: relative;
       // Pop up on top of peers to expose overlapped borders.
       z-index: 1;

--- a/test/SegmentedControl_test.jsx
+++ b/test/SegmentedControl_test.jsx
@@ -44,7 +44,7 @@ describe("SegmentedControl", () => {
     });
   });
 
-  it("initalizes selected when set", () => {
+  it("initalizes selected when defaultValue is set", () => {
     const expected = testOptions[2];
     const control = shallow(
       <SegmentedControl options={testOptions} defaultValue={expected.value} />
@@ -84,6 +84,42 @@ describe("SegmentedControl", () => {
       option.simulate("click");
       sinon.assert.calledWith(stub, testOptions[i].value);
     });
+  });
+
+  it("prioritizes the `value` prop when determining the selected option", () => {
+    const onSelect = sinon.stub();
+    const controlledValue = testOptions[1];
+
+    const control = shallow(
+      <SegmentedControl
+        options={testOptions}
+        onSelect={onSelect}
+        value={controlledValue.value}
+      />
+    );
+
+    assert.equal(control.instance().getValue(), controlledValue.value);
+
+    const options = control.find(`.${cssClass.OPTION}`);
+    options.forEach((option, i) => {
+      option.simulate("click");
+      sinon.assert.calledWith(onSelect, testOptions[i].value);
+      assert(options.at(1).hasClass(cssClass.SELECTED), "Option at index 1 should remain selected");
+    });
+  });
+
+  it("throws error on conflicting controlled/uncontrolled mode", () => {
+    assert.throws(
+      () => shallow(<SegmentedControl defaultValue="one" options={testOptions} value="two" />),
+      /controlled or uncontrolled/
+    );
+  });
+
+  it("throws error on missing `onSelect` prop in controlled mode", () => {
+    assert.throws(
+      () => shallow(<SegmentedControl options={testOptions} value="two" />),
+      /`onSelect` prop required/
+    );
   });
 
   it("disables selection on all options if control is disabled", () => {


### PR DESCRIPTION
Ran into a complex use-case that now requires this element to support controlled mode.
[More info: https://fb.me/react-controlled-components]

- Add a `value` prop that overrides the selected value.
- Requires `onSelect` to be specified; throws an error otherwise.
- Also requires only one of `value` or `defaultValue` to be specified.

Bonus: s/span/button/ so that the options get tabIndex and the button ARIA role `#accessibility`