### PR TITLE
Make Grid.Col a flex item, not a flex box

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To learn which styles are available, read through the [less code](https://github
 
 ### Publishing
 
-First, increment the version in `package.json` according to [semver](http://semver.org/).
+First, increment the version in `package.json` according to [semver](http://semver.org/). You can use the `npm version` command (e.g. `npm version major`).
 
 Then, when you merge your branch into `master`, Drone will automatically build and publish a new version to npm.
 

--- a/docs/GridExample.jsx
+++ b/docs/GridExample.jsx
@@ -93,17 +93,17 @@ export default function GridExample() {
       <h2>Nested Grids</h2>
       <Grid className="items--center outlined resizable" style={{height: "400px", minWidth: "550px"}}>
         <Row className="shaded outlined" style={{marginBottom: "1rem"}}>
-          <Col span={12} className="justify--center">
+          <Col span={12} className="flexbox justify--center">
             <Grid style={{padding: 0, maxWidth: "700px"}}>
               <Row>{renderCol(2)}{renderCol(7)}{renderCol(3)}</Row>
             </Grid>
           </Col>
         </Row>
         <Row className="shaded outlined" grow>
-          <Col span={12} className="justify--center self--stretch">
+          <Col span={12} className="flexbox justify--center self--stretch">
             <Grid style={{padding: 0, maxWidth: "700px"}} className="self--stretch">
               <Row>{renderCol(3)}{renderCol(9)}</Row>
-              <Row grow>{renderCol(3)}{renderCol(9)}</Row>
+              <Row grow>{renderCol(3, "flexbox")}{renderCol(9, "flexbox")}</Row>
               <Row>{renderCol(12)}</Row>
             </Grid>
           </Col>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/less/flex.less
+++ b/src/less/flex.less
@@ -105,11 +105,11 @@
  * @initial {1}
  */
 .flexShrink(@value: 1) {
- -moz-box-flex-grow: @value;
+ -moz-box-flex-shrink: @value;
  -ms-flex-negative: @value;
- -webkit-box-flex-grow: @value;
- -webkit-flex-grow: @value;
- flex-grow: @value;
+ -webkit-box-flex-shrink: @value;
+ -webkit-flex-shrink: @value;
+ flex-shrink: @value;
 }
 
 /**
@@ -119,11 +119,11 @@
  * @initial {auto}
  */
 .flexBasis(@value: 1) {
- -moz-box-flex-grow: @value;
- -ms-flex-negative: @value;
- -webkit-box-flex-grow: @value;
- -webkit-flex-grow: @value;
- flex-grow: @value;
+ -moz-box-flex-basis: @value;
+ -ms-flex-preferred-size: @value;
+ -webkit-box-flex-basis: @value;
+ -webkit-flex-basis: @value;
+ flex-basis: @value;
 }
 
 /**

--- a/src/less/grid.less
+++ b/src/less/grid.less
@@ -36,7 +36,6 @@
 
 .genColumns(@numCol, @size, @i: 1) when (@i =< @numCol) {
   .Grid--Col--@{size}--@{i} {
-    .flexbox;
     box-sizing: border-box;
     width: (@i * 100% / @numCol);
   }


### PR DESCRIPTION
Grid.Col should have normal flow for the children within it, so it should have display:
block, not flex. When desired, the `flexbox` class can be added to turn
a Col into a flexbox.

Also fixes some small bugs within flex.less.

Tested by visually comparing the grid examples.