### PR TITLE
[Table] Additional table component tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/Table/Column.jsx
+++ b/src/Table/Column.jsx
@@ -10,7 +10,7 @@ Column.propTypes = {
     className: PropTypes.string,
     renderer: PropTypes.func.isRequired,
   }),
-  id: PropTypes.string,
+  id: PropTypes.string.isRequired,
   header: PropTypes.shape({
     className: PropTypes.string,
     content: PropTypes.node,

--- a/src/Table/Header.jsx
+++ b/src/Table/Header.jsx
@@ -5,19 +5,19 @@ import Column from "./Column";
 import HeaderCell from "./HeaderCell";
 
 
-export default function Header({children, onSortChange, sortState}) {
+export default function Header({children, disableSort, onSortChange, sortState}) {
   const {cssClass} = Header;
 
   return (
     <thead className={cssClass.CONTAINER}>
       <tr className={cssClass.ROW}>
-        {children.map(({props: column}, columnIndex) => (
+        {children.map(({props: column}) => (
           <HeaderCell
-            activeSortDirection={sortState.columnIndex === columnIndex ? sortState.direction : null}
+            activeSortDirection={sortState.columnID === column.id ? sortState.direction : null}
             className={column.header && column.header.className}
-            key={column.id || columnIndex}
-            onSortChange={() => onSortChange(columnIndex)}
-            sortable={column.sortable}
+            key={column.id}
+            onSortChange={() => onSortChange(column.id)}
+            sortable={column.sortable && !disableSort}
             width={column.width}
           >
             {column.header && column.header.content}
@@ -32,6 +32,7 @@ Header.propTypes = {
   children: PropTypes.arrayOf(PropTypes.shape({
     type: PropTypes.oneOf([Column]),
   })),
+  disableSort: PropTypes.bool,
   onSortChange: PropTypes.func,
   sortState: tablePropTypes.sortState,
 };

--- a/src/Table/tablePropTypes.js
+++ b/src/Table/tablePropTypes.js
@@ -9,6 +9,5 @@ export const sortDirection = PropTypes.oneOf([
 
 export const sortState = PropTypes.shape({
   columnID: PropTypes.string,
-  columnIndex: PropTypes.number,
   direction: sortDirection,
 });

--- a/test/Table/Header_test.jsx
+++ b/test/Table/Header_test.jsx
@@ -65,12 +65,18 @@ describe("Table -- Header", () => {
   });
 
   it("sets active sort state", () => {
-    const sortState = {columnIndex: 0, direction: sortDirection.DESCENDING};
+    const sortState = {columnID: "name_column", direction: sortDirection.DESCENDING};
 
     const nameCell = newHeader({sortState}).find(HeaderCell).at(0);
 
     assert(nameCell.props().sortable, `Expected ${nameCell.debug()} to be sortable.`);
     assert.equal(nameCell.props().activeSortDirection, sortDirection.DESCENDING, "Incorrect sort direction");
+  });
+
+  it("disables sorting is `disableSort` prop is specified", () => {
+    const nameCell = newHeader({disableSort: true}).find(HeaderCell).at(0);
+
+    assert(!nameCell.props().sortable, `${nameCell.debug()} should not be sortable when 'dissableSort' is true.`);
   });
 
   it("sets custom column width", () => {
@@ -80,11 +86,11 @@ describe("Table -- Header", () => {
 
   it("propagates sort change events", () => {
     const onSortChange = sinon.stub();
-    const columnIndex = 1;
+    const descriptionColumnIndex = 1;
 
-    const cell = newHeader({onSortChange}).find(HeaderCell).at(columnIndex);
+    const cell = newHeader({onSortChange}).find(HeaderCell).at(descriptionColumnIndex);
     cell.simulate("sortChange");
 
-    sinon.assert.calledWith(onSortChange, columnIndex);
+    sinon.assert.calledWith(onSortChange, descriptionColumn.props.id);
   });
 });

--- a/test/Table/Header_test.jsx
+++ b/test/Table/Header_test.jsx
@@ -75,8 +75,7 @@ describe("Table -- Header", () => {
 
   it("disables sorting is `disableSort` prop is specified", () => {
     const nameCell = newHeader({disableSort: true}).find(HeaderCell).at(0);
-
-    assert(!nameCell.props().sortable, `${nameCell.debug()} should not be sortable when 'dissableSort' is true.`);
+    assert(!nameCell.props().sortable, `${nameCell.debug()} should not be sortable when 'disableSort' is true.`);
   });
 
   it("sets custom column width", () => {


### PR DESCRIPTION
- Hide sort controls when there are fewer than 2 rows visible.
- Filter and sort on render to simplify the code a bit. Shouldn't have an
  effect on performance, since rendering is already optimized based on
  prop/state comparisons.
- Also require column IDs to simplify the logic around sorting. Consistently
  identify sorted columns by ID instead of index.