### PR TITLE
don't push wizard to bottom

### DIFF
--- a/src/Wizard/Wizard.less
+++ b/src/Wizard/Wizard.less
@@ -6,8 +6,6 @@
 }
 
 .Wizard--sidebar {
-  .flexbox();
-  .flexDirection(column);
   .flex(0, 0, 200px);
   .padding--m;
   background-color: @neutral_off_white;
@@ -55,7 +53,6 @@
 }
 
 .Wizard--stepsDisplay {
-  .flex(1);
   list-style-type: none;
   .padding--none;
 
@@ -71,7 +68,7 @@
 }
 
 .Wizard--controls {
-  .flex(0, 1);
+  .margin--top--l;
 }
 
 .Wizard--stepsDisplay--stepButton.Button {


### PR DESCRIPTION
Before, the controls defined on the wizard would get pushed all the way to the bottom of the wizard, so if you have a step with a lot of content it would be rendered with a lot of spacing in between the listed steps and the controls.

This just sets a padding between the steps list and the controls for the wizard.

A future development may be to have the wizard stick to a fixed position on screen regardless of how far you scroll down; this will be left for a future PR.

![screen shot 2016-11-17 at 17 08 10](https://cloud.githubusercontent.com/assets/1890926/20414717/c35282c6-ace8-11e6-8fb9-716d29aadbf6.png)

## TODO

- [ ] version bump
