### PR TITLE
Add back prefixed flex mixins to fix IE10 clients.

### DIFF
--- a/src/less/flex.less
+++ b/src/less/flex.less
@@ -9,6 +9,9 @@
  * @target Flex container.
  */
 .flexbox() {
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
   display: flex;
 }
 
@@ -17,6 +20,9 @@
  * @target Flex container.
  */
 .inlineFlexbox() {
+  display: -moz-box;
+  display: -ms-inline-flexbox;
+  display: -webkit-inline-flex;
   display: inline-flex;
 }
 
@@ -27,6 +33,8 @@
  * @initial {nowrap}
  */
 .flexWrap(@wrap: wrap) {
+  -ms-flex-wrap: @wrap;
+  -webkit-flex-wrap: @wrap;
   flex-wrap: @wrap;
 }
 
@@ -37,6 +45,8 @@
  * @initial {row}
  */
 .flexDirection(@direction) {
+  -ms-flex-direction: @direction;
+  -webkit-flex-direction: @direction;
   flex-direction: @direction;
 }
 
@@ -51,6 +61,10 @@
  * @initial {0 1 auto}
  */
 .flex(@grow, @shrink: 1, @basis: auto) {
+  -moz-box-flex: @grow @shrink @basis;
+  -ms-flex: @grow @shrink @basis;
+  -webkit-box-flex: @grow @shrink @basis;
+  -webkit-flex: @grow @shrink @basis;
   flex: @grow @shrink @basis;
 }
 
@@ -60,6 +74,10 @@
  * @initial {0 1 auto}
  */
 .flexNone() {
+  -moz-box-flex: none;
+  -ms-flex: none;
+  -webkit-box-flex: none;
+  -webkit-flex: none;
   flex: none;
 }
 
@@ -71,6 +89,10 @@
  * @initial {0}
  */
 .flexGrow(@value: 1) {
+ -moz-box-flex-grow: @value;
+ -ms-flex-positive: @value;
+ -webkit-box-flex-grow: @value;
+ -webkit-flex-grow: @value;
  flex-grow: @value;
 }
 
@@ -83,6 +105,10 @@
  * @initial {1}
  */
 .flexShrink(@value: 1) {
+ -moz-box-flex-shrink: @value;
+ -ms-flex-negative: @value;
+ -webkit-box-flex-shrink: @value;
+ -webkit-flex-shrink: @value;
  flex-shrink: @value;
 }
 
@@ -93,6 +119,10 @@
  * @initial {auto}
  */
 .flexBasis(@value: 1) {
+ -moz-box-flex-basis: @value;
+ -ms-flex-preferred-size: @value;
+ -webkit-box-flex-basis: @value;
+ -webkit-flex-basis: @value;
  flex-basis: @value;
 }
 
@@ -103,6 +133,28 @@
  * @initial {flex-start}
  */
 .justifyContent(@justify) {
+  -ms-flex-pack: @justify;
+  -webkit-justify-content: @justify;
+  justify-content: @justify;
+}
+.justifyContent(@justify) when (@justify = flex-start) {
+  -ms-flex-pack: start;
+  -webkit-justify-content: @justify;
+  justify-content: @justify;
+}
+.justifyContent(@justify) when (@justify = flex-end) {
+  -ms-flex-pack: end;
+  -webkit-justify-content: @justify;
+  justify-content: @justify;
+}
+.justifyContent(@justify) when (@justify = space-between) {
+  -ms-flex-pack: justify;
+  -webkit-justify-content: @justify;
+  justify-content: @justify;
+}
+.justifyContent(@justify) when (@justify = space-around) {
+  -ms-flex-pack: distribute;
+  -webkit-justify-content: @justify;
   justify-content: @justify;
 }
 
@@ -113,6 +165,18 @@
  * @initial {stretch}
  */
 .alignItems(@align) {
+  -ms-flex-align: @align;
+  -webkit-align-items: @align;
+  align-items: @align;
+}
+.alignItems(@align) when (@align = flex-start) {
+  -ms-flex-align: start;
+  -webkit-align-items: @align;
+  align-items: @align;
+}
+.alignItems(@align) when (@align = flex-end) {
+  -ms-flex-align: end;
+  -webkit-align-items: @align;
   align-items: @align;
 }
 
@@ -123,6 +187,28 @@
  * @initial {stretch}
  */
 .alignContent(@align) {
+  -webkit-align-content: @align;
+  -ms-flex-line-pack: @align;
+  align-content: @align;
+}
+.alignContent(@align) when (@align = flex-start) {
+  -ms-flex-line-pack: start;
+  -webkit-align-content: @align;
+  align-content: @align;
+}
+.alignContent(@align) when (@align = flex-end) {
+  -ms-flex-line-pack: end;
+  -webkit-align-content: @align;
+  align-content: @align;
+}
+.alignContent(@align) when (@align = space-between) {
+  -ms-flex-line-pack: justify;
+  -webkit-align-content: @align;
+  align-content: @align;
+}
+.alignContent(@align) when (@align = space-around) {
+  -ms-flex-line-pack: distribute;
+  -webkit-align-content: @align;
   align-content: @align;
 }
 
@@ -133,6 +219,18 @@
  * @param {flex-start|flex-end|center|baseline|stretch} [align] - Defaults to `stretch`.
  */
 .alignSelf(@align) {
+  -webkit-align-self: @align;
+  -ms-flex-item-align: @align;
+  align-self: @align;
+}
+.alignSelf(@align) when (@align = flex-start) {
+  -ms-flex-item-align: start;
+  -webkit-align-self: @align;
+  align-self: @align;
+}
+.alignSelf(@align) when (@align = flex-end) {
+  -ms-flex-item-align: end;
+  -webkit-align-self: @align;
   align-self: @align;
 }
 
@@ -142,6 +240,10 @@
  * @param {int} value
  */
 .order(@value) {
+  -moz-box-ordinal-group: @value;
+  -ms-flex-order: @value;
+  -webkit-box-ordinal-group: @value;
+  -webkit-order: @value;
   order: @value;
 }
 


### PR DESCRIPTION
PostCSS isn't running as a build step, so clients don't get the benefit of the processing that was added recently. Since we removed the prefixes, clients are currently broken.

This partially reverts https://github.com/Clever/components/pull/82 and adds in additional mixin prefixes for special-case IE10 rules (mostly `flex-xxx` -> `xxx`).