### PR TITLE
style tweaks for Wizard

### DIFF
--- a/docs/WizardExample.jsx
+++ b/docs/WizardExample.jsx
@@ -152,7 +152,7 @@ export default class WizardExample extends React.Component {
         nextButtonValue: "Save address",
       },
       {
-        title: "Delivery Contact",
+        title: "Preferred Primary Delivery Contact",
         description: "Who should we contact when we have arrived to your delivery address?",
         component: ContactStep,
         validate: ContactStep.validate,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.17.12",
+  "version": "0.17.13",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Wizard/Wizard.less
+++ b/src/Wizard/Wizard.less
@@ -2,11 +2,12 @@
 @import (reference) "../less/index";
 
 .Wizard {
-  display: flex;
+  .flexbox();
 }
 
 .Wizard--sidebar {
-  .flex(0, 0, 200px);
+  .flex(0, 0, 15rem);
+  width: 15rem;
   .padding--m;
   background-color: @neutral_off_white;
   .border--right--m(@neutral_silver);
@@ -19,9 +20,7 @@
 .Wizard--contentGroup {
   min-width: 37.5rem;
   max-width: 37.5rem;
-  .tint(background, @neutral_silver, 3);
   .padding--s;
-  .margin--m;
   .margin--left--none;
 
   &.Wizard--WizardStep--help {
@@ -41,7 +40,6 @@
 .Wizard--WizardStep--title {
   width: 100%;
   .border--bottom--m(@neutral_silver);
-  .padding--bottom--m;
 }
 
 .Wizard--stepContainer {
@@ -107,19 +105,17 @@
 
 .Wizard--stepsDisplay--stepTitle {
   display: block;
-  // don't allow wrapping of text
   overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 }
 
 .Wizard--stepsDisplay--icon {
   display: inline-block;
+  .flexShrink(0);
   width: 1.5rem;
   height: 1.5rem;
   background-image: url("../../assets/images/progress_notStarted.svg");
   background-repeat: no-repeat;
-  background-size: 1.5rem 1.5rem;
+  background-size: contain;
   .margin--right--2xs;
 }
 


### PR DESCRIPTION
## Screenshots

### New
<img width="924" alt="screen shot 2016-11-29 at 13 18 11" src="https://cloud.githubusercontent.com/assets/1890926/20725155/8cfef0a4-b636-11e6-92c9-72475ffc0baa.png">
<img width="1040" alt="screen shot 2016-11-29 at 13 18 22" src="https://cloud.githubusercontent.com/assets/1890926/20725156/8d006eca-b636-11e6-9768-cb2ffb14233f.png">

### Old
<img width="941" alt="screen shot 2016-11-29 at 13 19 19" src="https://cloud.githubusercontent.com/assets/1890926/20725157/8d0092f6-b636-11e6-8428-43a2afca1fc2.png">

* long ∂escription text

<img width="983" alt="screen shot 2016-11-29 at 13 19 45" src="https://cloud.githubusercontent.com/assets/1890926/20725158/8d012748-b636-11e6-94e7-9c6d4d0d09d2.png">
