### PR TITLE
[Table] Skip data chunking logic when pagination is disabled.

### DIFF
--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -96,7 +96,10 @@ export class Table extends Component {
     displayedData = displayedData.value();
     const disableSort = displayedData.length <= 1;
 
-    const pages = lodash.chunk(displayedData, pageSize);
+    let pages = [displayedData];
+    if (paginated) {
+      pages = lodash.chunk(displayedData, pageSize);
+    }
     const numPages = pages.length;
     const displayedPage = Math.min(currentPage, numPages);
     const displayedPageIndex = displayedPage - 1;

--- a/test/Table/Table_test.jsx
+++ b/test/Table/Table_test.jsx
@@ -186,8 +186,8 @@ describe("Table", () => {
       }, "Sort state not preserved after prop change.");
     });
 
-    it("shows only data from the selected page", () => {
-      const table = newTable({pageSize: 1, initialPage: 2});
+    it("shows only data from the selected page if paginated", () => {
+      const table = newTable({pageSize: 1, initialPage: 2, paginated: true});
 
       const expectedItem = DATA[1];
       const rows = table.find(`.${cssClass.ROW}`);
@@ -199,8 +199,17 @@ describe("Table", () => {
     });
   });
 
-  it("doesn't render footer by default", () => {
+  it("doesn't paginate by default", () => {
     const table = newTable({pageSize: 1, initialPage: 2});
+
+    const rows = table.find(`.${cssClass.ROW}`);
+    assert.equal(rows.length, DATA.length, "Incorrect number of rows on page.");
+    DATA.forEach((item, i) => {
+      assert(
+        rows.at(i).contains(item.name),
+        `Expected\n${rows.debug()}\nto contain "${item.name}"`
+      );
+    });
     assert(table.find(Footer).isEmpty(), "Footer should not be rendererd.");
   });
 


### PR DESCRIPTION
Switched to non-paginated by default at the last minute in the previous
PR, but missed this part. Was previously only hiding the footer.

Disabling the chunking logic as well when pagination is disabled.