### PR TITLE
Prop warning fixes

### DIFF
--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -242,6 +242,18 @@ class Demo extends React.Component {
         <Button type="secondary" size="regular" href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />
         <Button type="destructive" size="regular" href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />
         <Button disabled size="regular" href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />
+        <h2>Button with HTML content</h2>
+        <Button type="primary" value={<span className="fa fa-search" />} />
+        <Button type="destructive" value={<div><span className="fa fa-trash" /> Remove</div>} />
+        <Button
+          disabled
+          value={<div><span className="fa fa-spin fa-spinner" /> Saving...</div>}
+        />
+        <Button
+          href="//wikipedia.org"
+          type="link"
+          value={<span><span className="fa fa-external-link" /> Learn more</span>}
+        />
         <h1>Modal</h1>
         <Button size="large" type="primary" onClick={this.openModal} value="Open Modal" />
         {modalElement}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -1,3 +1,4 @@
+import classnames from "classnames";
 import React from "react";
 
 require("./Button.less");
@@ -11,10 +12,11 @@ export function Button(props) {
     throw new Error("Buttons with href do not support the submit option");
   }
 
-  let classes = `Button Button--${props.type} Button--${props.size}`;
-  if (props.className) {
-    classes += ` ${props.className}`;
-  }
+  const classes = classnames(
+    `Button Button--${props.type}`,
+    `Button--${props.size}`,
+    props.className
+  );
   const type = props.submit ? "submit" : "button";
 
   if (props.href == null || props.disabled) {
@@ -42,7 +44,7 @@ Button.propTypes = {
   className: React.PropTypes.string,
   type: React.PropTypes.oneOf(["primary", "secondary", "destructive", "link", "linkPlain"]),
   size: React.PropTypes.oneOf(["large", "regular", "small"]),
-  value: React.PropTypes.string.isRequired,
+  value: React.PropTypes.node.isRequired,
   href: React.PropTypes.string,
   target: React.PropTypes.oneOf(["_self", "_blank"]),
   disabled: React.PropTypes.bool,

--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -98,7 +98,7 @@ export class Table extends Component {
     const disableSort = displayedData.length <= 1;
 
     let pages = [displayedData];
-    if (paginated) {
+    if (paginated && displayedData.length > 0) {
       pages = lodash.chunk(displayedData, pageSize);
     }
     const numPages = pages.length;

--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -98,9 +98,16 @@ export class Table extends Component {
     const disableSort = displayedData.length <= 1;
 
     let pages = [displayedData];
-    if (paginated && displayedData.length > 0) {
+    if (paginated) {
       pages = lodash.chunk(displayedData, pageSize);
     }
+
+    if (pages.length === 0) {
+      // Chunking will return 0 pages if the data array is empty. Since we always show at least one
+      // page of (potentially empty) data, add an empty page by default.
+      pages = [[]];
+    }
+
     const numPages = pages.length;
     const displayedPage = Math.min(currentPage, numPages);
     const displayedPageIndex = displayedPage - 1;


### PR DESCRIPTION
**[Button] Support HTML content in Buttons.**
We've been using <Button> with HTML labels for a while now. Updating
prop validation to officially support it and clear up the prop warnings
we've been seeing.

![html-buttons](https://cloud.githubusercontent.com/assets/16216084/19788684/9ee1ab32-9c5e-11e6-86a0-d2c7a354294e.gif)

**[Table] Fix Footer prop warning when rendering tables with empty data.**
Skip data chunking if the data array is empty to avoid ending up with
an invalid value in the page number calculation.