### PR TITLE
Create dist/css directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ es5:
 	@echo '✓ Convert ES6 to ES5'
 	@find ./dist -name "*.jsx" | xargs -n1 rm
 	@echo '✓ Remove JSX files'
+	@mkdir dist/css
 
 build: clean es5
 


### PR DESCRIPTION
Drone failed on the last PR because it expected the dist/css directory to exist. This creates it as part of the `make build` command so it should exist.