### PR TITLE
fix CopyableInput overflow issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ border-radius-styles:
 	@echo "Generating border-radius style definitions..."
 	@node genBorderRadius.js
 
-LINT_MAX_LESS_PROBLEMS := 91
+LINT_MAX_LESS_PROBLEMS := 90
 lint:
 	@echo "Linting files..."
 	@$(LINT) $(JS_FILES) $(JSX_FILES)

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ border-radius-styles:
 	@echo "Generating border-radius style definitions..."
 	@node genBorderRadius.js
 
-LINT_MAX_LESS_PROBLEMS := 90
+LINT_MAX_LESS_PROBLEMS := 86
 lint:
 	@echo "Linting files..."
 	@$(LINT) $(JS_FILES) $(JSX_FILES)

--- a/docs/components/CopyableInputView.jsx
+++ b/docs/components/CopyableInputView.jsx
@@ -13,6 +13,7 @@ export default class CopyableInputView extends Component {
 
     this.state = {
       disabled: false,
+      readOnly: false,
       hasError: false,
       inputValue: "🙈 🙉 🙊",
       obscured: true,
@@ -39,6 +40,7 @@ export default class CopyableInputView extends Component {
               placeholder="CopyableInput Placeholder"
               onChange={e => this.setState({inputValue: e.target.value})}
               value={this.state.inputValue}
+              readOnly={this.state.readOnly}
             />
           `}
         >
@@ -46,6 +48,7 @@ export default class CopyableInputView extends Component {
             <CopyableInput
               enableCopy
               disabled={this.state.disabled}
+              readOnly={this.state.readOnly}
               required={this.state.required}
               enableShow={this.state.obscured}
               error={this.state.hasError ? "Enter a valid email address" : null}
@@ -65,6 +68,15 @@ export default class CopyableInputView extends Component {
             />
             {" "}
             Disabled
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={this.state.readOnly}
+              onChange={({target}) => this.setState({readOnly: target.checked})}
+            />
+            {" "}
+            Read Only
           </label>
           <label className={cssClass.CONFIG}>
             <input

--- a/docs/components/TextInputView.jsx
+++ b/docs/components/TextInputView.jsx
@@ -13,6 +13,7 @@ export default class TextInputView extends Component {
 
     this.state = {
       disabled: false,
+      readOnly: false,
       hasError: false,
       inputValue: "",
       obscured: false,
@@ -29,6 +30,7 @@ export default class TextInputView extends Component {
           code={`
             <TextInput
               disabled={this.state.disabled}
+              readOnly={this.state.readOnly}
               required={this.state.required}
               enableShow={this.state.obscured}
               error={this.state.hasError ? "Enter a valid email address" : null}
@@ -44,6 +46,7 @@ export default class TextInputView extends Component {
           <div className={cssClass.INPUT_CONTAINER}>
             <TextInput
               disabled={this.state.disabled}
+              readOnly={this.state.readOnly}
               required={this.state.required}
               enableShow={this.state.obscured}
               error={this.state.hasError ? "Invalid password" : null}
@@ -63,6 +66,15 @@ export default class TextInputView extends Component {
             />
             {" "}
             Disabled
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={this.state.readOnly}
+              onChange={({target}) => this.setState({readOnly: target.checked})}
+            />
+            {" "}
+            Read Only
           </label>
           <label className={cssClass.CONFIG}>
             <input

--- a/src/CopyableInput/CopyableInput.less
+++ b/src/CopyableInput/CopyableInput.less
@@ -1,12 +1,22 @@
+@import (reference) "../less/colors";
+@import (reference) "../less/border";
+
 .CopyableInput {
-  position: relative;
+  .border--s(@neutral_silver);
+  display: flex;
+  background: @neutral_white;
+  width: 100%;
+
+  .TextInput {
+    border: none;
+    flex: 1 0;
+  }
 }
 
 .CopyableInput--links {
-  position: absolute;
-  top: 50%;
-  right: 0;
-  margin: -8px 7px;
+  margin: auto 7px;
+  white-space: nowrap;
+  background: white;
 
   .CopyableInput--link {
     border: 0;

--- a/src/CopyableInput/CopyableInput.less
+++ b/src/CopyableInput/CopyableInput.less
@@ -1,29 +1,34 @@
 @import (reference) "../less/colors";
 @import (reference) "../less/border";
+@import (reference) "../less/sizing";
+@import (reference) "../less/flex";
+@import (reference) "../less/type-size";
 
 .CopyableInput {
   .border--s(@neutral_silver);
-  display: flex;
+  .flexbox();
   background: @neutral_white;
   width: 100%;
 
   .TextInput {
     border: none;
-    flex: 1 0;
+    .flexShrink(1);
   }
 }
 
 .CopyableInput--links {
-  margin: auto 7px;
+  margin: auto @size_s;
   white-space: nowrap;
   background: white;
+  .flexShrink(0);
 
   .CopyableInput--link {
     border: 0;
     background: none;
-    color: #4274F6;
-    font-size: 12px;
-    border-right: 1px solid #dddddd;
+    color: @primary_blue;
+    font-size: @type_small;
+    .border--right--s(@neutral_silver);
+    .shade(border-right-color, @neutral_silver, 1);
 
     &:last-child {
       border: 0;


### PR DESCRIPTION
It would display text underneath the buttons. gross!

### Before...

![copyable-input-before](https://cloud.githubusercontent.com/assets/1890926/20694092/54fe6092-b5a8-11e6-9b04-7a4996000d8e.gif)

### After!

![copyable-input-after](https://cloud.githubusercontent.com/assets/1890926/20694091/52e7b4a2-b5a8-11e6-9c87-e48a613d0c9d.gif)

