### PR TITLE
DIS2-374: LeftNav tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ viewport. Any additional `Grid.Col`s will wrap onto the following line.
 
 | Prop             | Type     | Description                           | Default
 |------------------|----------|---------------------------------------|---------
-| children (optional) | Array<Grid.Row> | The rows to render in the grid. | None
+| children (optional) | Array\<Grid.Row\> | The rows to render in the grid. | None
 | className (optional) | String | Additional classname to apply to the grid. | None
 | wrapperComponent (optional) | Any | The tagname or component class for the wrapper component to render for the grid | "div"
 
@@ -422,7 +422,7 @@ viewport. Any additional `Grid.Col`s will wrap onto the following line.
 
 | Prop             | Type     | Description                           | Default
 |------------------|----------|---------------------------------------|---------
-| children (optional) | Array<Grid.Col> | The columns to render in the row. | None
+| children (optional) | Array\<Grid.Col\> | The columns to render in the row. | None
 | className (optional) | String | Additional classname to apply to the row. | None
 | grow (optional) | Boolean | Fluidly grows the row to fill any available vertical space. The parent Grid should have an explicit height set for this to work. | False
 | wrapperComponent (optional) | Any | The tagname or component class for the wrapper component to render for the row | "div"
@@ -433,7 +433,7 @@ viewport. Any additional `Grid.Col`s will wrap onto the following line.
 |------------------|----------|---------------------------------------|---------
 | children (optional) | React Node | The content to render in the column. | None
 | className (optional) | String | Additional classname to apply to the column. | None
-| span (optional) | Number or Map<Grid.Size, Number> | The number of columns (1-12) that this column spans. Can optionally as a map of viewport size to column span in order to dynamically update the grid based on the user's viewport width. | 1
+| span (optional) | Number or Map\<Grid.Size, Number\> | The number of columns (1-12) that this column spans. Can optionally as a map of viewport size to column span in order to dynamically update the grid based on the user's viewport width. | 1
 | wrapperComponent (optional) | Any | The tagname or component class for the wrapper component to render for the column | "div"
 
 **Usage Examples**
@@ -498,7 +498,7 @@ It requires `Tab` components as children.
 | Prop             | Type     | Description                           | Default
 |------------------|----------|---------------------------------------|---------
 | alignSelf (optional) | ItemAlign | Sets the cross-axis alignment of this flex item only. | ItemAlign.STRETCH
-| children (optional) | Tab or Array<Tab> | The tabs to render in the tab bar. | None
+| children (optional) | Tab or Array\<Tab\> | The tabs to render in the tab bar. | None
 | className (optional) | String | Additional classname to apply to the tab bar. | None
 | justify (optional) | Justify | Sets the horizontal alignment of the tab bar tabs. See documentation on  [justify-content](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) for a description of the available options. | Justify.START
 | size (optional) | TabBar.Size | Controls the size of the tabs in the tab bar. | TabBar.Size.MEDIUM
@@ -555,9 +555,9 @@ to define the conditions under which their inputs are considered valid.
 | title (required)    | String   | Title of the wizard          | None
 | description (required)    | String  | Description of the wizard          | None
 | onComplete (required)    | Funntion   | Defines what happens when all `steps` are valid, and the user clicks the next button past the final step.          | None
-| steps (required)    | `Array<step>`   | Steps in the wizard.          | None
+| steps (required)    | Array\<step\>   | Steps in the wizard.          | None
 | help (optional)    | String or React Node   | Global help text to display next to form. Can be overridden by a step that has its own `help` property.         | None
-| wizardButtons (optional)    | `Array<wizardButton>`   | Buttons to show in sidebar.          | `[]`
+| wizardButtons (optional)    | Array\<wizardButton\>   | Buttons to show in sidebar.          | `[]`
 | initialWizardData (optional)    | Object   | Initial data to seed `wizardState`. Useful for saving the state of a form for later.          | `{}`
 | nextButtonValue (optional)    | String or React Node   | Global text to display on next buttons in form. Can be overriden by a step that has its own `nextButtonValue` property. | `'Next'`
 | prevButtonValue (optional)    | String or React Node   | Global text to display on prev buttons in form. Can be overriden by a step that has its own `prevButtonValue` property. | `'Back'`
@@ -596,7 +596,7 @@ to define the conditions under which their inputs are considered valid.
 | Prop             | Type     | Description                           | Default
 |------------------|----------|---------------------------------------|---------
 | collapsed (optional) | Boolean | If true, shrinks the sidebar, rendering just the top-level link icons and omitting the labels. The drawer is unaffected. | false
