### PR TITLE
Type utility tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/less/type-utilities.less
+++ b/src/less/type-utilities.less
@@ -33,7 +33,6 @@
 
 .text--caps    {
   text-transform: uppercase;
-  letter-spacing: .2em;
 }
 
 .text--left { text-align: left }

--- a/src/less/type-utilities.less
+++ b/src/less/type-utilities.less
@@ -7,7 +7,7 @@
 .text--decoration-none { text-decoration: none }
 
 .text--semi-bold    {
-   font-weight: 400;
+   font-weight: 600;
    font-style: normal;
 }
 


### PR DESCRIPTION
- Corrects semi-bold `font-weight` to 600, instead of 400 (which is equivalent to `normal`)
- Removes letter spacing for all caps. `0.2em` was too much - the letters flew apart. I couldn't find a value I liked, so I just pulled it out for now. We can always readd it later once we have time to work through some examples. Currently, the all caps text in the product doesn't have modified letter spacing.