### PR TITLE
[Table] Add a pagination footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This is a set of button components with various sizes and types.
 | Prop                | Type     | Description                                          | Default
 |---------------------|----------|------------------------------------------------------|---------
 | value               | String   | The text that appears on the button                  | None
-| type                | String   | One of `primary`, `secondary`, `destructive`, `link` | `secondary`
+| type                | String   | One of `primary`, `secondary`, `destructive`, `link`, `linkPlain` | `secondary`
 | size                | String   | One of "large", "regular", "small"                   | `regular`
 | onClick (optional)  | Function | Called when the user clicks on the button            | None
 | href (optional)     | String   | If provided, causes the button to behave as a link   | None
@@ -111,7 +111,7 @@ the string `"modal"` prepended to them (i.e. `modalWidth`, `modalTitle`).
 | onClick (optional)               | Function | Called when the user clicks the button               | None
 | onClose (optional)               | Function | Called when the user closes the modal                | None
 | value                            | String   | The text that appears on the button                  | None
-| type                             | String   | One of `primary`, `secondary`, `destructive`, `link` | `secondary`
+| type                             | String   | One of `primary`, `secondary`, `destructive`, `link`, `linkPlain` | `secondary`
 | size                             | String   | One of "large", "regular", "small"                   | `regular`
 | href (optional)                  | String   | If provided, causes the button to behave as a link   | None
 | target (optional)                | String   | For links, either "_self" or "_blank"                | "_blank"
@@ -151,7 +151,7 @@ Inherits all options from `ModalButton` and `Button`. `Button`'s properties have
 | modalTitle                       | String   | Header text for the modal                                   | None
 | modalWidth (optional)            | Number   | Width of the modal                                          | 400px
 | confirmButtonValue               | String   | The text that appears on the Confirm button                 | None
-| confirmButtonType                | String   | One of `primary`, `secondary`, `destructive`, `link`        | `secondary`
+| confirmButtonType                | String   | One of `primary`, `secondary`, `destructive`, `link`, `linkPlain`        | `secondary`
 | confirmButtonSize                | String   | One of "large", "regular", "small"                          | `regular`
 | confirmButtonHref (optional)     | String   | If provided, causes the Confirm button to behave as a link  | None
 | confirmButtonTarget (optional)   | String   | For links, either "_self" or "_blank"                       | "_blank"
