### PR TITLE
[Grid] Add grid component and IE10-compatible flex mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,3 +354,37 @@ The `Table` component requires child components of type `Table.Column`, which pr
 **Usage Example**
 
 [Sample Code](https://github.com/Clever/components/tree/master/docs/TableExample.jsx) ([Live Demo](http://clever.github.io/components/#table))
+
+### Grid
+
+12-column grid component for consistent, simple and flexible layouts.
+
+**`<Grid />` Options**
+
+| Prop             | Type     | Description                           | Default
+|------------------|----------|---------------------------------------|---------
+| children (optional) | Array<Grid.Row> | The rows to render in the grid. | None
+| className (optional) | String | Additional classname to apply to the grid. | None
+| wrapperComponent (optional) | Any | The tagname or component class for the wrapper component to render for the grid | "div"
+
+**`<Grid.Row />` Options**
+
+| Prop             | Type     | Description                           | Default
+|------------------|----------|---------------------------------------|---------
+| children (optional) | Array<Grid.Col> | The columns to render in the row. | None
+| className (optional) | String | Additional classname to apply to the row. | None
+| grow (optional) | Boolean | Fluidly grows the row to fill any available vertical space. The parent Grid should have an explicit height set for this to work. | False
+| wrapperComponent (optional) | Any | The tagname or component class for the wrapper component to render for the row | "div"
+
+**`<Grid.Col />` Options**
+
+| Prop             | Type     | Description                           | Default
+|------------------|----------|---------------------------------------|---------
+| children (optional) | React Node | The content to render in the column. | None
+| className (optional) | String | Additional classname to apply to the column. | None
+| span (optional) | Number or Map<Grid.Size, Number> | The number of columns (1-12) that this column spans. Can optionally as a map of viewport size to column span in order to dynamically update the grid based on the user's viewport width. | 1
+| wrapperComponent (optional) | Any | The tagname or component class for the wrapper component to render for the column | "div"
+
+**Usage Examples**
+
+[Sample Code](https://github.com/Clever/components/tree/master/docs/GridExample.jsx) ([Live Demo](http://clever.github.io/components/#grid))

--- a/README.md
+++ b/README.md
@@ -359,6 +359,14 @@ The `Table` component requires child components of type `Table.Column`, which pr
 
 12-column grid component for consistent, simple and flexible layouts.
 
+The `Grid` is a single column of any number of `Grid.Row`s, which contain any number of `Grid.Col`s.
+
+`Grid.Col`s can have varying sizes, determined by the values of their `span` prop.
+A single `Grid.Col` can have different span lengths for different viewport sizes to enable layouts that update dynamically based on available space in the viewport.
+
+**NOTE:** A row of `Grid.Col`s is guaranteed to fit on a single line only if the sum of the `span`s add up to 12 in the current
+viewport. Any additional `Grid.Col`s will wrap onto the following line.
+
 **`<Grid />` Options**
 
 | Prop             | Type     | Description                           | Default

--- a/docs/GridExample.jsx
+++ b/docs/GridExample.jsx
@@ -1,0 +1,122 @@
+import _ from "lodash";
+import classnames from "classnames";
+import React from "react";
+
+import {Grid} from "../src/Grid/Grid";
+
+require("./GridExample.less");
+require("../src/less/flex.less");
+require("../src/less/spacing.less");
+
+
+function renderCol(spans, className) {
+  const {Col, Size} = Grid;
+  let content;
+  if (typeof spans === "number") {
+    content = `${Size.DEFAULT}: ${spans}`;
+  } else {
+    content = _.map(spans, (span, gridSize) => `${gridSize}: ${span}`).join("\n");
+  }
+
+  return (
+    <Col className={classnames("gridCell", className)} span={spans}>
+      <code className="gridContent">
+        <pre className="margin--none">{content}</pre>
+      </code>
+    </Col>
+  );
+}
+
+export default function GridExample() {
+  const {Col, Row, Size} = Grid;
+
+  return (
+    <div className="GridExample">
+      <a name="grid">
+        <h1>Grid (12-Column)</h1>
+      </a>
+      <h2>Single Layout</h2>
+      <Grid className="outlined resizable">
+        <Row grow>{renderCol(2)}{renderCol(7)}{renderCol(3)}</Row>
+        <Row grow>{renderCol(2)}{renderCol(2)}{renderCol(5)}{renderCol(3)}</Row>
+        <Row grow>{renderCol(12)}</Row>
+      </Grid>
+
+      <h2>Single Layout (with gutters)</h2>
+      <Grid className="outlined resizable">
+        <Row className="margin--bottom--xs" grow>
+          {renderCol(2, "padding--right--xs")}
+          {renderCol(7, "padding--right--xs")}
+          {renderCol(3)}
+        </Row>
+        <Row className="margin--bottom--xs" grow>
+          {renderCol(2, "padding--right--xs")}
+          {renderCol(2, "padding--right--xs")}
+          {renderCol(5, "padding--right--xs")}
+          {renderCol(3)}
+        </Row>
+        <Row>{renderCol(12)}</Row>
+      </Grid>
+
+      <h2>Mixed Layouts</h2>
+      <Grid className="outlined resizable">
+        <Row grow>
+          {renderCol({
+            [Size.DEFAULT]: 12,
+            [Size.S]: 6,
+            [Size.M]: 4,
+            [Size.L]: 3,
+          })}
+          {renderCol({
+            [Size.DEFAULT]: 12,
+            [Size.S]: 6,
+            [Size.M]: 4,
+            [Size.L]: 3,
+          })}
+          {renderCol({
+            [Size.DEFAULT]: 12,
+            [Size.S]: 6,
+            [Size.M]: 4,
+            [Size.L]: 3,
+          })}
+          {renderCol({
+            [Size.DEFAULT]: 12,
+            [Size.S]: 6,
+            [Size.M]: 12,
+            [Size.L]: 3,
+          })}
+        </Row>
+        <Row grow>{renderCol(6)}{renderCol(6)}</Row>
+        <Row>{renderCol(12)}</Row>
+      </Grid>
+
+      <h2>Nested Grids</h2>
+      <Grid className="items--center outlined resizable" style={{height: "400px", minWidth: "550px"}}>
+        <Row className="shaded outlined" style={{marginBottom: "1rem"}}>
+          <Col span={12} className="justify--center">
+            <Grid style={{padding: 0, maxWidth: "700px"}}>
+              <Row>{renderCol(2)}{renderCol(7)}{renderCol(3)}</Row>
+            </Grid>
+          </Col>
+        </Row>
+        <Row className="shaded outlined" grow>
+          <Col span={12} className="justify--center self--stretch">
+            <Grid style={{padding: 0, maxWidth: "700px"}} className="self--stretch">
+              <Row>{renderCol(3)}{renderCol(9)}</Row>
+              <Row grow>{renderCol(3)}{renderCol(9)}</Row>
+              <Row>{renderCol(12)}</Row>
+            </Grid>
+          </Col>
+        </Row>
+      </Grid>
+
+      <h2>Standalone Row</h2>
+      <Row>
+        {renderCol(3, "padding--right--xs")}
+        {renderCol(3, "padding--right--xs")}
+        {renderCol(3, "padding--right--xs")}
+        {renderCol(3)}
+      </Row>
+    </div>
+  );
+}

--- a/docs/GridExample.less
+++ b/docs/GridExample.less
@@ -1,0 +1,57 @@
+@import (reference) "../src/less/colors";
+@import (reference) "../src/less/flex";
+@import (reference) "../src/less/grid";
+@import (reference) "../src/less/spacing";
+@import (reference) "../src/less/type-size";
+
+
+.GridExample {
+  .margin--top--2xl;
+
+  div {
+    box-sizing: border-box;
+  }
+
+  h2 {
+    .margin--none;
+    .margin--bottom--xs
+  }
+
+  .shaded {
+    background-color: fadeout(@neutral_gray, 90%);
+  }
+
+  .outlined {
+    border: 1px solid shade(@neutral_silver, 10%);
+  }
+
+  .Grid {
+    .shaded;
+    padding: 1rem;
+
+    &:not(:last-child) {
+      .margin--bottom--l;
+    }
+
+    &.resizable {
+      resize: vertical;
+      overflow: hidden;
+    }
+  }
+
+  code.gridContent {
+    .alignItems(center);
+    .flex--grow;
+    .flexbox;
+    .justifyContent(center);
+    .outlined;
+    .tint(color, @accent_purple, 2);
+    .type_medium;
+    background-color: @neutral_silver;
+    font-size: 0.875rem;
+    font-family: Menlo, Monaco, Consolas, Courier New, monospace;
+    font-weight: 600;
+    padding: 1rem;
+    text-align: center;
+  }
+}

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -2,6 +2,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 
+import GridExample from "./GridExample";
 import TableExample from "./TableExample";
 import {
   Button,
@@ -309,6 +310,9 @@ class Demo extends React.Component {
           }]}
         />
         <TableExample />
+        <GridExample />
+        {/* Enable scrolling past the bottom for convenience. */}
+        <div style={{margin: "0 0 600px"}} />
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/Grid/Col.jsx
+++ b/src/Grid/Col.jsx
@@ -29,6 +29,7 @@ export default function Col({
   );
 }
 
+// Define the shape of the `span` prop as a map from viewport `Size` to the associated span length.
 Col.colSpanPropShape = {};
 _.forEach(Size, size => {
   Col.colSpanPropShape[size] = PropTypes.number;

--- a/src/Grid/Col.jsx
+++ b/src/Grid/Col.jsx
@@ -1,0 +1,54 @@
+import _ from "lodash";
+import classnames from "classnames";
+import React, {PropTypes} from "react";
+
+import Size from "./Size";
+
+require("../less/grid.less");
+
+
+export default function Col({
+  children,
+  className,
+  span,
+  wrapperComponent: Wrapper,
+  ...additionalProps,
+}) {
+  const {cssClass} = Col;
+  let colSpanClasses;
+  if (typeof span === "number") {
+    colSpanClasses = `${cssClass.COL}--${Size.DEFAULT}--${span}`;
+  } else {
+    colSpanClasses = _.map(Size, s => span[s] && `${cssClass.COL}--${s}--${span[s]}`);
+  }
+
+  return (
+    <Wrapper className={classnames(cssClass.COL, colSpanClasses, className)} {...additionalProps}>
+      {children}
+    </Wrapper>
+  );
+}
+
+Col.colSpanPropShape = {};
+_.forEach(Size, size => {
+  Col.colSpanPropShape[size] = PropTypes.number;
+});
+
+Col.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  span: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.shape(Col.colSpanPropShape),
+  ]),
+  wrapperComponent: PropTypes.any,
+};
+
+Col.defaultProps = {
+  span: 1,
+  wrapperComponent: "div",
+};
+
+Col.cssClass = {
+  COL: "Grid--Col",
+};

