### PR TITLE
[TextInput] Add focus() API; support disabling browser autocomplete.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,17 +182,18 @@ This component is a `text input`.
 
 | Prop             | Type     | Description                           | Default
 |------------------|----------|---------------------------------------|---------
-| name (required) | String | Name for input element | None
-| label (optional) | String | Label for modal | None
-| value (optional) | Node | Value of input | None
-| placeholder (optional) | Node | Placeholder node for input | None
-| type (optional) | String   | The type of control to display, tested 'number' and 'text' | 'text'
-| error (optional) | String | Adds indicator and error text to element. | None
-| onChange (optional) | Function | Called when value of input changes. | None
-| required (optional) | Bool   | Marks input as required and adds indicator. | false
 | disabled (optional) | Bool   | Sets element as disabled. | false
-| readOnly (optional) | Bool   | Sets element as read only. | false
+| disableAutocomplete (optional) | Bool   | Sets `autocomplete="off"` on the input element to disable the default browser autocomplete functionality. | false
 | enableShow (optional) | Bool  | Displays a show/hide link that reveals passwords | false
+| error (optional) | String | Adds indicator and error text to element. | None
+| label (optional) | String | Label for modal | None
+| name (required) | String | Name for input element | None
+| onChange (optional) | Function | Called when value of input changes. | None
+| placeholder (optional) | Node | Placeholder node for input | None
+| readOnly (optional) | Bool   | Sets element as read only. | false
+| required (optional) | Bool   | Marks input as required and adds indicator. | false
+| type (optional) | String   | The type of control to display, tested 'number' and 'text' | 'text'
+| value (optional) | Node | Value of input | None
 
 **Usage Example**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -19,6 +19,10 @@ export class TextInput extends React.Component {
     this.setState({inFocus: false});
   }
 
+  focus() {
+    this.refs.input.focus();
+  }
+
   toggleHidden() {
     this.setState({hidden: !this.state.hidden});
   }
@@ -61,17 +65,19 @@ export class TextInput extends React.Component {
           {inputNote}
         </div>
         <input
+          autoComplete={this.props.disableAutocomplete && "off"}
           className="TextInput--input"
-          type={type}
+          disabled={this.props.disabled}
           name={this.props.name}
-          placeholder={this.props.placeholder}
-          value={this.props.value}
-          onFocus={this.onFocus}
           onBlur={this.onBlur}
           onChange={this.props.onChange}
+          onFocus={this.onFocus}
+          placeholder={this.props.placeholder}
           readOnly={this.props.readOnly}
-          disabled={this.props.disabled}
+          ref="input"
           required={this.props.required}
+          type={type}
+          value={this.props.value}
         />
         {this.props.enableShow &&
           <button type="button" className="TextInput--link" onClick={this.toggleHidden}>
@@ -84,15 +90,16 @@ export class TextInput extends React.Component {
 }
 
 TextInput.propTypes = {
-  name: React.PropTypes.string.isRequired,
-  label: React.PropTypes.string,
-  value: React.PropTypes.node,
-  placeholder: React.PropTypes.node,
-  type: React.PropTypes.string,
-  onChange: React.PropTypes.func,
-  error: React.PropTypes.string,
-  required: React.PropTypes.bool,
   disabled: React.PropTypes.bool,
-  readOnly: React.PropTypes.bool,
+  disableAutocomplete: React.PropTypes.bool,
   enableShow: React.PropTypes.bool,
+  error: React.PropTypes.string,
+  label: React.PropTypes.string,
+  name: React.PropTypes.string.isRequired,
+  onChange: React.PropTypes.func,
+  placeholder: React.PropTypes.node,
+  readOnly: React.PropTypes.bool,
+  required: React.PropTypes.bool,
+  type: React.PropTypes.string,
+  value: React.PropTypes.node,
 };


### PR DESCRIPTION
* Add `TextInput.focus()` so clients can set default focus on render when necessary.
* Add support for disabling autocomplete. Because this isn't cute:
![autocomplete-bad](https://cloud.githubusercontent.com/assets/16216084/18936494/a14beaa0-859c-11e6-9901-7a8bde56ad97.gif)

We can eventually fix the styling a bit to avoid that, but autocomplete isn't always desirable anyway.