-| children (required) | Array<Union<LeftNav.NavLink, LeftNav.NavGroup>> | The links and link groups to render in the nav. | None
+| children (required) | Array\<Union\<LeftNav.NavLink, LeftNav.NavGroup\>\> | The links and link groups to render in the nav. | None
 
 #### `<NavLink>` Options
 | Prop             | Type     | Description                           | Default

--- a/README.md
+++ b/README.md
@@ -588,3 +588,31 @@ to define the conditions under which their inputs are considered valid.
 #### Usage Examples
 
 [Sample Code](https://github.com/Clever/components/tree/master/docs/WizardExample.jsx) ([Live Demo](http://clever.github.io/components/#wizardExample))
+
+### LeftNav
+`LeftNav` is a navigation sidebar component designed to be anchored to the left side of the page. It takes as its children a list consisting of top-level links (`LeftNav.NavLink`) as well as groups of nested links (`LeftNav.NavGroup`). Nested links are rendered in a slide-out drawer.
+
+#### `<LeftNav>` Options
+| Prop             | Type     | Description                           | Default
+|------------------|----------|---------------------------------------|---------
+| collapsed (optional) | Boolean | If true, shrinks the sidebar, rendering just the top-level link icons and omitting the labels. The drawer is unaffected. | false
+| children (required) | Array<Union<LeftNav.NavLink, LeftNav.NavGroup>> | The links and link groups to render in the nav. | None
+
+#### `<NavLink>` Options
+| Prop             | Type     | Description                           | Default
+|------------------|----------|---------------------------------------|---------
+| label (required) | String   | The label to render as the link text.  | None
+| icon (optional)  | Node     | The node to render as the link icon. While this is optional for nested links, top-level links should have an icon so they can be clicked in the collapsed state. | None
+| onClick (optional) | Function | Handler to call when the link is clicked. | None
+| selected (optional) | Boolean | Whether or not to render the link as selected. LeftNav does not track the currently selected link - you have to manage that yourself. Only one link should be selected at a time. Note that if a nested link is marked as selected, the drawer for its parent NavGroup will be open. | false
+
+#### `<NavGroup>` Options
+| Prop             | Type     | Description                           | Default
+|------------------|----------|---------------------------------------|---------
+| id (required)    | String   | Unique identifier for this group.     | None
+| label (required) | String   | The label to render as the link text. | None
+| icon (optional)  | Node     | The node to render as the link icon.  | None
+
+#### Usage Examples
+
+[Sample Code](https://github.com/Clever/components/tree/master/docs/LeftNavExample.jsx) ([Live Demo](http://clever.github.io/components/#leftNav))

--- a/docs/LeftNavExample.jsx
+++ b/docs/LeftNavExample.jsx
@@ -31,8 +31,8 @@ export default class LeftNavExample extends React.Component {
 
     return (
       <div>
-        <a name="leftnav">
-          <h1>Left Nav</h1>
+        <a name="leftNav">
+          <h1>LeftNav</h1>
         </a>
         <Button
           className={cssClass.COLLAPSE}

--- a/src/LeftNav/LeftNav.jsx
+++ b/src/LeftNav/LeftNav.jsx
@@ -40,7 +40,7 @@ export class LeftNav extends React.Component {
       if (child.type === NavGroup) {
         const open = child.props.id === this.state.openNavGroup;
         return React.cloneElement(child, {
-          open,
+          _open: open,
           _onClick: () => this.setState({openNavGroup: open ? null : child.props.id}),
         });
       }
@@ -49,7 +49,7 @@ export class LeftNav extends React.Component {
     });
 
     // Find the open NavGroup so that we can render its children NavLinks in the drawer
-    const openChild = _.find(React.Children.toArray(children), child => child.props.open);
+    const openChild = _.find(React.Children.toArray(children), child => child.props._open);
 
     const collapsed = this.props.collapsed ? cssClass.COLLAPSED : null;
 

--- a/src/LeftNav/LeftNav.jsx
+++ b/src/LeftNav/LeftNav.jsx
@@ -14,7 +14,7 @@ export class LeftNav extends React.Component {
 
     // If a NavLink in a NavGroup is marked as selected on initialization, we
     // should open the drawer to show it. Otherwise, don't start with the drawer open.
-    const selectedNavGroup = _.find(props.children, child =>
+    const selectedNavGroup = _.find(React.Children.toArray(props.children), child =>
       child.type === NavGroup &&
         React.Children.toArray(child.props.children).some(navLink => navLink.props.selected)
     );

--- a/src/LeftNav/NavGroup.jsx
+++ b/src/LeftNav/NavGroup.jsx
@@ -8,7 +8,7 @@ import {NavLink} from "./NavLink";
 export function NavGroup(props) {
   const {cssClass} = NavGroup;
 
-  const open = props.open ? cssClass.OPEN : null;
+  const open = props._open ? cssClass.OPEN : null;
   return (
     <NavLink
       className={classnames(cssClass.CONTAINER, open)}
@@ -23,7 +23,7 @@ NavGroup.propTypes = {
   id: PropTypes.string.isRequired,
   icon: PropTypes.node.isRequired,
   label: PropTypes.string.isRequired,
-  open: PropTypes.bool,
+  _open: PropTypes.bool, // private - used by LeftNav only
   _onClick: PropTypes.func, // private - used by LeftNav only
 };
 

--- a/test/LeftNav_test.jsx
+++ b/test/LeftNav_test.jsx
@@ -1,0 +1,197 @@
+import assert from "assert";
+import React from "react";
+import sinon from "sinon";
+import {shallow} from "enzyme";
+import {LeftNav} from "../src";
+
+describe("LeftNav", function LeftNavTest() {
+  const {NavLink, NavGroup} = LeftNav;
+  const {cssClass: navCss} = LeftNav;
+  const {cssClass: linkCss} = NavLink;
+
+  const fakeIcon = <img src="iconSrc" />;
+
+  const topNavLinkSpy = sinon.spy();
+  const subNavLinkSpy = sinon.spy();
+
+  const renderLeftNav = (props) => shallow(
+    <LeftNav {...props}>
+      <NavLink label="topLink1" icon={fakeIcon} onClick={topNavLinkSpy} />
+      <NavGroup label="group1" id="group1" icon={fakeIcon}>
+        <NavLink label="subLink11" onClick={subNavLinkSpy} />
+        <NavLink label="subLink12" />
+      </NavGroup>
+      <NavLink label="topLink2" icon={fakeIcon} />
+      <NavGroup label="group2" id="group2" icon={fakeIcon}>
+        <NavLink label="subLink21" />
+        <NavLink label="subLink22" />
+      </NavGroup>
+    </LeftNav>
+  );
+
+
+  describe("initially", () => {
+    const nav = renderLeftNav();
+
+    it("renders nav", () => {
+      assert.equal(nav.type(), "nav");
+    });
+
+    it("renders top nav with NavLinks and NavGroups", () => {
+      const topnav = nav.find(`.${navCss.TOPNAV}`);
+      assert(!topnav.isEmpty());
+      assert.equal(topnav.type(), "ul");
+      assert.equal(topnav.children().length, 4);
+    });
+
+    it("doesn't render the subnav drawer initially", () => {
+      assert(nav.find(`.${navCss.SUBNAV}`).isEmpty());
+    });
+
+    it("renders topnav NavLink with label and icon", () => {
+      const link = nav.find(NavLink).first().dive();
+      const label = link.find(`.${linkCss.LABEL}`);
+      const icon = link.find(`.${linkCss.ICON}`);
+      assert.equal(link.type(), "li");
+      assert(!label.isEmpty());
+      assert.equal(label.text(), "topLink1");
+      assert(!icon.isEmpty());
+      assert.equal(icon.childAt(0).get(0), fakeIcon);
+    });
+
+    it("renders topnav NavGroup as a NavLink, without rendering its subnav children", () => {
+      const group = nav.find(NavGroup).first().dive();
+      const link = group.get(0);
+      assert.equal(group.type(), NavLink);
+      assert.equal(link.props.label, "group1");
+      assert.equal(link.props.icon, fakeIcon);
+      assert(group.children().find(NavLink).isEmpty());
+    });
+
+    it("calls the onClick handler when a topnav NavLink is clicked", () => {
+      const link = nav.find(NavLink).first().dive();
+      link.simulate("click");
+      assert(topNavLinkSpy.calledOnce);
+    });
+
+    it("opens the subnav drawer and renders the children NavLinks when a NavGroup is clicked", () => {
+      const group = nav.find(NavGroup).first().dive();
+      group.simulate("click");
+      // Manually trigger update since enzyme doesn't detect LeftNav state change for some reason
+      nav.update();
+      const subnav = nav.find(`.${navCss.SUBNAV}`);
+      assert(!subnav.isEmpty());
+      assert.equal(subnav.children().length, 2);
+      assert.equal(subnav.childAt(0).prop("label"), "subLink11");
+      assert.equal(subnav.childAt(1).prop("label"), "subLink12");
+    });
+  });
+
+  describe("when the subnav drawer is open", () => {
+    beforeEach(() => {
+      this.nav = renderLeftNav();
+      const group = this.nav.find(NavGroup).first().dive();
+      group.simulate("click");
+      // Manually trigger update since enzyme doesn't detect LeftNav state change for some reason
+      this.nav.update();
+    });
+
+    it("calls the onClick handler when a subnav NavLink is clicked", () => {
+      const link = this.nav.find(NavGroup).find(NavLink).first().dive();
+      link.simulate("click");
+      assert(subNavLinkSpy.calledOnce);
+      // And the drawer stays open
+      this.nav.update();
+      const subnav = this.nav.find(`.${navCss.SUBNAV}`);
+      assert(!subnav.isEmpty());
+    });
+
+    it("closes the subnav drawer when the open NavGroup is clicked", () => {
+      const group = this.nav.find(NavGroup).first().dive();
+      group.simulate("click");
+      this.nav.update();
+      const subnav = this.nav.find(`.${navCss.SUBNAV}`);
+      assert(subnav.isEmpty());
+    });
+
+    it("closes the subnav drawer when a topnav NavLink is clicked", () => {
+      const link = this.nav.find(NavLink).first().dive();
+      link.simulate("click");
+      this.nav.update();
+      const subnav = this.nav.find(`.${navCss.SUBNAV}`);
+      assert(subnav.isEmpty());
+    });
+
+    it("rerenders the subnav drawer when a different NavGroup is clicked", () => {
+      const otherGroup = this.nav.find(NavGroup).last().dive();
+      otherGroup.simulate("click");
+      this.nav.update();
+      const subnav = this.nav.find(`.${navCss.SUBNAV}`);
+      assert(!subnav.isEmpty());
+      assert.equal(subnav.children().length, 2);
+      assert.equal(subnav.childAt(0).prop("label"), "subLink21");
+      assert.equal(subnav.childAt(1).prop("label"), "subLink22");
+    });
+  });
+
+  describe("when a topnav NavLink is selected", () => {
+    const nav = shallow(
+      <LeftNav>
+        <NavLink selected label="topLink1" icon={fakeIcon} />
+      </LeftNav>
+    );
+
+    it("renders the NavLink with the 'selected' class", () => {
+      const link = nav.find(NavLink).first().dive();
+      assert(link.hasClass(linkCss.SELECTED));
+    });
+  });
+
+  describe("when a subnav NavLink is selected", () => {
+    beforeEach(() => {
+      this.nav = shallow(
+        <LeftNav>
+          <NavLink label="topLink1" icon={fakeIcon} />
+          <NavGroup label="group1" id="group1" icon={fakeIcon}>
+            <NavLink selected label="subLink11" />
+          </NavGroup>
+          <NavGroup label="group2" id="group2" icon={fakeIcon}>
+            <NavLink label="subLink21" />
+          </NavGroup>
+        </LeftNav>
+      );
+    });
+
+    it("renders the subnav drawer corresponding to the link's parent NavGroup", () => {
+      const subnav = this.nav.find(`.${navCss.SUBNAV}`);
+      assert(!subnav.isEmpty());
+      assert.equal(subnav.children().length, 1);
+      assert.equal(subnav.childAt(0).prop("label"), "subLink11");
+    });
+
+    it("renders the NavLink with the 'selected' class", () => {
+      const subnav = this.nav.find(`.${navCss.SUBNAV}`);
+      const link = subnav.find(NavLink).first().dive();
+      assert(link.hasClass(linkCss.SELECTED));
+    });
+
+    it("rerenders the subnav drawer when a different NavGroup is clicked", () => {
+      const otherGroup = this.nav.find(NavGroup).last().dive();
+      otherGroup.simulate("click");
+      this.nav.update();
+      const subnav = this.nav.find(`.${navCss.SUBNAV}`);
+      assert(!subnav.isEmpty());
+      assert.equal(subnav.children().length, 1);
+      assert.equal(subnav.childAt(0).prop("label"), "subLink21");
+    });
+  });
+
+  describe("when collapsed", () => {
+    const nav = renderLeftNav({collapsed: true});
+
+    it("renders the topnav with the 'collapsed' class", () => {
+      const topnav = nav.find(`.${navCss.TOPNAV}`);
+      assert(topnav.hasClass(navCss.COLLAPSED));
+    });
+  });
+});


### PR DESCRIPTION
This PR adds unit tests and documentation for the LeftNav component. It also makes two small tweaks to the LeftNav code - using React.Children.toArray in a place where we should be using it, and renaming a private prop. Each change is in a separate commit.