### PR TITLE
add loaders to package dependencies so that works elsewhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",
@@ -23,25 +23,19 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.7.2",
-    "css-loader": "^0.23.1",
     "enzyme": "^2.2.0",
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-react": "^4.2.3",
-    "file-loader": "^0.8.5",
     "ignore-styles": "^1.2.0",
     "jsdom": "^8.4.0",
     "jsdom-global": "^1.7.0",
-    "jsx-loader": "^0.13.2",
-    "less": "^2.6.1",
-    "less-loader": "^2.2.3",
     "mocha": "^2.4.5",
     "react": "^0.14.8",
     "react-addons-test-utils": "^0.14.8",
     "react-dom": "^0.14.7",
     "sinon": "^1.17.3",
     "style-loader": "^0.13.0",
-    "url-loader": "^0.5.7",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1"
   },
@@ -49,7 +43,13 @@
     "dev-server": "node_modules/.bin/webpack-dev-server --content-base docs/ --inline --watch"
   },
   "dependencies": {
+    "css-loader": "^0.23.1",
+    "file-loader": "^0.8.5",
+    "jsx-loader": "^0.13.2",
+    "less": "^2.6.1",
+    "less-loader": "^2.2.3",
     "lodash": "^4.14.1",
-    "react-copy-to-clipboard": "^4.2.1"
+    "react-copy-to-clipboard": "^4.2.1",
+    "url-loader": "^0.5.7"
   }
 }


### PR DESCRIPTION
This makes it more likely that the package just works when included elsewhere, as not all including repos have these loaders installed.