### PR TITLE
Select component that works for a basic dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clever Front End Components
 
-**Jump to** [Modal](#modal), [Button](#button), [ModalButton](#modalbutton), [ConfirmationButton](#confirmationbutton), [TextInput](#textinput), [SegmentedControl](#segmentedcontrol)
+**Jump to** [Modal](#modal), [Button](#button), [ModalButton](#modalbutton), [ConfirmationButton](#confirmationbutton), [TextInput](#textinput), [Select](#select), [SegmentedControl](#segmentedcontrol)
 
 ## Install
 
@@ -231,6 +231,47 @@ This is a special [TextInput](#textinput) that allows the user to show/hide the 
 | Prop             | Type     | Description                           | Default
 |------------------|----------|---------------------------------------|---------
 | enableCopy (optional) | Bool | Display a Copy link | True
+
+### Select
+
+Component to allow selecting options from a list. Right now this only supports a basic dropdown with
+a fixed list of options.
+
+**Options**
+
+| Prop             | Type     | Description                           | Default
+|------------------|----------|---------------------------------------|---------
+| id (required) | String | ID for the select element to be used by the label. Must be unique | None
+| name (required) | String | Name for select element | None
+| label (optional) | String | Label for select element | None
+| onChange (optional) | Function | Called with new value when it changes | None
+| options (optional) | Array | Possible options. Must contain objects with label and value attributes | None
+| placeholder (optional) | String | Placeholder text | ""
+| value (optional) | Object | Selected value. Must be updated by caller in the onChange | None
+
+**Usage Example**
+
+```jsx
+<Select
+  id="BasicSelect"
+  label="Basic Select"
+  name="BasicSelect"
+  onChange={onBasicSelectChange}
+  options={[
+    {label: "Option 1", value: "opt1"},
+    {label: "Option 2", value: "opt2"},
+    {label: "Option 3", value: "opt3"},
+  ]}
+  placeholder="placeholder for select"
+  value={this.state.basicSelectValue}
+/>
+```
+
+```js
+function onBasicSelectChange(value) {
+  this.setState({basicSelectValue: value});
+}
+```
 
 ### SegmentedControl
 

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -10,6 +10,7 @@ import {
   Modal,
   ModalButton,
   SegmentedControl,
+  Select,
   TextInput,
 } from "../src/";
 
@@ -28,16 +29,27 @@ class Demo extends React.Component {
         copyableInput: "1234-1234-1234-1234",
         copyablePwd: "🙈 🙉 🙊",
       },
+      selectValues: {
+        basicSelect: null,
+      },
     };
     this.openModal = this.openModal.bind(this);
     this.closeModal = this.closeModal.bind(this);
     this.onChangeText = this.onChangeText.bind(this);
+    this.onBasicSelectChange = this.onBasicSelectChange.bind(this);
   }
   onChangeText(event, inputElem) {
     var newInputValues = Object.assign({}, this.state.inputValues);
     newInputValues[inputElem] = event.target.value;
     this.setState(
-      {inputValues: newInputValues}
+      {inputValues: newInputValues, selectValues: this.state.selectValues}
+    );
+  }
+  onBasicSelectChange(value) {
+    const newSelectValues = Object.assign({}, this.state.selectValues);
+    newSelectValues.basicSelect = value;
+    this.setState(
+      {inputValues: this.state.inputValues, selectValues: newSelectValues}
     );
   }
   openModal() {
@@ -130,6 +142,22 @@ class Demo extends React.Component {
             enableShow
           />
           <br />
+        </div>
+        <h1>Selects</h1>
+        <div style={{width: "300px"}}>
+          <Select
+            id="BasicSelect"
+            label="Basic Select"
+            name="BasicSelect"
+            onChange={this.onBasicSelectChange}
+            options={[
+              {label: "Option 1", value: "opt1"},
+              {label: "Option 2", value: "opt2"},
+              {label: "Option 3", value: "opt3"},
+            ]}
+            placeholder="placeholder for select"
+            value={this.state.selectValues.basicSelect}
+          />
         </div>
         <h1>Button</h1>
         <h2>Button Sizing</h2>

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "less-loader": "^2.2.3",
     "lodash": "^4.14.1",
     "react-copy-to-clipboard": "^4.2.1",
+    "react-select": "^1.0.0-beta14",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7"
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ignore-styles": "^1.2.0",
     "jsdom": "^8.4.0",
     "jsdom-global": "^1.7.0",
+    "lorem-ipsum": "^1.0.3",
     "mocha": "^2.4.5",
     "react": "~15.3.0",
     "react-addons-test-utils": "~15.3.0",

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -1,0 +1,65 @@
+import React from "react";
+import ReactSelect from "react-select";
+
+import "react-select/dist/react-select.css";
+import "./Select.less";
+
+/*
+  Component to allow selecting options from a list. Right now this only supports a basic dropdown
+  with a fixed list of options. This component will be updated to allow searching for options that
+  may be fetched asynchronously.
+*/
+
+export function Select({id, name, label, onChange, options, placeholder = "", value}) {
+  const {cssClass} = Select;
+
+  let labelContainerClasses = cssClass.LABEL_CONTAINER;
+  if (placeholder && !value) {
+    labelContainerClasses += ` ${cssClass.LABEL_HIDDEN}`;
+  }
+
+  // The label container must be returned after the ReactSelect otherwise it does not get displayed
+  // in the browser.
+  return (
+    <div className={cssClass.CONTAINER}>
+      <div id={id}>
+        <ReactSelect
+          className={cssClass.REACT_SELECT}
+          clearable={false}
+          name={name}
+          onChange={onChange}
+          options={options}
+          placeholder={placeholder}
+          searchable={false}
+          value={value}
+        />
+      </div>
+      <div className={labelContainerClasses}>
+        <label className={cssClass.LABEL} htmlFor={id}>{label}</label>
+      </div>
+    </div>
+  );
+}
+
+Select.cssClass = {
+  CONTAINER: "Select--container",
+  LABEL: "Select--label",
+  LABEL_CONTAINER: "Select--labelContainer",
+  LABEL_HIDDEN: "Select--labelHidden",
+  REACT_SELECT: "Select--ReactSelect",
+};
+
+const selectValue = React.PropTypes.shape({
+  label: React.PropTypes.string.isRequired,
+  value: React.PropTypes.string.isRequired,
+});
+
+Select.propTypes = {
+  id: React.PropTypes.string.isRequired,
+  name: React.PropTypes.string.isRequired,
+  label: React.PropTypes.string,
+  onChange: React.PropTypes.func,
+  options: React.PropTypes.arrayOf(selectValue),
+  placeholder: React.PropTypes.string,
+  value: selectValue,
+};

--- a/src/Select/Select.less
+++ b/src/Select/Select.less
@@ -1,0 +1,68 @@
+@import "../colors.less";
+
+.Select--container {
+  position: relative;
+
+  .Select--labelContainer {
+    color: @neutral_dark_gray;
+    font-size: 0.625rem;
+    position: absolute;
+    text-transform: uppercase;
+    top: 5px;
+    width: 100%;
+
+    &.Select--labelHidden {
+      opacity: 0 !important;
+    }
+
+    .Select--label {
+      left: 10px;
+      position: absolute;
+    }
+  }
+
+  .Select--ReactSelect {
+    // overrides styles from the exact same selector in react-select's CSS
+    &.is-focused:not(.is-open) > .Select-control {
+      border-color: @neutral_silver;
+      box-shadow: inset 5px 0 @primary_blue;
+      transition: box-shadow .25s ease-out;
+    }
+
+    .Select-control {
+      border-radius: 0px;
+      border-color: @neutral_silver;
+      height: 50px;
+      .Select-placeholder {
+        font-size: .75rem;
+        line-height: 40px;
+        padding-top: 5px;
+        text-transform: uppercase;
+      }
+      .Select-value {
+        font-size: 1rem;
+        line-height: 40px;
+        min-height: 40px;
+        padding-top: 10px;
+      }
+    }
+
+    // overrides styles from the exact same selector in react-select's CSS
+    .has-value.Select--single > .Select-control .Select-value .Select-value-label,
+    .has-value.is-pseudo-focused.Select--single > .Select-control .Select-value .Select-value-label{
+      color: @neutral_black
+    }
+
+    .Select-menu-outer {
+      border-radius: 0px;
+      border-color: @neutral_silver;
+      .Select-option {
+        color: @neutral_black;
+        &.is-focused {
+          box-shadow: inset 5px 0 @primary_blue;
+          background-color: @neutral_off_white;
+        }
+      }
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,4 +5,5 @@ export {ConfirmationButton} from "./ConfirmationButton/ConfirmationButton";
 export {TextInput} from "./TextInput/TextInput";
 export {CopyableInput} from "./CopyableInput/CopyableInput";
 export {SegmentedControl} from "./SegmentedControl/SegmentedControl";
+export {Select} from "./Select/Select";
 export {Table} from "./Table/Table";

--- a/test/Select_test.jsx
+++ b/test/Select_test.jsx
@@ -1,0 +1,122 @@
+import assert from "assert";
+import {shallow} from "enzyme";
+import React from "react";
+import ReactSelect from "react-select";
+import sinon from "sinon";
+
+import {Select} from "../src";
+
+describe("Select", () => {
+  const testOptions = [
+    {label: "Test Option 1", value: "testopt1"},
+    {label: "Test Option 2", value: "testopt2"},
+    {label: "Test Option 3", value: "testopt3"},
+    {label: "Test Option 4", value: "testopt4"},
+  ];
+
+  it("wraps ReactSelect with an element with the provided id", () => {
+    const select = shallow(
+      <Select
+        id="testid"
+        name="testname"
+        label="test label"
+      />
+    );
+    const idWrapper = select.find("#testid");
+    assert.equal(idWrapper.find(ReactSelect).isEmpty(), false);
+  });
+
+  it("sets htmlFor for label to point to provided id", () => {
+    const select = shallow(
+      <Select
+        id="testid"
+        name="testname"
+        label="test label"
+      />
+    );
+    const labelContainer = select.find(`.${Select.cssClass.LABEL_CONTAINER}`);
+    assert.equal(labelContainer.hasClass(Select.cssClass.LABEL_HIDDEN), false);
+    const label = labelContainer.find(`label.${Select.cssClass.LABEL}`);
+    assert.equal(label.prop("htmlFor"), "testid");
+  });
+
+  it("renders the label when no placeholder is provided", () => {
+    const select = shallow(
+      <Select
+        id="testid"
+        name="testname"
+        label="test label"
+      />
+    );
+    const labelContainer = select.find(`.${Select.cssClass.LABEL_CONTAINER}`);
+    assert.equal(labelContainer.hasClass(Select.cssClass.LABEL_HIDDEN), false);
+  });
+
+  it("renders the label when no placeholder is provided and a value is selected", () => {
+    const select = shallow(
+      <Select
+        id="testid"
+        name="testname"
+        label="test label"
+        placeholder="test placeholder"
+        options={testOptions}
+        value={testOptions[2]}
+      />
+    );
+    const labelContainer = select.find(`.${Select.cssClass.LABEL_CONTAINER}`);
+    assert.equal(labelContainer.hasClass(Select.cssClass.LABEL_HIDDEN), false);
+  });
+
+  it("hides the label when a placeholder is provided but no value is selected", () => {
+    const select = shallow(
+      <Select
+        id="testid"
+        name="testname"
+        label="test label"
+        placeholder="test placeholder"
+      />
+    );
+    const labelContainer = select.find(`.${Select.cssClass.LABEL_CONTAINER}`);
+    assert(labelContainer.hasClass(Select.cssClass.LABEL_HIDDEN));
+  });
+
+  it("correctly sets the appropriate props on ReactSelect", () => {
+    const onChange = sinon.spy();
+    const select = shallow(
+      <Select
+        id="testid"
+        name="testname"
+        label="test label"
+        onChange={onChange}
+        options={testOptions}
+        placeholder="test placeholder"
+        value={testOptions[2]}
+      />
+    );
+    const expectedPropValues = {
+      className: Select.cssClass.REACT_SELECT,
+      clearable: false,
+      name: "testname",
+      onChange,
+      options: testOptions,
+      placeholder: "test placeholder",
+      searchable: false,
+      value: testOptions[2],
+    };
+    const reactSelectProps = select.find(ReactSelect).props();
+    for (const prop of Object.keys(expectedPropValues)) {
+      assert.equal(reactSelectProps[prop], expectedPropValues[prop]);
+    }
+  });
+
+  it("defaults to an empty string placeholder ReactSelect", () => {
+    const select = shallow(
+      <Select
+        id="testid"
+        name="testname"
+      />
+    );
+    const reactSelect = select.find(ReactSelect);
+    assert.equal(reactSelect.prop("placeholder"), "");
+  });
+});


### PR DESCRIPTION
JIRA: https://clever.atlassian.net/browse/DIS2-179

Creates a new select component that works as a basic dropdown for now. Wraps react-select with styling based on mocks at https://projects.invisionapp.com/share/TG89776AU#/screens/180681819.

Wraps react-select and applies custom styling.

**Screenshots**

Focused on an option with none selected:
<img width="314" alt="screenshot 2016-08-24 16 24 10" src="https://cloud.githubusercontent.com/assets/10036433/17951531/a6577c80-6a17-11e6-917e-0119658ea405.png">

Focused with an option selected:
<img width="322" alt="screenshot 2016-08-24 16 24 18" src="https://cloud.githubusercontent.com/assets/10036433/17951532/a88e4998-6a17-11e6-9c3f-50079e9451f7.png">

