### PR TITLE
Add segmented control button type=button so it's not a submit button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/SegmentedControl/SegmentedControl.jsx
+++ b/src/SegmentedControl/SegmentedControl.jsx
@@ -78,6 +78,7 @@ export class SegmentedControl extends React.Component {
           className={classes.join(" ")}
           onClick={() => this.onSelect(option)}
           key={idx}
+          type="button"
         >
           {option.content}
         </button>


### PR DESCRIPTION
Forgot to set the button type when switching from `span` to `button` for the individual controls. That turned it into a submit button by default :/