### PR TITLE
Add FlexBox and FlexItem wrappers for abstracting away flex classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ However `FlexBox` can be used without `FlexItem` in many cases.
 | alignSelf (optional) | ItemAlign | Sets the cross-axis alignment of this flex item only. | ItemAlign.STRETCH
 | children (optional) | React Node | The child items to render in the flex box. | None
 | className (optional) | String | Additional classname to apply to the flex box. | None
-| component (optional) | Any | The tagname or component class for the wrapper component to render for the flex item | "div"
+| component (optional) | Any | Tagname of class for the wrapper component. `FlexItem` renders as a `<div>` by default. It can be made to render as a different component by specifying the component tagname or class. e.g. `<FlexItem component="li" />` or `<FlexItem component={Button} />` | "div"
 | grow (optional) | Boolean | Fluidly grows the item to fill any available space along the main axis. | False
 
 #### `<FlexBox />` Options

--- a/README.md
+++ b/README.md
@@ -421,3 +421,46 @@ viewport. Any additional `Grid.Col`s will wrap onto the following line.
 **Usage Examples**
 
 [Sample Code](https://github.com/Clever/components/tree/master/docs/GridExample.jsx) ([Live Demo](http://clever.github.io/components/#grid))
+
+### FlexBox and FlexItem
+
+`FlexBox` provides a flex-enabled container as a convenience wrapper around the clever-components flex CSS classes.
+A `FlexBox` may contain any other renderable elements, including other `FlexBox` components or `FlexItem`s.
+
+`FlexItem` similarly provides a convenience wrapper around flex item-specific CSS classes and may in turn contain any combination of React-supported elements.
+
+**NOTE:** Using a `FlexItem` properties have no effect on an element unless it is rendered within a `FlexBox` or other `display: flex` container.
+However `FlexBox` can be used without `FlexItem` in many cases.
+
+#### `<FlexItem />` Options
+
+([Source code](https://github.com/Clever/components/tree/master/src/flex/FlexItem.jsx))
+
+| Prop             | Type     | Description                           | Default
+|------------------|----------|---------------------------------------|---------
+| alignSelf (optional) | ItemAlign | Sets the cross-axis alignment of this flex item only. | ItemAlign.STRETCH
+| children (optional) | React Node | The child items to render in the flex box. | None
+| className (optional) | String | Additional classname to apply to the flex box. | None
+| component (optional) | Any | The tagname or component class for the wrapper component to render for the flex item | "div"
+| grow (optional) | Boolean | Fluidly grows the item to fill any available space along the main axis. | False
+
+#### `<FlexBox />` Options
+
+([Source code](https://github.com/Clever/components/tree/master/src/flex/FlexBox.jsx))
+
+`FlexBox`es can be nested within one another, hence `FlexBox` supports all the above `FlexItem` props in addition to the following `FlexBox`-specific props:
+
+| Prop             | Type     | Description                           | Default
+|------------------|----------|---------------------------------------|---------
+| alignContent (optional) | ContentAlign | Sets the cross-axis alignment of multi-line content. | ContentAlign.STRETCH
+| alignItems (optional) | ItemAlign | Sets the cross-axis alignment of single-line content. | ItemAlign.STRETCH
+| children (optional) | React Node | The child items to render in the flex box. | None
+| className (optional) | String | Additional classname to apply to the flex box. | None
+| column (optional) | Boolean | Switches the flex box to a column-direction main axis. Child items will flow vertically. | False
+| inline (optional) | Boolean | Enables the inline-flex display mode for the flex box. The flex box container will fit the width of its content and share the line with any other inline elements. Similar to display: inline-block. | False
+| justify (optional) | Justify | Sets the main-axis alignment of the flex box content. | ContentAlign.START
+| wrap (optional) | Boolean | Causes child items to wrap if they are unable to fit on a single line. By default, flex items will shrink up to their minimum widths without wrapping, eventually causing them to overflow their container. `wrap` allows items to wrap to the multiple lines if necessary. | False
+
+#### Usage Examples
+
+[Sample Code](https://github.com/Clever/components/tree/master/docs/FlexExample.jsx) ([Live Demo](http://clever.github.io/components/#flex))

--- a/docs/FlexExample.jsx
+++ b/docs/FlexExample.jsx
@@ -1,0 +1,130 @@
+import classnames from "classnames";
+import React from "react";
+
+import {Button} from "../src/Button/Button";
+import {FlexBox, FlexItem, ItemAlign, Justify} from "../src/flex";
+
+import "./FlexExample.less";
+import "../src/less/spacing.less";
+
+
+export default function FlexExample() {
+  const {cssClass} = FlexExample;
+
+  return (
+    <div className={cssClass.CONTAINER}>
+      <a name="flexbox">
+        <h1>FlexBox</h1>
+      </a>
+
+      <h2>Simple</h2>
+      <p>A FlexBox may contain regular HTML elements.</p>
+      <FlexBox className={classnames(cssClass.BOX, cssClass.BOX_MIN_WIDTH)}>
+        <div className={cssClass.ITEM}>
+          <span className={classnames(cssClass.fa("exclamation-triangle"), cssClass.ALERT)} />
+        </div>
+        <div className={cssClass.ITEM}>
+          You have received a notification!
+        </div>
+        <Button className={cssClass.ITEM} type="linkPlain" value="Got it" />
+      </FlexBox>
+
+      <h2>With grow-enabled item</h2>
+      <p>FlexItem children with <code>grow={"{true}"}</code> will fill any available space.</p>
+      <FlexBox className={classnames(cssClass.BOX, cssClass.BOX_MIN_WIDTH)}>
+        <div className={cssClass.ITEM}>
+          <span className={classnames(cssClass.fa("exclamation-triangle"), cssClass.ALERT)} />
+        </div>
+        <FlexItem className={cssClass.ITEM} grow>
+          You have received a notification!
+        </FlexItem>
+        <Button className={cssClass.ITEM} type="linkPlain" value="Got it" />
+      </FlexBox>
+
+      <h2>FlexBox as FlexItem</h2>
+      <p>
+        FlexBoxes can be nested as any other eleemnts.
+        FlexItem properties, such as <code>grow</code> can also be applied for FlexItem behavior.
+      </p>
+      <FlexBox className={classnames(cssClass.BOX, cssClass.BOX_MIN_WIDTH)}>
+        <FlexBox className={cssClass.ITEM} alignItems={ItemAlign.CENTER}>
+          <span className={cssClass.fa("trophy")} />
+        </FlexBox>
+        <FlexBox className={cssClass.ITEM} grow>
+          <FlexItem className={cssClass.ITEM} grow>
+            <h3>100m</h3>
+            <p>World record: 9.58s</p>
+            <p>Record holder: Usain Bolt</p>
+            <p>Last updated: Aug 16, 2009</p>
+          </FlexItem>
+          <FlexItem className={cssClass.ITEM} grow>
+            <h3>200m</h3>
+            <p>World record: 19.19s</p>
+            <p>Record holder: Usain Bolt</p>
+            <p>Last updated: Aug 20, 2009</p>
+          </FlexItem>
+        </FlexBox>
+        <Button className={cssClass.ITEM} type="linkPlain" value="Close" />
+      </FlexBox>
+
+      <h2>With wrapped FlexItems</h2>
+      <p>
+        Setting <code>wrap={"{true}"}</code> causes FlexBox children to wrap to the next line when
+        there isn't enough space on one line.
+      </p>
+      <p>
+        FlexBox and FlexItem are divs by default but can be rendered as any element or component.
+        Here, the FlexBox is rendered as a <code>{"<ul>"}</code> and the FlexItems
+        as <code>{"<li>"}</code>s.
+      </p>
+      <FlexBox
+        className={classnames(cssClass.BOX, cssClass.BOX_TINY, cssClass.RESIZABLE_X)}
+        component="ul"
+        wrap
+      >
+        {["ambulance", "car", "taxi", "bus", "train", "truck", "subway"].map((faIcon, i) => (
+          <FlexBox className={cssClass.ITEM} component="li" grow justify={Justify.CENTER} key={i}>
+            <span className={cssClass.fa(faIcon)} />
+          </FlexBox>
+        ))}
+      </FlexBox>
+
+      <h2>Column-direction FlexBox</h2>
+      <p>
+        Setting <code>column={"{true}"}</code> causes FlexBox children to be arranged vertically.
+        FlexItem properties such as <code>grow</code> now act along the vertical axis.
+      </p>
+      <FlexBox
+        className={classnames(cssClass.BOX, cssClass.RESIZABLE_Y)}
+        column
+        component="ul"
+        alignItems={ItemAlign.START}
+      >
+        {["ambulance", "car", "taxi", "bus", "train"].map((faIcon, i) => (
+          <FlexBox
+            className={cssClass.ITEM}
+            component="li"
+            grow
+            alignItems={ItemAlign.CENTER}
+            key={i}
+          >
+            <span className={cssClass.fa(faIcon)} />
+          </FlexBox>
+        ))}
+      </FlexBox>
+    </div>
+  );
+}
+
+FlexExample.cssClass = {
+  ALERT: "color--alert--orange",
+  BOX: "FlexExample--box",
+  BOX_MIN_WIDTH: "FlexExample--box--minWidth",
+  BOX_TINY: "FlexExample--box--tiny",
+  CONTAINER: "FlexExample",
+  ITEM: "FlexExample--item",
+  RESIZABLE_X: "FlexExample--box--resizable--x",
+  RESIZABLE_Y: "FlexExample--box--resizable--y",
+
+  fa: fontAwesomeClass => `fa fa-fw fa-${fontAwesomeClass}`,
+};

--- a/docs/FlexExample.less
+++ b/docs/FlexExample.less
@@ -1,0 +1,46 @@
+@import (reference) "../src/less/index";
+
+
+.FlexExample {
+  .margin--top--2xl;
+
+  h2 {
+    .margin--top--l;
+  }
+
+  .FlexExample--box {
+    .margin--x--3xl;
+  }
+
+  .FlexExample--box,
+  .FlexExample--item {
+    .padding--m;
+    background-color: fadeout(@neutral_gray, 90%);
+    border: 1px solid shade(@neutral_silver, 10%);
+    border-radius: 0;
+    box-sizing: border-box;
+    font-size: 0.875rem;
+  }
+}
+
+.FlexExample--box--minWidth {
+  min-width: 400px;
+}
+
+.FlexExample--box--tiny {
+  width: 90px;
+}
+
+.FlexExample--box--resizable--x {
+  resize: horizontal;;
+  overflow: hidden;
+}
+
+.FlexExample--box--resizable--y {
+  resize: vertical;
+  overflow: hidden;
+}
+
+.color--alert--orange {
+  color: @alert_orange;
+}

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -2,6 +2,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 
+import FlexExample from "./FlexExample";
 import GridExample from "./GridExample";
 import TableExample from "./TableExample";
 import {
@@ -327,6 +328,7 @@ class Demo extends React.Component {
           }]}
         />
         <TableExample />
+        <FlexExample />
         <GridExample />
         {/* Enable scrolling past the bottom for convenience. */}
         <div style={{margin: "0 0 600px"}} />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "A library of helpful React components",
   "repository": {
     "type": "git",

--- a/src/flex/ContentAlign.js
+++ b/src/flex/ContentAlign.js
@@ -1,0 +1,10 @@
+const ContentAlign = {
+  AROUND: "around",
+  BETWEEN: "between",
+  CENTER: "center",
+  END: "end",
+  START: "start",
+  STRETCH: "stretch",
+};
+
+export default ContentAlign;

--- a/src/flex/FlexBox.jsx
+++ b/src/flex/FlexBox.jsx
@@ -1,0 +1,69 @@
+import _ from "lodash";
+import classnames from "classnames";
+import React, {PropTypes} from "react";
+
+import ContentAlign from "./ContentAlign";
+import FlexItem from "./FlexItem";
+import ItemAlign from "./ItemAlign";
+import Justify from "./Justify";
+
+import "../less/flex.less";
+
+
+export default function FlexBox({
+  alignContent,
+  alignItems,
+  children,
+  className,
+  column,
+  inline,
+  justify,
+  wrap,
+  ...additionalProps,
+}) {
+  const {cssClass} = FlexBox;
+
+  return (
+    <FlexItem
+      className={classnames(
+        inline ? cssClass.FLEXBOX_INLINE : cssClass.FLEXBOX,
+        column && cssClass.COLUMN,
+        alignContent && cssClass.alignContent(alignContent),
+        alignItems && cssClass.alignItems(alignItems),
+        justify && cssClass.justify(justify),
+        wrap && cssClass.WRAP,
+        className
+      )}
+      {...additionalProps}
+    >
+      {children}
+    </FlexItem>
+  );
+}
+
+FlexBox.propTypes = {
+  ...FlexItem.propTypes,
+  alignContent: PropTypes.oneOf(_.values(ContentAlign)),
+  alignItems: PropTypes.oneOf(_.values(ItemAlign)),
+  children: PropTypes.node,
+  className: PropTypes.string,
+  column: PropTypes.bool,
+  inline: PropTypes.bool,
+  justify: PropTypes.oneOf(_.values(Justify)),
+  wrap: PropTypes.bool,
+};
+
+FlexBox.defaultProps = {
+  component: "div",
+};
+
+FlexBox.cssClass = {
+  FLEXBOX: "flexbox",
+  COLUMN: "flex--direction--column",
+  FLEXBOX_INLINE: "flexbox--inline",
+  WRAP: "flex--wrap",
+
+  alignContent: value => `content--${value}`,
+  alignItems: value => `items--${value}`,
+  justify: value => `justify--${value}`,
+};

--- a/src/flex/FlexItem.jsx
+++ b/src/flex/FlexItem.jsx
@@ -1,0 +1,50 @@
+import _ from "lodash";
+import classnames from "classnames";
+import React, {PropTypes} from "react";
+
+import ItemAlign from "./ItemAlign";
+
+import "../less/flex.less";
+
+
+export default function FlexItem({
+  alignSelf,
+  children,
+  className,
+  component: Wrapper,
+  grow,
+  ...additionalProps,
+}) {
+  const {cssClass} = FlexItem;
+
+  return (
+    <Wrapper
+      className={classnames(
+        alignSelf && cssClass.alignSelf(alignSelf),
+        grow && cssClass.GROW,
+        className
+      )}
+      {...additionalProps}
+    >
+      {children}
+    </Wrapper>
+  );
+}
+
+FlexItem.propTypes = {
+  alignSelf: PropTypes.oneOf(_.values(ItemAlign)),
+  children: PropTypes.node,
+  className: PropTypes.string,
+  component: PropTypes.any,
+  grow: PropTypes.bool,
+};
+
+FlexItem.defaultProps = {
+  component: "div",
+};
+
+FlexItem.cssClass = {
+  GROW: "flex--grow",
+
+  alignSelf: value => `self--${value}`,
+};

--- a/src/flex/ItemAlign.js
+++ b/src/flex/ItemAlign.js
@@ -1,0 +1,9 @@
+const ItemAlign = {
+  BASELINE: "baseline",
+  CENTER: "center",
+  END: "end",
+  START: "start",
+  STRETCH: "stretch",
+};
+
+export default ItemAlign;

--- a/src/flex/Justify.js
+++ b/src/flex/Justify.js
@@ -1,0 +1,9 @@
+const Justify = {
+  AROUND: "around",
+  BETWEEN: "between",
+  CENTER: "center",
+  END: "end",
+  START: "start",
+};
+
+export default Justify;

--- a/src/flex/index.js
+++ b/src/flex/index.js
@@ -1,0 +1,7 @@
+import ContentAlign from "./ContentAlign";
+import FlexBox from "./FlexBox";
+import FlexItem from "./FlexItem";
+import ItemAlign from "./ItemAlign";
+import Justify from "./Justify";
+
+export {ContentAlign, FlexBox, FlexItem, ItemAlign, Justify};

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+export * from "./flex";
 export {Modal} from "./Modal/Modal";
 export {Button} from "./Button/Button";
 export {ModalButton} from "./ModalButton/ModalButton";

--- a/test/flex/FlexBox_test.jsx
+++ b/test/flex/FlexBox_test.jsx
@@ -1,0 +1,69 @@
+import assert from "assert";
+import React from "react";
+import {shallow} from "enzyme";
+
+import ContentAlign from "../../src/flex/ContentAlign";
+import Justify from "../../src/flex/Justify";
+import FlexBox from "../../src/flex/FlexBox";
+import FlexItem from "../../src/flex/FlexItem";
+import ItemAlign from "../../src/flex/ItemAlign";
+
+
+describe("FlexBox", () => {
+  it("applies flexbox classname", () => {
+    const flexBox = shallow(<FlexBox />);
+    assert(flexBox.hasClass("flexbox"), "flexbox class should be applied.");
+  });
+
+  it("applies flexbox--inline classname if 'inline' prop is specified", () => {
+    const flexBox = shallow(<FlexBox inline />);
+    assert(!flexBox.hasClass("flexbox"), "flexbox class name should not be applied.");
+    assert(flexBox.hasClass("flexbox--inline"), "flexbox class name should be applied.");
+  });
+
+  it("applies custom classname", () => {
+    const flexBox = shallow(<FlexBox className="custom" />);
+    assert(flexBox.hasClass("custom"), "Custom class name not applied.");
+  });
+
+  it("applies flex--direction--column classname if applicable", () => {
+    const flexBox = shallow(<FlexBox column />);
+    assert(
+      flexBox.hasClass("flex--direction--column"),
+      "flex--direction--column class name should be applied."
+    );
+  });
+
+  it("applies content alignment classnames", () => {
+    const flexBox = shallow(<FlexBox alignContent={ContentAlign.END} />);
+    assert(flexBox.hasClass("content--end"), "content--end class name should be applied.");
+  });
+
+  it("applies item alignment classnames", () => {
+    const flexBox = shallow(<FlexBox alignItems={ItemAlign.START} />);
+    assert(flexBox.hasClass("items--start"), "items--start class name should be applied.");
+  });
+
+  it("applies content justify classnames", () => {
+    const flexBox = shallow(<FlexBox justify={Justify.CENTER} />);
+    assert(flexBox.hasClass("justify--center"), "justify--center class name should be applied.");
+  });
+
+  it("passes through additional props to FlexItem", () => {
+    const flexBox = shallow(<FlexBox component="ul" />);
+
+    assert.equal(flexBox.type(), FlexItem);
+    assert.equal(flexBox.props().component, "ul");
+  });
+
+  it("renders child items", () => {
+    const items = [
+      <div key="0" />,
+      <span key="1" />,
+    ];
+
+    const flexBox = shallow(<FlexBox>{items}</FlexBox>);
+
+    assert(flexBox.containsAllMatchingElements(items), "child items not rendered");
+  });
+});

--- a/test/flex/FlexItem_test.jsx
+++ b/test/flex/FlexItem_test.jsx
@@ -1,0 +1,40 @@
+import assert from "assert";
+import React from "react";
+import {shallow} from "enzyme";
+
+import FlexItem from "../../src/flex/FlexItem";
+import ItemAlign from "../../src/flex/ItemAlign";
+
+
+describe("FlexBox", () => {
+  it("applies custom classname", () => {
+    const flexItem = shallow(<FlexItem className="custom" />);
+    assert(flexItem.hasClass("custom"), "Custom class name should be applied.");
+  });
+
+  it("applies flex--grow classname", () => {
+    const flexItem = shallow(<FlexItem grow />);
+    assert(flexItem.hasClass("flex--grow"), "flex--grow class name should be applied.");
+  });
+
+  it("applies self-alignment classname", () => {
+    const flexItem = shallow(<FlexItem alignSelf={ItemAlign.END} />);
+    assert(flexItem.hasClass("self--end"), "self--end class name should be applied.");
+  });
+
+  it("uses custom wrapper component", () => {
+    const flexItem = shallow(<FlexItem component="ul" />);
+    assert.equal(flexItem.type(), "ul", "Incorrect wrapper component type.");
+  });
+
+  it("renders child items", () => {
+    const items = [
+      <div key="0" />,
+      <span key="1" />,
+    ];
+
+    const flexItem = shallow(<FlexItem>{items}</FlexItem>);
+
+    assert(flexItem.containsAllMatchingElements(items), "child items not rendered");
+  });
+});


### PR DESCRIPTION
After using the flex classes for a bit in a few places, realised it'll be useful to have a component wrapper for them, to complement what we have with the `Grid`.

Abstracts the details of class names away into strict props and cuts down on duplicated CSS for components that reference the flex classes while hopefully making layout clearer from reading the jsx code.

First usage coming up in https://github.com/Clever/components/pull/68

![flexbox-simple](https://cloud.githubusercontent.com/assets/16216084/19736449/1f15e080-9b64-11e6-9e5b-60da08de24d0.gif)

![flexbox-nested](https://cloud.githubusercontent.com/assets/16216084/19736453/2343b07e-9b64-11e6-8ba7-12b5e0e2277d.gif)

![flexbox-wrap](https://cloud.githubusercontent.com/assets/16216084/19736456/27e409f8-9b64-11e6-887f-7c1ad9e963e6.gif)

![flexbox-column](https://cloud.githubusercontent.com/assets/16216084/19736460/2aeec41c-9b64-11e6-920a-5362b32882eb.gif)
