### PR TITLE
Add git-push step to deploy script to keep master and gh-pages in sync.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+currentBranch=$(git symbolic-ref --short HEAD)
+if [[ $currentBranch != "master" ]]
+then
+  echo -e "\n\033[0;31m✖ The deploy script must be run from the master branch.\033[0m\n";
+  exit 1;
+fi
+
+diffWithOrigin=$(git diff --name-only origin/master)
+if [[ $diffWithOrigin != "" ]]
+then
+  echo -e "\n\033[0;31m✖ Your local master branch must be in sync with origin/master.\033[0m\n";
+  exit 1;
+fi
+
 ./node_modules/.bin/webpack
 
 git add docs/
@@ -11,3 +25,5 @@ git commit
 git subtree push --prefix docs origin gh-pages
 
 git push origin master
+
+echo -e "\n\033[0;32m✓ Deployment complete. Verify at http://clever.github.io/components\033[0m\n";

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,3 +9,5 @@ git add docs/
 git commit
 
 git subtree push --prefix docs origin gh-pages
+
+git push origin master


### PR DESCRIPTION
Run `git push origin master` after gh-pages deployment.

This keeps master in sync with the gh-pages branch, which is required in order for future deployments to work.

Tested manually with last deployment (for v0.9.0)