### PR TITLE
[Select] Fix incorrect `value` propType and enable searching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ a fixed list of options.
 | onChange (optional) | Function | Called with new value when it changes | None
 | options (optional) | Array | Possible options. Must contain objects with label and value attributes | None
 | placeholder (optional) | String | Placeholder text | ""
+| searchable (optional) | Bool | Whether or not the values in the dropdown are searchable. | False
 | value (optional) | Object | Selected value. Must be updated by caller in the onChange | None
 
 **Usage Example**

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -32,6 +32,7 @@ class Demo extends React.Component {
       },
       selectValues: {
         basicSelect: null,
+        searchableSelect: "opt2",
         disabledBasicSelect: {label: "Selected Option", value: "selected_opt"},
         disabledMultiSelect: [{label: "1", value: "1"}, {label: "9", value: "9"}],
         multiSelect: [{label: "3", value: "3"}],
@@ -162,6 +163,22 @@ class Demo extends React.Component {
             ]}
             placeholder="Select one option"
             value={this.state.selectValues.basicSelect}
+          />
+          <br />
+          <Select
+            id="SearchableSelect"
+            label="Searchable Select"
+            clearable
+            name="SearchableSelect"
+            onChange={(val) => this.onSelectChange("searchableSelect", val)}
+            options={[
+              {label: "Option 1", value: "opt1"},
+              {label: "Option 2", value: "opt2"},
+              {label: "Option 3", value: "opt3"},
+            ]}
+            placeholder="Select or search"
+            searchable
+            value={this.state.selectValues.searchableSelect}
           />
           <br />
           <Select

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -23,7 +23,19 @@ function isLabelHidden(placeholder, value) {
   may be fetched asynchronously.
 */
 
-export function Select({id, name, clearable = false, disabled, label, multi, onChange, options, placeholder = "", value}) {
+export function Select({
+  id,
+  name,
+  clearable,
+  disabled,
+  label,
+  multi,
+  onChange,
+  options,
+  placeholder = "",
+  searchable,
+  value,
+}) {
   const {cssClass} = Select;
 
   let labelContainerClasses = cssClass.LABEL_CONTAINER;
@@ -45,7 +57,7 @@ export function Select({id, name, clearable = false, disabled, label, multi, onC
           onChange={onChange}
           options={options}
           placeholder={placeholder}
-          searchable={false}
+          searchable={searchable}
           value={value}
         />
       </div>
@@ -64,7 +76,7 @@ Select.cssClass = {
   REACT_SELECT: "Select--ReactSelect",
 };
 
-const selectValue = React.PropTypes.shape({
+const selectValuePropType = React.PropTypes.shape({
   label: React.PropTypes.string.isRequired,
   value: React.PropTypes.string.isRequired,
 });
@@ -77,10 +89,19 @@ Select.propTypes = {
   label: React.PropTypes.string,
   multi: React.PropTypes.bool,
   onChange: React.PropTypes.func,
-  options: React.PropTypes.arrayOf(selectValue),
+  options: React.PropTypes.arrayOf(selectValuePropType),
   placeholder: React.PropTypes.string,
+  searchable: React.PropTypes.bool,
   value: React.PropTypes.oneOfType([
-    selectValue,
-    React.PropTypes.arrayOf(selectValue),
+    React.PropTypes.string,
+    selectValuePropType,
+    React.PropTypes.arrayOf(React.PropTypes.string),
+    React.PropTypes.arrayOf(selectValuePropType),
   ]),
+};
+
+Select.defaultProps = {
+  clearable: false,
+  placeholder: "",
+  searchable: false,
 };

--- a/src/Select/Select.less
+++ b/src/Select/Select.less
@@ -61,12 +61,19 @@
       border-radius: 0px;
       border-color: @neutral_silver;
       height: 50px;
+
       .Select-placeholder {
         font-size: .75rem;
         line-height: 40px;
         padding-top: 5px;
         text-transform: uppercase;
       }
+
+      .Select-input {
+        position: absolute;
+      }
+
+      .Select-input,
       .Select-value {
         font-size: 1rem;
         line-height: 40px;

--- a/test/Select_test.jsx
+++ b/test/Select_test.jsx
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import assert from "assert";
 import {shallow} from "enzyme";
 import React from "react";
@@ -134,10 +135,11 @@ describe("Select", () => {
       searchable: false,
       value: testOptions[2],
     };
-    const reactSelectProps = select.find(ReactSelect).props();
-    for (const prop of Object.keys(expectedPropValues)) {
-      assert.equal(reactSelectProps[prop], expectedPropValues[prop]);
-    }
+    const reactSelectProps = _.pick(
+      select.find(ReactSelect).props(),
+      Object.keys(expectedPropValues)
+    );
+    assert.deepEqual(reactSelectProps, expectedPropValues);
   });
 
   it("allows selecting multiple options if specified", () => {
@@ -182,6 +184,18 @@ describe("Select", () => {
     );
     const reactSelect = select.find(ReactSelect);
     assert(reactSelect.prop("clearable"));
+  });
+
+  it("sets searchable on the react select element if specified", () => {
+    const select = shallow(
+      <Select
+        id="testid"
+        name="testname"
+        searchable
+      />
+    );
+    const reactSelect = select.find(ReactSelect);
+    assert(reactSelect.prop("searchable"));
   });
 
   it("defaults to an empty string placeholder ReactSelect", () => {


### PR DESCRIPTION
* Enabling a pass-through of the `searchable` prop for use with large option lists.
Some style tweaking was needed to position the search input properly.
This component needs to be reworked a bit - the styling looks very brittle.

* `react-select` supports specifying actual values in the `value` prop instead of option objects, which is a lot more convenient in some cases. Expanding the clever `Select` proptypes to support that use case as well.

* Bump 0.11.0 -> 0.12.0

![searchable-select](https://cloud.githubusercontent.com/assets/16216084/18926721/cdeedd08-856d-11e6-950e-e905fb856109.gif)