@@ -314,7 +314,7 @@ var onSelect = function(selected) {
 
 ### Table
 
-Table component supporting sorting and filtering.
+Table component supporting sorting, filtering and pagination.
 
 **Options**
 
@@ -324,9 +324,17 @@ Table component supporting sorting and filtering.
 | data (required) | Array | The array of data items, each corresponding to a single potential table row | None
 | filter (optional) | Function | Called with data for a single row. Should return `false` if the row should be filtered out, or `true` otherwise. | None
 | fixed (optional) | Boolean | Whether or not table column widths should be fixed (vs fluid). | False
+| initialPage (optional) | Number | The initial page to be displayed initially. | None
 | initialSortState (optional) | `{columnID: String, direction: Table.sortDirection}` | The initial sort state of the table. | None
+| onPageChange (optional) | Function | Callback function for the displayed page change event. | None
 | onSortChange (optional) | Function | Callback function for the sort state change event. | None
+| pageSize (optional) | Number | The number of data rows to display on each page. Set to the length of the data set to effectively disable pagination. | 10
 | rowIDFn (required) | Function | Called with data for a single row. Should return the unique ID for that row. | None
+
+**API**
+
+- `setCurrentPage(page: Number)` - Explicitly sets the displayed page on the Table. Useful for reacting to data or filter changes that warrant resetting the current page.
+  - **NOTE:** The current page is automatically reset to the first page on every sort state change.
 
 #### Table.Column
 The `Table` component requires child components of type `Table.Column`, which provide configuration for the table header and row cells.
@@ -344,4 +352,4 @@ The `Table` component requires child components of type `Table.Column`, which pr
 
 **Usage Example**
 
-[Source Code](https://github.com/Clever/components/tree/master/docs/TableExample.jsx) ([Live Demo](http://clever.github.io/components/#table))
+[Sample Code](https://github.com/Clever/components/tree/master/docs/TableExample.jsx) ([Live Demo](http://clever.github.io/components/#table))

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Table component supporting sorting, filtering and pagination.
 
 **API**
 
-- `setCurrentPage(page: Number)` - Explicitly sets the displayed page on the Table. Useful for reacting to data or filter changes that warrant resetting the current page.
+- `setCurrentPage(page: Number)` - Explicitly sets the displayed page on the Table with the specified 1-based page. Useful for reacting to data or filter changes that warrant resetting the current page.
   - **NOTE:** The current page is automatically reset to the first page on every sort state change.
 
 #### Table.Column

--- a/README.md
+++ b/README.md
@@ -328,7 +328,8 @@ Table component supporting sorting, filtering and pagination.
 | initialSortState (optional) | `{columnID: String, direction: Table.sortDirection}` | The initial sort state of the table. | None
 | onPageChange (optional) | Function | Callback function for the displayed page change event. | None
 | onSortChange (optional) | Function | Callback function for the sort state change event. | None
-| pageSize (optional) | Number | The number of data rows to display on each page. Set to the length of the data set to effectively disable pagination. | 10
+| pageSize (optional) | Number | The number of data rows to display on each page. | 10
+| paginated (optional) | Boolean | Whether or not to enable pagination. See `pageSize` | false
 | rowIDFn (required) | Function | Called with data for a single row. Should return the unique ID for that row. | None
 
 **API**

--- a/README.md
+++ b/README.md
@@ -324,9 +324,9 @@ Table component supporting sorting, filtering and pagination.
 | data (required) | Array | The array of data items, each corresponding to a single potential table row | None
 | filter (optional) | Function | Called with data for a single row. Should return `false` if the row should be filtered out, or `true` otherwise. | None
 | fixed (optional) | Boolean | Whether or not table column widths should be fixed (vs fluid). | False
-| initialPage (optional) | Number | The initial page to be displayed initially. | None
+| initialPage (optional) | Number | The 1-based index of the initial page to be displayed initially. | None
 | initialSortState (optional) | `{columnID: String, direction: Table.sortDirection}` | The initial sort state of the table. | None
-| onPageChange (optional) | Function | Callback function for the displayed page change event. | None
+| onPageChange (optional) | Function | Callback function for the 1-based index displayed page change event. | None
 | onSortChange (optional) | Function | Callback function for the sort state change event. | None
 | pageSize (optional) | Number | The number of data rows to display on each page. | 10
 | paginated (optional) | Boolean | Whether or not to enable pagination. See `pageSize` | false

--- a/docs/TableExample.jsx
+++ b/docs/TableExample.jsx
@@ -77,6 +77,7 @@ export default class TableExample extends Component {
             ref="table"
             onPageChange={page => console.log("Table page changed:", page)}
             onSortChange={sortState => console.log("Table sort changed:", sortState)}
+            paginated
             pageSize={9}
             rowIDFn={r => r.id}
           >

--- a/docs/TableExample.jsx
+++ b/docs/TableExample.jsx
@@ -15,12 +15,12 @@ export default class TableExample extends Component {
   }
 
   componentWillMount() {
-    this._reload();
+    this._reload(5000);
   }
 
-  _reload() {
+  _reload(numItems) {
     const tableData = [];
-    for (var i = 0; i < 10; i++) {
+    for (var i = 0; i < numItems; i++) {
       tableData.push({
         id: i,
         name: {
@@ -45,9 +45,12 @@ export default class TableExample extends Component {
         </a>
         <div style={{marginTop: "20px"}}>
           <Button
-            onClick={() => this._reload()}
+            onClick={() => {
+              this._reload(Math.random() * 5000);
+              this.refs.table.setCurrentPage(1);
+            }}
             type="secondary"
-            value="Reload"
+            value="Reload random data"
           />
         </div>
         <div style={{width: "300px", marginTop: "20px"}}>
@@ -55,7 +58,10 @@ export default class TableExample extends Component {
             label="Filter by name"
             name="tableFilter"
             placeholder="Filter by name"
-            onChange={e => this.setState({tableFilter: e.target.value})}
+            onChange={e => {
+              this.setState({tableFilter: e.target.value});
+              this.refs.table.setCurrentPage(1);
+            }}
             value={this.state.tableFilter}
           />
         </div>
@@ -66,8 +72,12 @@ export default class TableExample extends Component {
               [rowData.name.first, rowData.name.last].join(" "),
               this.state.tableFilter.trim().toLowerCase()
             )}
+            initialPage={24}
             initialSortState={{columnID: "name", direction: Table.sortDirection.ASCENDING}}
+            ref="table"
+            onPageChange={page => console.log("Table page changed:", page)}
             onSortChange={sortState => console.log("Table sort changed:", sortState)}
+            pageSize={9}
             rowIDFn={r => r.id}
           >
             <Table.Column

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -209,6 +209,14 @@ class Demo extends React.Component {
         <Button disabled size="regular" value="Disabled" />
         <Button type="link" href="http://clever.com" value="Link" />
         <Button disabled type="link" href="http://clever.com" value="Disabled Link" />
+        <br />
+        <p>
+          Here is a <Button type="linkPlain" href="//google.com" value="plain link" /> with no margin/padding.
+          <br />
+          Better suited for inline links than the
+          regular <Button type="link" href="//google.com" value="link button" />, which doesn't automatically
+          match the text around it.
+        </p>
         <h2>Button-as-Link</h2>
         <Button type="primary" size="regular" href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />
         <Button type="secondary" size="regular" href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -40,7 +40,7 @@ Button.defaultProps = {
 
 Button.propTypes = {
   className: React.PropTypes.string,
-  type: React.PropTypes.oneOf(["primary", "secondary", "destructive", "link"]),
+  type: React.PropTypes.oneOf(["primary", "secondary", "destructive", "link", "linkPlain"]),
   size: React.PropTypes.oneOf(["large", "regular", "small"]),
   value: React.PropTypes.string.isRequired,
   href: React.PropTypes.string,

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -25,6 +25,7 @@ a, button {
       border: 1px solid #D7D9D9;
       border-bottom: 3px solid #A4A6A6;
 
+      &.Button--linkPlain,
       &.Button--link {
         background: none;
         border: none;
@@ -87,6 +88,7 @@ a, button {
     }
   }
 
+  &.Button--linkPlain,
   &.Button--link {
     background-color: transparent;
     color: #4274F6;
@@ -114,4 +116,9 @@ a, button {
     font-size: 20px;
   }
 
+  &.Button--linkPlain {
+    font-size: 1em;
+    margin: 0;
+    padding: 0;
+  }
 }

--- a/src/Table/Footer.jsx
+++ b/src/Table/Footer.jsx
@@ -12,13 +12,6 @@ require("./Footer.less");
  * Only rendered if there are more than 1 page of data available.
  */
 export default class Footer extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-    };
-  }
-
   _selectPage(page) {
     if (page === this.props.currentPage) {
       return;

--- a/src/Table/Footer.jsx
+++ b/src/Table/Footer.jsx
@@ -9,7 +9,7 @@ require("./Footer.less");
 
 /**
  * Pagination footer for the Table component.
- * Only rendered if there are more than 1 page of data available.
+ * Only rendered if there are at least 2 pages of data available.
  */
 export default function Footer({currentPage, numColumns, numPages, onPageChange}) {
   const {cssClass, VISIBLE_PAGE_RANGE_SIZE} = Footer;
@@ -58,6 +58,7 @@ export default function Footer({currentPage, numColumns, numPages, onPageChange}
             value="Prev"
           />
           <div className={cssClass.PAGE_NUMBERS}>
+            {/* Make sure the first page is always visible. */}
             {visibleRange[0] > 1 && (
               <Button
                 className={cssClass.BUTTON_PAGE}
@@ -67,6 +68,10 @@ export default function Footer({currentPage, numColumns, numPages, onPageChange}
                 value="1"
               />
             )}
+            {/*
+              * Show ellipsis if there's at least one omitted page number between 1 and the start of
+              * the visible rnage.
+              */}
             {visibleRange[0] > 2 && renderEllipsis()}
             {visibleRange.map(pageNumber => (
               <Button
@@ -80,7 +85,12 @@ export default function Footer({currentPage, numColumns, numPages, onPageChange}
                 value={`${pageNumber}`}
               />
             ))}
+            {/*
+              * Show ellipsis if there's at least one omitted page number between the end of the
+              * visible range and the last page number.
+              */}
             {visibleRange[VISIBLE_PAGE_RANGE_SIZE - 1] < numPages - 1 && renderEllipsis()}
+            {/* Make sure the last page is always visible. */}
             {visibleRange[VISIBLE_PAGE_RANGE_SIZE - 1] < numPages && (
               <Button
                 className={cssClass.BUTTON_PAGE}

--- a/src/Table/Footer.jsx
+++ b/src/Table/Footer.jsx
@@ -1,0 +1,149 @@
+import classnames from "classnames";
+import React, {Component, PropTypes} from "react";
+
+import {Button} from "../Button/Button";
+import Cell from "./Cell";
+
+require("./Footer.less");
+
+
+/**
+ * Pagination footer for the Table component.
+ * Only rendered if there are more than 1 page of data available.
+ */
+export default class Footer extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+    };
+  }
+
+  _selectPage(page) {
+    if (page === this.props.currentPage) {
+      return;
+    }
+
+    this.props.onPageChange(page);
+  }
+
+  _renderEllipsis() {
+    return <span className={Footer.cssClass.ELLIPSIS}>{"•••"}</span>;
+  }
+
+  _renderPaginationControls() {
+    const {cssClass, VISIBLE_PAGE_RANGE_SIZE} = Footer;
+    const {currentPage, numPages} = this.props;
+
+    // Find the widest possible number range <= `VISIBLE_PAGE_RANGE_SIZE`.
+    const pageNumberPadding = (VISIBLE_PAGE_RANGE_SIZE - 1) / 2;
+    let pageNumStart;
+    if ((currentPage + pageNumberPadding) >= numPages) {
+      pageNumStart = Math.max(numPages - (VISIBLE_PAGE_RANGE_SIZE - 1), 1);
+    } else {
+      pageNumStart = Math.max(currentPage - pageNumberPadding, 1);
+    }
+    const pageNumEnd = Math.min(pageNumStart + (VISIBLE_PAGE_RANGE_SIZE - 1), numPages);
+
+    const visibleRange = [];
+    for (let i = pageNumStart; i <= pageNumEnd; i++) {
+      visibleRange.push(i);
+    }
+
+    return (
+      <div>
+        <Button
+          className={cssClass.BUTTON_SCROLL}
+          disabled={currentPage === 1}
+          onClick={() => this._selectPage(currentPage - 1)}
+          type="linkPlain"
+          value="Prev"
+        />
+        <div className={cssClass.PAGE_NUMBERS}>
+          {visibleRange[0] > 1 && (
+            <Button
+              className={cssClass.BUTTON_PAGE}
+              key={1}
+              onClick={() => this._selectPage(1)}
+              type="linkPlain"
+              value="1"
+            />
+          )}
+          {visibleRange[0] > 2 && this._renderEllipsis()}
+          {visibleRange.map(pageNumber => (
+            <Button
+              className={classnames(cssClass.BUTTON_PAGE, pageNumber === currentPage && cssClass.BUTTON_PAGE_SELECTED)}
+              key={pageNumber}
+              onClick={() => this._selectPage(pageNumber)}
+              type="linkPlain"
+              value={`${pageNumber}`}
+            />
+          ))}
+          {visibleRange[VISIBLE_PAGE_RANGE_SIZE - 1] < numPages - 1 && this._renderEllipsis()}
+          {visibleRange[VISIBLE_PAGE_RANGE_SIZE - 1] < numPages && (
+            <Button
+              className={cssClass.BUTTON_PAGE}
+              key={numPages}
+              onClick={() => this._selectPage(numPages)}
+              type="linkPlain"
+              value={`${numPages}`}
+            />
+          )}
+        </div>
+        <Button
+          className={cssClass.BUTTON_SCROLL}
+          disabled={currentPage === numPages}
+          onClick={() => this._selectPage(currentPage + 1, numPages)}
+          type="linkPlain"
+          value="Next"
+        />
+      </div>
+    );
+  }
+
+  render() {
+    const {cssClass} = Footer;
+    const {numColumns, numPages} = this.props;
+
+    if (numPages < 2) {
+      return null;
+    }
+
+    return (
+      <tfoot className={cssClass.CONTAINER}>
+        <tr className={cssClass.ROW}>
+          <Cell
+            className={cssClass.CELL}
+            colSpan={numColumns}
+          >
+            {this._renderPaginationControls()}
+          </Cell>
+        </tr>
+      </tfoot>
+    );
+  }
+}
+
+Footer.propTypes = {
+  currentPage: PropTypes.number.isRequired,
+  onPageChange: PropTypes.func,
+  numColumns: PropTypes.number.isRequired,
+  numPages: PropTypes.number.isRequired,
+};
+
+Footer.defaultProps = {
+  onPageChange: () => {},
+};
+
+Footer.cssClass = {
+  BUTTON_PAGE: "Table--footer--button--page",
+  BUTTON_PAGE_SELECTED: "Table--footer--button--page--selected",
+  BUTTON_SCROLL: "Table--footer--button--scroll",
+  CELL: "Table--footer--cell",
+  CONTAINER: "Table--footer",
+  ELLIPSIS: "Table--footer--ellipsis",
+  PAGE_NUMBERS: "Table--footer--page_numbers",
+  ROW: "Table--footer--row",
+};
+
+Footer.VISIBLE_PAGE_RANGE_SIZE = 5;

--- a/src/Table/Footer.jsx
+++ b/src/Table/Footer.jsx
@@ -1,5 +1,5 @@
 import classnames from "classnames";
-import React, {Component, PropTypes} from "react";
+import React, {PropTypes} from "react";
 
 import {Button} from "../Button/Button";
 import Cell from "./Cell";
@@ -11,110 +11,97 @@ require("./Footer.less");
  * Pagination footer for the Table component.
  * Only rendered if there are more than 1 page of data available.
  */
-export default class Footer extends Component {
-  _selectPage(page) {
-    if (page === this.props.currentPage) {
+export default function Footer({currentPage, numColumns, numPages, onPageChange}) {
+  const {cssClass, VISIBLE_PAGE_RANGE_SIZE} = Footer;
+
+  const renderEllipsis = () => <span className={cssClass.ELLIPSIS}>&hellip;</span>;
+
+  const selectPage = page => {
+    if (page === currentPage) {
       return;
     }
 
-    this.props.onPageChange(page);
+    onPageChange(page);
+  };
+
+  if (numPages < 2) {
+    return null;
   }
 
-  _renderEllipsis() {
-    return <span className={Footer.cssClass.ELLIPSIS}>{"•••"}</span>;
+  // Find the widest possible number range <= `VISIBLE_PAGE_RANGE_SIZE`.
+  const pageNumberPadding = (VISIBLE_PAGE_RANGE_SIZE - 1) / 2;
+  let pageNumStart;
+  if ((currentPage + pageNumberPadding) >= numPages) {
+    pageNumStart = Math.max(numPages - (VISIBLE_PAGE_RANGE_SIZE - 1), 1);
+  } else {
+    pageNumStart = Math.max(currentPage - pageNumberPadding, 1);
+  }
+  const pageNumEnd = Math.min(pageNumStart + (VISIBLE_PAGE_RANGE_SIZE - 1), numPages);
+
+  const visibleRange = [];
+  for (let i = pageNumStart; i <= pageNumEnd; i++) {
+    visibleRange.push(i);
   }
 
-  _renderPaginationControls() {
-    const {cssClass, VISIBLE_PAGE_RANGE_SIZE} = Footer;
-    const {currentPage, numPages} = this.props;
-
-    // Find the widest possible number range <= `VISIBLE_PAGE_RANGE_SIZE`.
-    const pageNumberPadding = (VISIBLE_PAGE_RANGE_SIZE - 1) / 2;
-    let pageNumStart;
-    if ((currentPage + pageNumberPadding) >= numPages) {
-      pageNumStart = Math.max(numPages - (VISIBLE_PAGE_RANGE_SIZE - 1), 1);
-    } else {
-      pageNumStart = Math.max(currentPage - pageNumberPadding, 1);
-    }
-    const pageNumEnd = Math.min(pageNumStart + (VISIBLE_PAGE_RANGE_SIZE - 1), numPages);
-
-    const visibleRange = [];
-    for (let i = pageNumStart; i <= pageNumEnd; i++) {
-      visibleRange.push(i);
-    }
-
-    return (
-      <div>
-        <Button
-          className={cssClass.BUTTON_SCROLL}
-          disabled={currentPage === 1}
-          onClick={() => this._selectPage(currentPage - 1)}
-          type="linkPlain"
-          value="Prev"
-        />
-        <div className={cssClass.PAGE_NUMBERS}>
-          {visibleRange[0] > 1 && (
-            <Button
-              className={cssClass.BUTTON_PAGE}
-              key={1}
-              onClick={() => this._selectPage(1)}
-              type="linkPlain"
-              value="1"
-            />
-          )}
-          {visibleRange[0] > 2 && this._renderEllipsis()}
-          {visibleRange.map(pageNumber => (
-            <Button
-              className={classnames(cssClass.BUTTON_PAGE, pageNumber === currentPage && cssClass.BUTTON_PAGE_SELECTED)}
-              key={pageNumber}
-              onClick={() => this._selectPage(pageNumber)}
-              type="linkPlain"
-              value={`${pageNumber}`}
-            />
-          ))}
-          {visibleRange[VISIBLE_PAGE_RANGE_SIZE - 1] < numPages - 1 && this._renderEllipsis()}
-          {visibleRange[VISIBLE_PAGE_RANGE_SIZE - 1] < numPages && (
-            <Button
-              className={cssClass.BUTTON_PAGE}
-              key={numPages}
-              onClick={() => this._selectPage(numPages)}
-              type="linkPlain"
-              value={`${numPages}`}
-            />
-          )}
-        </div>
-        <Button
-          className={cssClass.BUTTON_SCROLL}
-          disabled={currentPage === numPages}
-          onClick={() => this._selectPage(currentPage + 1, numPages)}
-          type="linkPlain"
-          value="Next"
-        />
-      </div>
-    );
-  }
-
-  render() {
-    const {cssClass} = Footer;
-    const {numColumns, numPages} = this.props;
-
-    if (numPages < 2) {
-      return null;
-    }
-
-    return (
-      <tfoot className={cssClass.CONTAINER}>
-        <tr className={cssClass.ROW}>
-          <Cell
-            className={cssClass.CELL}
-            colSpan={numColumns}
-          >
-            {this._renderPaginationControls()}
-          </Cell>
-        </tr>
-      </tfoot>
-    );
-  }
+  return (
+    <tfoot className={cssClass.CONTAINER}>
+      <tr className={cssClass.ROW}>
+        <Cell
+          className={cssClass.CELL}
+          colSpan={numColumns}
+        >
+          <Button
+            className={cssClass.BUTTON_SCROLL}
+            disabled={currentPage === 1}
+            onClick={() => selectPage(currentPage - 1)}
+            type="linkPlain"
+            value="Prev"
+          />
+          <div className={cssClass.PAGE_NUMBERS}>
+            {visibleRange[0] > 1 && (
+              <Button
+                className={cssClass.BUTTON_PAGE}
+                key={1}
+                onClick={() => selectPage(1)}
+                type="linkPlain"
+                value="1"
+              />
+            )}
+            {visibleRange[0] > 2 && renderEllipsis()}
+            {visibleRange.map(pageNumber => (
+              <Button
+                className={classnames(
+                  cssClass.BUTTON_PAGE,
+                  pageNumber === currentPage && cssClass.BUTTON_PAGE_SELECTED
+                )}
+                key={pageNumber}
+                onClick={() => selectPage(pageNumber)}
+                type="linkPlain"
+                value={`${pageNumber}`}
+              />
+            ))}
+            {visibleRange[VISIBLE_PAGE_RANGE_SIZE - 1] < numPages - 1 && renderEllipsis()}
+            {visibleRange[VISIBLE_PAGE_RANGE_SIZE - 1] < numPages && (
+              <Button
+                className={cssClass.BUTTON_PAGE}
+                key={numPages}
+                onClick={() => selectPage(numPages)}
+                type="linkPlain"
+                value={`${numPages}`}
+              />
+            )}
+          </div>
+          <Button
+            className={cssClass.BUTTON_SCROLL}
+            disabled={currentPage === numPages}
+            onClick={() => selectPage(currentPage + 1, numPages)}
+            type="linkPlain"
+            value="Next"
+          />
+        </Cell>
+      </tr>
+    </tfoot>
+  );
 }
 
 Footer.propTypes = {

--- a/src/Table/Footer.jsx
+++ b/src/Table/Footer.jsx
@@ -1,8 +1,9 @@
 import classnames from "classnames";
 import React, {PropTypes} from "react";
 
-import {Button} from "../Button/Button";
+import * as tablePropTypes from "./tablePropTypes";
 import Cell from "./Cell";
+import {Button} from "../Button/Button";
 
 require("./Footer.less");
 
@@ -115,7 +116,7 @@ export default function Footer({currentPage, numColumns, numPages, onPageChange}
 }
 
 Footer.propTypes = {
-  currentPage: PropTypes.number.isRequired,
+  currentPage: tablePropTypes.pageNumber.isRequired,
   onPageChange: PropTypes.func,
   numColumns: PropTypes.number.isRequired,
   numPages: PropTypes.number.isRequired,

--- a/src/Table/Footer.less
+++ b/src/Table/Footer.less
@@ -1,0 +1,45 @@
+@import "../colors.less";
+
+@pageNumberMargin: 0 5px;
+
+.Table--footer {
+  background-color: @neutral_silver;
+}
+
+.Table--footer--cell {
+  font-size: 0.75rem;
+  padding: 0.75rem;
+  text-align: center;
+}
+
+.Button.Table--footer--button--scroll {
+  @spacing: 40px;
+  margin: 0;
+
+  &:not(:last-child) {
+    margin-right: @spacing;
+  }
+
+  &:not(:first-child) {
+    margin-left: @spacing;
+  }
+}
+
+.Button.Table--footer--button--page {
+  margin: @pageNumberMargin;
+
+  &.Button.Table--footer--button--page--selected {
+    color: @neutral_black;
+  }
+}
+
+.Table--footer--page_numbers {
+  display: inline-block;
+}
+
+.Table--footer--ellipsis {
+  color: @primary_blue;
+  cursor: default;
+  margin: @pageNumberMargin;
+  vertical-align: middle;
+}

--- a/src/Table/Footer.less
+++ b/src/Table/Footer.less
@@ -40,6 +40,6 @@
 .Table--footer--ellipsis {
   color: @primary_blue;
   cursor: default;
+  font-size: 1rem;
   margin: @pageNumberMargin;
-  vertical-align: middle;
 }

--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -34,10 +34,6 @@ export class Table extends Component {
     this.setState({currentPage: page}, () => this.props.onPageChange(page));
   }
 
-  resetPage() {
-    this.setCurrentPage(1);
-  }
-
   _getColumn(columnID) {
     return lodash.find(this.props.children, column => column.props.id === columnID);
   }

--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -144,7 +144,7 @@ Table.propTypes = {
   data: PropTypes.array.isRequired,
   filter: PropTypes.func,
   fixed: PropTypes.bool,
-  initialPage: PropTypes.number,
+  initialPage: tablePropTypes.pageNumber,
   initialSortState: tablePropTypes.sortState,
   onPageChange: PropTypes.func,
   onSortChange: PropTypes.func,

--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -70,6 +70,7 @@ export class Table extends Component {
       fixed,
       initialSortState,
       pageSize,
+      paginated,
       rowIDFn,
     } = this.props;
     const {currentPage, sortState = initialSortState} = this.state;
@@ -116,7 +117,7 @@ export class Table extends Component {
                 NO DATA
               </Cell>
             </tr>
-          ) : pages[displayedPageIndex].map(rowData => (
+            ) : pages[displayedPageIndex].map(rowData => (
             <tr className={cssClass.ROW} key={rowIDFn(rowData)}>
               {columns.map(({props: col}) => (
                 <Cell className={col.cell.className} key={col.id} noWrap={col.noWrap}>
@@ -126,12 +127,14 @@ export class Table extends Component {
             </tr>
           ))}
         </tbody>
-        <Footer
-          currentPage={displayedPage}
-          onPageChange={newPage => this.setCurrentPage(newPage)}
-          numColumns={columns.length}
-          numPages={numPages}
-        />
+        {paginated && (
+          <Footer
+            currentPage={displayedPage}
+            onPageChange={newPage => this.setCurrentPage(newPage)}
+            numColumns={columns.length}
+            numPages={numPages}
+          />
+        )}
       </table>
     );
   }
@@ -150,6 +153,7 @@ Table.propTypes = {
   onPageChange: PropTypes.func,
   onSortChange: PropTypes.func,
   pageSize: PropTypes.number,
+  paginated: PropTypes.bool,
   rowIDFn: PropTypes.func.isRequired,
 };
 

--- a/src/Table/Table.less
+++ b/src/Table/Table.less
@@ -15,6 +15,12 @@
   }
 }
 
+.Table--no_data_cell {
+  color: @neutral_gray;
+  font-size: 1rem;
+  text-align: center;
+}
+
 .Table--body {
   .Table--row {
     &:nth-child(even) {

--- a/src/Table/tablePropTypes.js
+++ b/src/Table/tablePropTypes.js
@@ -11,3 +11,28 @@ export const sortState = PropTypes.shape({
   columnID: PropTypes.string,
   direction: sortDirection,
 });
+
+export const pageNumber = (props, propName, componentName) => {
+  const value = props[propName];
+
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value !== "number" || value < 1) {
+    return new Error(
+      `Invalid prop \`${propName}\` supplied to ${componentName}. Must be a 1-based page index.`
+    );
+  }
+
+  return null;
+};
+
+pageNumber.isRequired = (props, propName, componentName) => {
+  const value = props[propName];
+  if (value === null || value === undefined) {
+    return new Error(`Missing required prop \`${propName}\` in ${componentName}.`);
+  }
+
+  return pageNumber(props, propName, componentName);
+};

--- a/test/Button_test.jsx
+++ b/test/Button_test.jsx
@@ -8,7 +8,7 @@ import {Button} from "../src";
 
 describe("Button", () => {
   const sizes = ["small", "regular", "large"];
-  const types = ["primary", "secondary", "destructive", "link"];
+  const types = ["primary", "secondary", "destructive", "link", "linkPlain"];
 
   sizes.forEach((size) => {
     types.forEach((type) => {

--- a/test/Table/Footer_test.jsx
+++ b/test/Table/Footer_test.jsx
@@ -37,14 +37,14 @@ describe("Footer", () => {
       const scrollButtons = newFooter({currentPage: 1, numPages: 2}).find(`.${cssClass.BUTTON_SCROLL}`);
 
       assert(scrollButtons.at(0).props().disabled, "Left scroll button should be disabled.");
-      assert(!scrollButtons.at(1).props().disabled, "Left scroll button should not be disabled.");
+      assert(!scrollButtons.at(1).props().disabled, "Right scroll button should not be disabled.");
     });
 
-    it("disables 'Next' button when on first page", () => {
+    it("disables 'Next' button when on last page", () => {
       const scrollButtons = newFooter({currentPage: 2, numPages: 2}).find(`.${cssClass.BUTTON_SCROLL}`);
 
       assert(!scrollButtons.at(0).props().disabled, "Left scroll button should not be disabled.");
-      assert(scrollButtons.at(1).props().disabled, "Left scroll button should be disabled.");
+      assert(scrollButtons.at(1).props().disabled, "Right scroll button should be disabled.");
     });
 
     it("increments current page on 'Next' button click", () => {

--- a/test/Table/Footer_test.jsx
+++ b/test/Table/Footer_test.jsx
@@ -1,0 +1,112 @@
+import assert from "assert";
+import React from "react";
+import sinon from "sinon";
+import {shallow} from "enzyme";
+
+import Cell from "../../src/Table/Cell";
+import Footer from "../../src/Table/Footer";
+
+
+describe("Footer", () => {
+  const {cssClass, VISIBLE_PAGE_RANGE_SIZE} = Footer;
+
+  const newFooter = props => shallow(
+    <Footer currentPage={1} numColumns={3} numPages={3} {...props} />
+  );
+
+  it("is empty for numPages < 2", () => {
+    assert(newFooter({numPages: 0}).children().isEmpty(), "Footer should be empty for 0 pages.");
+    assert(newFooter({numPages: 1}).children().isEmpty(), "Footer should be empty for 1 page.");
+  });
+
+  it("renders single cell spanning all columns", () => {
+    const footer = newFooter({numColumns: 3});
+    assert.equal(footer.find(Cell).props().colSpan, 3, "Invalid colSpan value");
+  });
+
+  describe("scroll buttons", () => {
+    it("renders 'Prev' and 'Next' scroll buttons", () => {
+      const scrollButtons = newFooter().find(`.${cssClass.BUTTON_SCROLL}`);
+
+      assert.equal(scrollButtons.length, 2, "Incorrect number of scroll buttons.");
+      assert.equal(scrollButtons.at(0).props().value, "Prev");
+      assert.equal(scrollButtons.at(1).props().value, "Next");
+    });
+
+    it("disables 'Prev' button when on first page", () => {
+      const scrollButtons = newFooter({currentPage: 1, numPages: 2}).find(`.${cssClass.BUTTON_SCROLL}`);
+
+      assert(scrollButtons.at(0).props().disabled, "Left scroll button should be disabled.");
+      assert(!scrollButtons.at(1).props().disabled, "Left scroll button should not be disabled.");
+    });
+
+    it("disables 'Next' button when on first page", () => {
+      const scrollButtons = newFooter({currentPage: 2, numPages: 2}).find(`.${cssClass.BUTTON_SCROLL}`);
+
+      assert(!scrollButtons.at(0).props().disabled, "Left scroll button should not be disabled.");
+      assert(scrollButtons.at(1).props().disabled, "Left scroll button should be disabled.");
+    });
+
+    it("increments current page on 'Next' button click", () => {
+      const onPageChange = sinon.spy();
+
+      const scrollButtons = newFooter({currentPage: 1, numPages: 2, onPageChange})
+        .find(`.${cssClass.BUTTON_SCROLL}`);
+
+      scrollButtons.at(1).simulate("click");
+      sinon.assert.calledWith(onPageChange, 2);
+      onPageChange.reset();
+    });
+
+    it("decrements current page on 'Prev' button click", () => {
+      const onPageChange = sinon.spy();
+
+      const scrollButtons = newFooter({currentPage: 2, numPages: 2, onPageChange})
+        .find(`.${cssClass.BUTTON_SCROLL}`);
+
+      scrollButtons.at(0).simulate("click");
+      sinon.assert.calledWith(onPageChange, 1);
+      onPageChange.reset();
+    });
+  });
+
+  describe("page buttons", () => {
+    it("renders all page numbers for numPages <= `VISIBLE_PAGE_RANGE_SIZE` + 2", () => {
+      const expectedButtons = ["1"];
+      for (let i = 2; i <= VISIBLE_PAGE_RANGE_SIZE + 2; i++) {
+        const midPage = Math.ceil(i / 2);
+
+        const footer = newFooter({numPages: i, currentPage: midPage});
+        const pageButtons = footer.find(`.${cssClass.BUTTON_PAGE}`);
+
+        expectedButtons.push(`${i}`);
+        assert.deepEqual(pageButtons.map(b => b.props().value), expectedButtons);
+      }
+    });
+
+    it("collapses extra page numbers into ellipsis", () => {
+      const numPages = 40;
+
+      const footer = newFooter({numPages, currentPage: 20});
+
+      const pageButtons = footer.find(`.${cssClass.BUTTON_PAGE}`);
+      const expectedButtons = ["1", "18", "19", "20", "21", "22", "40"];
+      assert.deepEqual(pageButtons.map(b => b.props().value), expectedButtons);
+
+      const pageNumbers = footer.find(`.${cssClass.PAGE_NUMBERS}`).children();
+      assert.equal(pageNumbers.length, expectedButtons.length + 2, "Incorrect number of page numbers displayed.");
+      assert(pageNumbers.at(1).hasClass(cssClass.ELLIPSIS));
+      assert(pageNumbers.at(pageNumbers.length - 2).hasClass(cssClass.ELLIPSIS));
+    });
+
+    it("highlights selected page number", () => {
+      const currentPage = 3;
+      const footer = newFooter({numPages: 5, currentPage});
+
+      const pageButtons = footer.find(`.${cssClass.BUTTON_PAGE}`);
+      const selectedButton = footer.find(`.${cssClass.BUTTON_PAGE_SELECTED}`);
+      assert.equal(selectedButton.length, 1, "Invalid number of selected page buttons,");
+      assert(selectedButton.equals(pageButtons.get(currentPage - 1)), "3rd page button should be selected.");
+    });
+  });
+});

--- a/test/Table/Table_test.jsx
+++ b/test/Table/Table_test.jsx
@@ -6,6 +6,7 @@ import {shallow} from "enzyme";
 
 import Cell from "../../src/Table/Cell";
 import Column from "../../src/Table/Column";
+import Footer from "../../src/Table/Footer";
 import Header from "../../src/Table/Header";
 import sortDirection from "../../src/Table/sortDirection";
 import {Table} from "../../src/Table/Table";
@@ -143,6 +144,14 @@ describe("Table", () => {
       assert(rows.first().contains(item.name), `Expected\n${rows.debug()}\nto contain "${item.name}"`);
     });
 
+    it("shows 'NO DATA' notice if filtered data is empty", () => {
+      const table = newTable({filter: () => false});
+
+      const rows = table.find(`.${cssClass.ROW}`);
+      assert.equal(rows.length, 1);
+      assert(rows.first().contains("NO DATA"), `Expected\n${rows.debug()}\nto contain "NO DATA"`);
+    });
+
     it("disables sorting if fewer than 2 rows are visible", () => {
       const table = newTable();
       assert(!table.find(Header).props().disableSort, "Sort should NOT be disabled if table contains > 1 row.");
@@ -176,5 +185,26 @@ describe("Table", () => {
         direction: sortDirection.DESCENDING,
       }, "Sort state not preserved after prop change.");
     });
+
+    it("shows only data from the selected page", () => {
+      const table = newTable({pageSize: 1, initialPage: 2});
+
+      const expectedItem = DATA[1];
+      const rows = table.find(`.${cssClass.ROW}`);
+      assert.equal(rows.length, 1, "Incorrect number of rows on page.");
+      assert(
+        rows.first().contains(expectedItem.name),
+        `Expected\n${rows.debug()}\nto contain "${expectedItem.name}"`
+      );
+    });
+  });
+
+  it("renders footer", () => {
+    const table = newTable({pageSize: 1, initialPage: 2});
+    const footer = table.find(Footer);
+
+    // assert.equal(footer.props().currentPage, 2, "Incorrect currrentPage prop value.");
+    assert.equal(footer.props().numColumns, 2, "Incorrect numColumns prop value.");
+    assert.equal(footer.props().numPages, DATA.length, "Incorrect numPages prop value.");
   });
 });

--- a/test/Table/Table_test.jsx
+++ b/test/Table/Table_test.jsx
@@ -199,11 +199,16 @@ describe("Table", () => {
     });
   });
 
-  it("renders footer", () => {
+  it("doesn't render footer by default", () => {
     const table = newTable({pageSize: 1, initialPage: 2});
+    assert(table.find(Footer).isEmpty(), "Footer should not be rendererd.");
+  });
+
+  it("renders footer if paginated", () => {
+    const table = newTable({pageSize: 1, initialPage: 2, paginated: true});
     const footer = table.find(Footer);
 
-    // assert.equal(footer.props().currentPage, 2, "Incorrect currrentPage prop value.");
+    assert.equal(footer.props().currentPage, 2, "Incorrect currrentPage prop value.");
     assert.equal(footer.props().numColumns, 2, "Incorrect numColumns prop value.");
     assert.equal(footer.props().numPages, DATA.length, "Incorrect numPages prop value.");
   });


### PR DESCRIPTION
- Add a pagination footer with default 10 rows per page.
  - Hidden if there's only 1 page of data available after filtering.
- Also show a 'NO DATA' row if the current filter has no matches.
- Update TableExample to include pagination over large sets of data.
![table-pagination](https://cloud.githubusercontent.com/assets/16216084/18306318/1ca1ac5c-74a0-11e6-9ffe-404be1e97feb.gif)

- Also add a "linkPlain" Button type to support plain inline text links.
  - We've needed to manually strip the padding and centering in a few cases.
     This should make it more convenient to use in those scenarios.
- Update live examples with a 'linkPlain' Button.
<img width="834" alt="screen shot 2016-09-07 at 1 48 21 am" src="https://cloud.githubusercontent.com/assets/16216084/18306330/27cce498-74a0-11e6-8057-dd7563f5f1d2.png">

- Minor bump 0.8.0 -> 0.9.0
  - Breaking change bump since tables that would usually display all data
     rows will now paginate by default.