--- a/src/Grid/Grid.jsx
+++ b/src/Grid/Grid.jsx
@@ -1,0 +1,59 @@
+import classnames from "classnames";
+import React, {PropTypes} from "react";
+
+import Col from "./Col";
+import Row from "./Row";
+import Size from "./Size";
+
+require("../less/grid.less");
+
+
+export function Grid({
+  className,
+  children,
+  wrapperComponent: Wrapper,
+  ...additionalProps,
+}) {
+  const {cssClass} = Grid;
+
+  return (
+    <Wrapper className={classnames(cssClass.GRID, className)} {...additionalProps}>
+      {children}
+    </Wrapper>
+  );
+}
+
+Grid.Row = Row;
+Grid.Col = Col;
+Grid.Size = Size;
+
+Grid.rowPropType = (props, propName) => {
+  const value = props[propName];
+
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (!value.type || value.type !== Row) {
+    return new Error("All children of the Grid should be `Row` components.");
+  }
+
+  return null;
+};
+
+Grid.propTypes = {
+  children: PropTypes.oneOfType([
+    Grid.rowPropType,
+    PropTypes.arrayOf(Grid.rowPropType),
+  ]),
+  className: PropTypes.string,
+  wrapperComponent: PropTypes.any,
+};
+
+Grid.defaultProps = {
+  wrapperComponent: "div",
+};
+
+Grid.cssClass = {
+  GRID: "Grid",
+};

