### PR TITLE
Autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "devDependencies": {
+    "autoprefixer": "^6.5.3",
     "babel-cli": "~6.0.0",
     "babel-core": "~6.7.4",
     "babel-eslint": "^6.0.2",
@@ -35,6 +36,7 @@
     "jsdom-global": "^1.7.0",
     "lorem-ipsum": "^1.0.3",
     "mocha": "^2.4.5",
+    "postcss-loader": "^1.1.1",
     "react": "~15.3.0",
     "react-addons-test-utils": "~15.3.0",
     "react-dom": "~15.3.0",

--- a/src/Modal/Modal.less
+++ b/src/Modal/Modal.less
@@ -20,7 +20,6 @@
   top: 50%;
   left: 50%;
   transform: translateY(-50%);
-  -webkit-transform: translateY(-50%);
   position: fixed;
   border-radius: 3px;
   font-family: "Proxima Nova";

--- a/src/less/flex.less
+++ b/src/less/flex.less
@@ -9,9 +9,6 @@
  * @target Flex container.
  */
 .flexbox() {
-  display: -moz-box;
-  display: -ms-flexbox;
-  display: -webkit-flex;
   display: flex;
 }
 
@@ -20,9 +17,6 @@
  * @target Flex container.
  */
 .inlineFlexbox() {
-  display: -moz-box;
-  display: -ms-inline-flexbox;
-  display: -webkit-inline-flex;
   display: inline-flex;
 }
 
@@ -33,8 +27,6 @@
  * @initial {nowrap}
  */
 .flexWrap(@wrap: wrap) {
-  -ms-flex-wrap: @wrap;
-  -webkit-flex-wrap: @wrap;
   flex-wrap: @wrap;
 }
 
@@ -45,8 +37,6 @@
  * @initial {row}
  */
 .flexDirection(@direction) {
-  -ms-flex-direction: @direction;
-  -webkit-flex-direction: @direction;
   flex-direction: @direction;
 }
 
@@ -61,10 +51,6 @@
  * @initial {0 1 auto}
  */
 .flex(@grow, @shrink: 1, @basis: auto) {
-  -moz-box-flex: @grow @shrink @basis;
-  -ms-flex: @grow @shrink @basis;
-  -webkit-box-flex: @grow @shrink @basis;
-  -webkit-flex: @grow @shrink @basis;
   flex: @grow @shrink @basis;
 }
 
@@ -74,10 +60,6 @@
  * @initial {0 1 auto}
  */
 .flexNone() {
-  -moz-box-flex: none;
-  -ms-flex: none;
-  -webkit-box-flex: none;
-  -webkit-flex: none;
   flex: none;
 }
 
@@ -89,10 +71,6 @@
  * @initial {0}
  */
 .flexGrow(@value: 1) {
- -moz-box-flex-grow: @value;
- -ms-flex-positive: @value;
- -webkit-box-flex-grow: @value;
- -webkit-flex-grow: @value;
  flex-grow: @value;
 }
 
@@ -105,10 +83,6 @@
  * @initial {1}
  */
 .flexShrink(@value: 1) {
- -moz-box-flex-shrink: @value;
- -ms-flex-negative: @value;
- -webkit-box-flex-shrink: @value;
- -webkit-flex-shrink: @value;
  flex-shrink: @value;
 }
 
@@ -119,10 +93,6 @@
  * @initial {auto}
  */
 .flexBasis(@value: 1) {
- -moz-box-flex-basis: @value;
- -ms-flex-preferred-size: @value;
- -webkit-box-flex-basis: @value;
- -webkit-flex-basis: @value;
  flex-basis: @value;
 }
 
@@ -133,8 +103,6 @@
  * @initial {flex-start}
  */
 .justifyContent(@justify) {
-  -ms-flex-pack: @justify;
-  -webkit-justify-content: @justify;
   justify-content: @justify;
 }
 
@@ -145,8 +113,6 @@
  * @initial {stretch}
  */
 .alignItems(@align) {
-  -ms-flex-align: @align;
-  -webkit-align-items: @align;
   align-items: @align;
 }
 
@@ -157,8 +123,6 @@
  * @initial {stretch}
  */
 .alignContent(@align) {
-  -webkit-align-content: @align;
-  -ms-flex-line-pack: @align;
   align-content: @align;
 }
 
@@ -169,8 +133,6 @@
  * @param {flex-start|flex-end|center|baseline|stretch} [align] - Defaults to `stretch`.
  */
 .alignSelf(@align) {
-  -webkit-align-self: @align;
-  -ms-flex-item-align: @align;
   align-self: @align;
 }
 
@@ -180,10 +142,6 @@
  * @param {int} value
  */
 .order(@value) {
-  -moz-box-ordinal-group: @value;
-  -ms-flex-order: @value;
-  -webkit-box-ordinal-group: @value;
-  -webkit-order: @value;
   order: @value;
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+const autoprefixer = require("autoprefixer");
+
 module.exports = {
   entry: "./docs/docs.jsx",
   output: {
@@ -19,7 +21,7 @@ module.exports = {
       },
       {
         test: /\.less$/,
-        loader: "style!css!less",
+        loader: "style!css!postcss!less",
       },
       {
         test: /\.jsx?$/,
@@ -31,4 +33,5 @@ module.exports = {
       },
     ],
   },
+  postcss: [autoprefixer({browsers: "> 1% in US, last 3 versions, ie > 9"})],
 };


### PR DESCRIPTION
Use Autoprefixer to add browser prefixes so we don't have to, reducing less code size and ensuring we don't forget to support certain browsers.

Also has the nice effect of making Flexbox work on IE10 (news flash, it wasn't!) by using the 2012 syntax. Yum.

Check that the spec for what browsers this prefixes matches what we want to support; if google analytics is queriable, we can actually make autoprefixer base the 1% number off our own data rather than global US data, but I think that this is close enough :)