### PR TITLE
[Select] Add support for custom option renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ a fixed list of options.
 | label (optional) | String | Label for select element | None
 | multi (optional) | Bool | Whether a multiple options may be selected | False
 | onChange (optional) | Function | Called with new value when it changes | None
+| optionRenderer (optional) | Function | A function that returns a custom display node for a specific Select option. Invoked with a single option as specified in `options` as the first argument and the index of the option as the second. | None
 | options (optional) | Array | Possible options. Must contain objects with label and value attributes | None
 | placeholder (optional) | String | Placeholder text | ""
 | searchable (optional) | Bool | Whether or not the values in the dropdown are searchable. | False

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.17.7",
+  "version": "0.17.8",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -31,6 +31,7 @@ export function Select({
   label,
   multi,
   onChange,
+  optionRenderer,
   options,
   placeholder = "",
   searchable,
@@ -55,6 +56,7 @@ export function Select({
           multi={multi}
           name={name}
           onChange={onChange}
+          optionRenderer={optionRenderer}
           options={options}
           placeholder={placeholder}
           searchable={searchable}
@@ -89,6 +91,7 @@ Select.propTypes = {
   label: React.PropTypes.string,
   multi: React.PropTypes.bool,
   onChange: React.PropTypes.func,
+  optionRenderer: React.PropTypes.func,
   options: React.PropTypes.arrayOf(selectValuePropType),
   placeholder: React.PropTypes.string,
   searchable: React.PropTypes.bool,


### PR DESCRIPTION
Just passes through the 'optionRenderer' prop to react-select.