--- a/src/Grid/Grid.jsx
+++ b/src/Grid/Grid.jsx
@@ -34,7 +34,7 @@ Grid.rowPropType = (props, propName) => {
     return null;
   }
 
-  if (!value.type || value.type !== Row) {
+  if (value.type !== Row) {
     return new Error("All children of the Grid should be `Row` components.");
   }
 

--- a/src/Grid/Row.jsx
+++ b/src/Grid/Row.jsx
@@ -33,7 +33,7 @@ Row.colPropType = (props, propName) => {
     return null;
   }
 
-  if (!value.type || value.type !== Col) {
+  if (value.type !== Col) {
     return new Error("All children of the Row should be `Col` components.");
   }
 

--- a/src/Grid/Row.jsx
+++ b/src/Grid/Row.jsx
@@ -1,0 +1,60 @@
+import classnames from "classnames";
+import React, {PropTypes} from "react";
+
+import Col from "./Col";
+
+require("../less/flex.less");
+require("../less/grid.less");
+
+
+export default function Row({
+  children,
+  className,
+  grow,
+  wrapperComponent: Wrapper,
+  ...additionalProps,
+}) {
+  const {cssClass} = Row;
+
+  return (
+    <Wrapper
+      className={classnames(cssClass.ROW, grow && cssClass.GROW, className)}
+      {...additionalProps}
+    >
+      {children}
+    </Wrapper>
+  );
+}
+
+Row.colPropType = (props, propName) => {
+  const value = props[propName];
+
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (!value.type || value.type !== Col) {
+    return new Error("All children of the Row should be `Col` components.");
+  }
+
+  return null;
+};
+
+Row.propTypes = {
+  children: PropTypes.oneOfType([
+    Row.colPropType,
+    PropTypes.arrayOf(Row.colPropType),
+  ]),
+  className: PropTypes.string,
+  grow: PropTypes.bool,
+  wrapperComponent: PropTypes.any,
+};
+
+Row.defaultProps = {
+  wrapperComponent: "div",
+};
+
+Row.cssClass = {
+  GROW: "flex--grow",
+  ROW: "Grid--Row",
+};

--- a/src/Grid/Size.js
+++ b/src/Grid/Size.js
@@ -1,0 +1,9 @@
+/** @enum {string} */
+const Size = {
+  DEFAULT: "dflt",
+  S: "s",
+  M: "m",
+  L: "l",
+};
+
+export default Size;

--- a/src/index.js
+++ b/src/index.js
@@ -7,3 +7,4 @@ export {CopyableInput} from "./CopyableInput/CopyableInput";
 export {SegmentedControl} from "./SegmentedControl/SegmentedControl";
 export {Select} from "./Select/Select";
 export {Table} from "./Table/Table";
+export {Grid} from "./Grid/Grid";

--- a/src/less/flex.less
+++ b/src/less/flex.less
@@ -1,0 +1,245 @@
+/**
+ * Flex layout definitions and mixins.
+ */
+
+@import (reference) "./layout";
+
+/**
+ * Block flexbox display mixin.
+ * @target Flex container.
+ */
+.flexbox() {
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+}
+
+/**
+ * Inline flexbox display mixin.
+ * @target Flex container.
+ */
+.inlineFlexbox() {
+  display: -moz-box;
+  display: -ms-inline-flexbox;
+  display: -webkit-inline-flex;
+  display: inline-flex;
+}
+
+/**
+ * Flex line-wrapping.
+ * @target Flex container.
+ * @param {nowrap|wrap|wrap-reverse}
+ * @initial {nowrap}
+ */
+.flexWrap(@wrap: wrap) {
+  -ms-flex-wrap: @wrap;
+  -webkit-flex-wrap: @wrap;
+  flex-wrap: @wrap;
+}
+
+/**
+ * Flex flow direction for flex containers.
+ * @target Flex container.
+ * @param {row|row-reverse|column|column-reverse} direction
+ * @initial {row}
+ */
+.flexDirection(@direction) {
+  -ms-flex-direction: @direction;
+  -webkit-flex-direction: @direction;
+  flex-direction: @direction;
+}
+
+/**
+ * Flex item shorthand rule mixin.
+ * Use one of `.flex-grow`, `.flex-shrink` or `.flex-basis` for more fine-grained control, if
+ * necessary.
+ * @target Flex item.
+ * @param {number|none} grow - See `.flex-grow`.
+ * @param {number} shrink - See `.flex-shrink`. Defaults to 1.
+ * @param {number} basis - See `.flex-basis`. Defaults to auto.
+ * @initial {0 1 auto}
+ */
+.flex(@grow, @shrink: 1, @basis: auto) {
+  -moz-box-flex: @grow @shrink @basis;
+  -ms-flex: @grow @shrink @basis;
+  -webkit-box-flex: @grow @shrink @basis;
+  -webkit-flex: @grow @shrink @basis;
+  flex: @grow @shrink @basis;
+}
+
+/**
+ * Flex item shorthand rule mixin for setting `flex: none`.
+ * @target Flex item.
+ * @initial {0 1 auto}
+ */
+.flexNone() {
+  -moz-box-flex: none;
+  -ms-flex: none;
+  -webkit-box-flex: none;
+  -webkit-flex: none;
+  flex: none;
+}
+
+/**
+ * Grow flex item to fill availalbe space along the main axis, in proportion to the grow factor of
+ * its siblings. A value of 0 prevents the item from growing past its original size.
+ * @target Flex item.
+ * @param {number} value
+ * @initial {0}
+ */
+.flexGrow(@value: 1) {
+ -moz-box-flex-grow: @value;
+ -ms-flex-positive: @value;
+ -webkit-box-flex-grow: @value;
+ -webkit-flex-grow: @value;
+ flex-grow: @value;
+}
+
+/**
+ * Shrink flex item along the main axis, in respose to a shrinking parent, in proportion to the
+ * shrink factor of its siblings. A value of 0 prevents the item from shrinking past its original
+ * size.
+ * @target Flex item.
+ * @param {number} value
+ * @initial {1}
+ */
+.flexShrink(@value: 1) {
+ -moz-box-flex-grow: @value;
+ -ms-flex-negative: @value;
+ -webkit-box-flex-grow: @value;
+ -webkit-flex-grow: @value;
+ flex-grow: @value;
+}
+
+/**
+ * Initial size of the flex item along the main axis.
+ * @target Flex item.
+ * @param {auto|size} value
+ * @initial {auto}
+ */
+.flexBasis(@value: 1) {
+ -moz-box-flex-grow: @value;
+ -ms-flex-negative: @value;
+ -webkit-box-flex-grow: @value;
+ -webkit-flex-grow: @value;
+ flex-grow: @value;
+}
+
+/**
+ * Flex item alignment along the main axis.
+ * @target Flex container.
+ * @param {flex-start|flex-end|center|space-between|space-around} justify
+ * @initial {flex-start}
+ */
+.justifyContent(@justify) {
+  -ms-flex-pack: @justify;
+  -webkit-justify-content: @justify;
+  justify-content: @justify;
+}
+
+/**
+ * Flex item alignment along the cross (perpendicular) axis.
+ * @target Flex container.
+ * @param {flex-start|flex-end|center|baseline|stretch} align
+ * @initial {stretch}
+ */
+.alignItems(@align) {
+  -ms-flex-align: @align;
+  -webkit-align-items: @align;
+  align-items: @align;
+}
+
+/**
+ * Flex item alignment along the cross axis.
+ * @target Flex container.
+ * @param {flex-start|flex-end|center|baseline|stretch} align
+ * @initial {stretch}
+ */
+.alignContent(@align) {
+  -webkit-align-content: @align;
+  -ms-flex-line-pack: @align;
+  align-content: @align;
+}
+
+/**
+ * Individual flex item alignment along the cross axis.
+ * verrides `align-items` for a single flex item.
+ * @target Flex item.
+ * @param {flex-start|flex-end|center|baseline|stretch} [align] - Defaults to `stretch`.
+ */
+.alignSelf(@align) {
+  -webkit-align-self: @align;
+  -ms-flex-item-align: @align;
+  align-self: @align;
+}
+
+/**
+ * Flex order.
+ * Target: Flex item.
+ * @param {int} value
+ */
+.order(@value) {
+  -moz-box-ordinal-group: @value;
+  -ms-flex-order: @value;
+  -webkit-box-ordinal-group: @value;
+  -webkit-order: @value;
+  order: @value;
+}
+
+
+/*
+ * Convenience classes.
+ */
+
+.flexbox { .flexbox() }
+/* Enable flex for specific layout breakpoints. */
+.breakpointS({ .flexbox--s { .flexbox } });
+.breakpointM({ .flexbox--m { .flexbox } });
+.breakpointL({ .flexbox--l { .flexbox } });
+
+.flexbox--inline { .inlineFlexbox() }
+.flex--direction--column { .flexDirection(column) }
+.flex--wrap { .flexWrap(wrap) }
+
+.flex--grow { .flexGrow(1) }
+.flex--none { .flexNone() }
+.flex--shrink { .flexShrink(1) }
+
+.items--baseline { .alignItems(baseline) }
+.items--center { .alignItems(center) }
+.items--end { .alignItems(flex-end) }
+.items--start { .alignItems(flex-start) }
+.items--stretch { .alignItems(stretch) }
+
+.self--baseline { .alignSelf(baseline) }
+.self--center { .alignSelf(center) }
+.self--end { .alignSelf(flex-end) }
+.self--start { .alignSelf(flex-start) }
+.self--stretch { .alignSelf(stretch) }
+
+.justify--around { .justifyContent(space-around) }
+.justify--between { .justifyContent(space-between) }
+.justify--center { .justifyContent(center) }
+.justify--end { .justifyContent(flex-end) }
+.justify--start { .justifyContent(flex-start) }
+
+.content--around { .alignContent(space-around) }
+.content--between { .alignContent(space-between) }
+.content--center { .alignContent(center) }
+.content--end { .alignContent(flex-end) }
+.content--start { .alignContent(flex-start) }
+.content--stretch { .alignContent(stretch) }
+
+/* 1. Fix for Chrome 44 bug. https://code.google.com/p/chromium/issues/detail?id=506893 */
+.flex--auto {
+  .flex(1, 1, auto);
+  min-width: 0; /* 1 */
+  min-height: 0; /* 1 */
+}
+
+.order--0 { .order(0) }
+.order--1 { .order(1) }
+.order--2 { .order(2) }
+.order--3 { .order(3) }
+.order--last { .order(99999) }

--- a/src/less/grid.less
+++ b/src/less/grid.less
@@ -1,127 +1,56 @@
-.flex { display: flex }
+@import (reference) "./flex";
+@import (reference) "./layout";
 
-@media @--breakpoint-sm {
-  .sm-flex { display: flex }
-}
-
-@media @--breakpoint-md {
-  .md-flex { display: flex }
-}
-
-@media @--breakpoint-lg {
-  .lg-flex { display: flex }
-}
-
-.flex-column  { flex-direction: column }
-.flex-wrap    { flex-wrap: wrap }
-
-.items-start    { align-items: flex-start }
-.items-end      { align-items: flex-end }
-.items-center   { align-items: center }
-.items-baseline { align-items: baseline }
-.items-stretch  { align-items: stretch }
-
-.self-start    { align-self: flex-start }
-.self-end      { align-self: flex-end }
-.self-center   { align-self: center }
-.self-baseline { align-self: baseline }
-.self-stretch  { align-self: stretch }
-
-.justify-start   { justify-content: flex-start }
-.justify-end     { justify-content: flex-end }
-.justify-center  { justify-content: center }
-.justify-between { justify-content: space-between }
-.justify-around  { justify-content: space-around }
-
-.content-start   { align-content: flex-start }
-.content-end     { align-content: flex-end }
-.content-center  { align-content: center }
-.content-between { align-content: space-between }
-.content-around  { align-content: space-around }
-.content-stretch { align-content: stretch }
-
-/* 1. Fix for Chrome 44 bug. https://code.google.com/p/chromium/issues/detail?id=506893 */
-.flex-auto {
-  flex: 1 1 auto;
-  min-width: 0; /* 1 */
-  min-height: 0; /* 1 */
-}
-.flex-none { flex: none }
-
-.order-0 { order: 0 }
-.order-1 { order: 1 }
-.order-2 { order: 2 }
-.order-3 { order: 3 }
-.order-last { order: 99999 }
-
-@--breakpoint-sm: -"(min-width: 40em)";
-@--breakpoint-md: -"(min-width: 52em)";
-@--breakpoint-lg: -"(min-width: 64em)";
-
-
-
-
-.Grid--container {
-  width: 100%;
-  .flex;
-  .flex-wrap;
-  box-sizing: border-box;
-}
-
-.Row--container {
-  .flex;
-  .flex-wrap;
+.Grid {
+  .flex--direction--column;
+  .flexbox;
   box-sizing: border-box;
   width: 100%;
-  flex-direction: row;
 }
 
-.Column {
+.Grid--Row {
+  .flex--wrap;
+  .flexbox;
   box-sizing: border-box;
-  flex-shrink: 0;
+  width: 100%;
 }
 
-/*******************************************************
 
-  Generated columns
+/*
+ * Generated Columns
+ *
+ * Generate 12-column grid classes for increasing viewport sizes (S, M, L) of the form:
+ * `Grid--Col-ls--1`, `Grid--Col--l--2`, ... `Grid--Col--l--12`.
+ *
+ * Each viewport-specific class applies to viewports of that size or larger.
+ * Different viewport-specific classes can be assigned to a column to enable responsive layout
+ * changes at different viewport sizes.
+ *
+ * Use default (`--dflt`) classes for layouts that should apply to all viewport sizes (or sizes not
+ * covered by other assigned classes in dynamic layouts).
+ *
+ * See http://clever.github.io/components/#grid for examples.
+ *
+ * Grid your loins!
+ */
 
-  Creates classes for a 12-column layout with classes of the form:
-  `Column--lg-1`, `Column--lg-2`, ... `Column--lg-12`.
-
-  There are three sizes (large, medium, and small) so an
-  element can have different properties on different screens.
-
-  Grid your loins!
-
- *******************************************************/
-
-.gen-columns(@numCol, @size, @i: 1) when (@i =< @numCol) {
-  .Column--@{size}-@{i} {
-    .Column;
+.genColumns(@numCol, @size, @i: 1) when (@i =< @numCol) {
+  .Grid--Col--@{size}--@{i} {
+    .flexbox;
+    box-sizing: border-box;
     width: (@i * 100% / @numCol);
   }
-  .gen-columns(@numCol, @size, (@i + 1));
+  .genColumns(@numCol, @size, (@i + 1));
 }
 
-// Default - large grid
-.gen-columns(12, lg);
+/** Default - applies to all viewport sizes. */
+.genColumns(12, dflt);
 
-// Desktop - large grid
-@media only screen and (max-width: 1040px){
-  .gen-columns(12, lg);
-}
+/** Small viewports and larger only (e.g. phones, small tablets). */
+.breakpointS({ .genColumns(12, s) });
 
-// Tablet - medium grid
-@media only screen and (max-width: 840px){
-  .gen-columns(12, md);
-}
+/** Medium viewports and larger only (e.g. tablets). */
+.breakpointM({ .genColumns(12, m) });
 
-// Mobile - small grid
-@media only screen and (max-width: 640px){
-  .gen-columns(12, sm);
-}
-
-// Mobile - small grid
-@media only screen and (max-width: 440px){
-  .gen-columns(12, sm);
-}
+/** Large viewports only (e.g. large tablets, laptops). */
+.breakpointL({ .genColumns(12, l) });

--- a/src/less/index.less
+++ b/src/less/index.less
@@ -3,11 +3,12 @@
 
 // Color and font variables
 @import "./colors.less";
+@import "./flex.less";
 @import "./fonts.less";
+@import "./grid.less";
 @import "./sizing.less";
 @import "./spacing.less";
 @import "./type-size.less";
-@import "./grid.less";
 
 // Component Modules
 @import "../Button/Button";

--- a/src/less/layout.less
+++ b/src/less/layout.less
@@ -1,0 +1,44 @@
+/**
+ * Layout size and breakpoint definitions.
+ */
+
+
+@breakpointS: 40em;
+/**
+ * Only applies to small screens (e.g. phones, small tablets) and larger.
+ */
+.breakpointS(@rules) {
+  @media only screen and (min-width: @breakpointS) {
+    @rules();
+  }
+}
+
+@breakpointM: 52em;
+/**
+ * Only applies to medium-sized screens (e.g. tablets) and larger.
+ */
+.breakpointM(@rules) {
+  @media only screen and (min-width: @breakpointM) {
+    @rules();
+  }
+}
+
+@breakpointL: 64em;
+/**
+ * Only applies to larger screens (e.g. large tablets, laptops) and larger.
+ */
+.breakpointL(@rules) {
+  @media only screen and (min-width: @breakpointL) {
+    @rules();
+  }
+}
+
+@breakpointXL: 75em;
+/**
+ * Only applies to extra-large screens (e.g. high-resolution laptops, large monitors).
+ */
+.breakpointXL(@rules) {
+  @media only screen and (min-width: @breakpointXL) {
+    @rules();
+  }
+}

--- a/test/Grid/Col_test.jsx
+++ b/test/Grid/Col_test.jsx
@@ -1,0 +1,41 @@
+import assert from "assert";
+import React from "react";
+import {shallow} from "enzyme";
+
+import Col from "../../src/Grid/Col";
+import Size from "../../src/Grid/Size";
+
+
+describe("Col", () => {
+  it("sets all relevant screen-size-specific classes", () => {
+    const col = shallow(
+      <Col
+        span={{
+          [Size.DEFAULT]: 12,
+          [Size.S]: 6,
+          [Size.M]: 4,
+          [Size.L]: 3,
+        }}
+      />
+    );
+
+    [
+      "Grid--Col--dflt--12",
+      "Grid--Col--s--6",
+      "Grid--Col--m--4",
+      "Grid--Col--l--3",
+    ].forEach(className => {
+      assert(col.hasClass(className), `${className} class not found on Col.`);
+    });
+  });
+
+  it("applies custom classname", () => {
+    const col = shallow(<Col className="custom" />);
+    assert(col.hasClass("custom"), "Custom class name not applied.");
+  });
+
+  it("uses custom wrapper component", () => {
+    const col = shallow(<Col wrapperComponent="li" />);
+    assert.equal(col.type(), "li", "Incorrect wrapper component type.");
+  });
+});

--- a/test/Grid/Grid_test.jsx
+++ b/test/Grid/Grid_test.jsx
@@ -1,0 +1,35 @@
+import assert from "assert";
+import React from "react";
+import {shallow} from "enzyme";
+
+import Row from "../../src/Grid/Row";
+import {Grid} from "../../src/Grid/Grid";
+
+
+describe("Grid", () => {
+  it("applies grid classname", () => {
+    const grid = shallow(<Grid />);
+    assert(grid.hasClass("Grid"), "Grid class name not applied.");
+  });
+
+  it("applies custom classname", () => {
+    const grid = shallow(<Grid className="custom" />);
+    assert(grid.hasClass("custom"), "Custom class name not applied.");
+  });
+
+  it("uses custom wrapper component", () => {
+    const grid = shallow(<Grid wrapperComponent="ul" />);
+    assert.equal(grid.type(), "ul", "Incorrect wrapper component type.");
+  });
+
+  it("renders child Rows", () => {
+    const rows = [
+      <Row key="0" />,
+      <Row key="1" />,
+    ];
+
+    const grid = shallow(<Grid>{rows}</Grid>);
+
+    assert(grid.containsAllMatchingElements(rows), "child rows not rendered");
+  });
+});

--- a/test/Grid/Row_test.jsx
+++ b/test/Grid/Row_test.jsx
@@ -1,0 +1,43 @@
+import assert from "assert";
+import React from "react";
+import {shallow} from "enzyme";
+
+import Col from "../../src/Grid/Col";
+import Row from "../../src/Grid/Row";
+
+
+describe("Row", () => {
+  it("applies Row classname", () => {
+    const row = shallow(<Row />);
+    assert(row.hasClass("Grid--Row"), "Row class name not applied.");
+  });
+
+  it("applies custom classname", () => {
+    const row = shallow(<Row className="custom" />);
+    assert(row.hasClass("custom"), "Custom class name not applied.");
+  });
+
+  it("uses custom wrapper component", () => {
+    const row = shallow(<Row wrapperComponent="ul" />);
+    assert.equal(row.type(), "ul", "Incorrect wrapper component type.");
+  });
+
+  it("sets flex-grow factor if `grow` prop is specified", () => {
+    const row = shallow(<Row grow />);
+    assert(
+      row.hasClass("flex--grow"),
+      "`flex--grow` class not found on row."
+    );
+  });
+
+  it("renders child Cols", () => {
+    const cols = [
+      <Col key="0" />,
+      <Col key="1" />,
+    ];
+
+    const grid = shallow(<Row>{cols}</Row>);
+
+    assert(grid.containsAllMatchingElements(cols), "child columns not rendered");
+  });
+});


### PR DESCRIPTION
*[ Tested: Chrome, Firefox, Safari, IE10/11/Edge ]*

- Copy over flex mixins we've been using in the Apps and Schools
  dashboards and reconcile with existing flex definitions.
- Add a Grid component for React clients.
- Some additional cleanup done on grid styles.
  - Use new mixins and tweak grid settings to ensure IE10 support.
  - Change the Grid to a column-axis flex box with rows as items
    (instead of the previous row-axis box with wrapped rows) to better
    fit the idiom.
- Minor bump 0.10.0 -> 0.11.0

![grid-single](https://cloud.githubusercontent.com/assets/16216084/18849892/f1617992-83e9-11e6-8b8d-7135bd6bae42.gif)

![grid-multi](https://cloud.githubusercontent.com/assets/16216084/18849897/f554031c-83e9-11e6-9b39-a89764e4134b.gif)

![grid-nested](https://cloud.githubusercontent.com/assets/16216084/18849899/f80b1172-83e9-11e6-94b6-034e4e91e191.gif)

![grid-standalone-row](https://cloud.githubusercontent.com/assets/16216084/18849904/facfcdb2-83e9-11e6-867d-0c83a162f2b1.gif)
