### PR TITLE
Wizard style again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.17.14",
+  "version": "0.17.15",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Wizard/Wizard.less
+++ b/src/Wizard/Wizard.less
@@ -8,24 +8,25 @@
 .Wizard--sidebar {
   .flex(0, 0, 15rem);
   width: 15rem;
-  .padding--m;
+  .padding--x--m;
+  .padding--y--l;
   background-color: @neutral_off_white;
   .border--right--m(@neutral_silver);
 
   h2 {
     .text--regular;
+    .padding--none;
+    .margin--bottom--m;
   }
 }
 
+@content_width: 37.5rem;
+@help_min_width: 18.75rem;
 .Wizard--contentGroup {
-  min-width: 37.5rem;
-  max-width: 37.5rem;
-  .padding--s;
+  min-width: @content_width;
+  max-width: @content_width;
+  .margin--bottom--s;
   .margin--left--none;
-
-  &.Wizard--WizardStep--help {
-    min-width: 18.75rem;
-  }
 }
 
 .Wizard--navButtons {
@@ -53,6 +54,7 @@
 .Wizard--stepsDisplay {
   list-style-type: none;
   .padding--none;
+  .margin--top--m;
 
   li {
     &:not(:last-child)::after {
@@ -66,7 +68,7 @@
 }
 
 .Wizard--controls {
-  .margin--top--l;
+  .margin--top--3xl;
 }
 
 .Wizard--stepsDisplay--stepButton.Button {
@@ -111,24 +113,28 @@
 .Wizard--stepsDisplay--icon {
   display: inline-block;
   .flexShrink(0);
-  width: 1.5rem;
-  height: 1.5rem;
+  width: @size_l;
+  height: @size_l;
   background-image: url("../../assets/images/progress_notStarted.svg");
   background-repeat: no-repeat;
   background-size: contain;
   .margin--right--2xs;
 }
 
-.Wizard--WizardStep--componentWrapper {
+.Wizard--WizardStep--component {
+  .flex(1, 0, 37.5rem);
+  .margin--bottom--2xl;
+}
+
+.Wizard--WizardStep--topInfo {
   .flexbox();
   .flexWrap(wrap);
   .alignItems(flex-start);
-}
-
-.Wizard--WizardStep--component {
-  .flex(1, 0, 37.5rem);
+  .margin--top--l;
+  .margin--bottom--m;
 }
 
 .Wizard--WizardStep--help {
-  .flex(1, 0, 18.75rem);
+  min-width: @help_min_width;
+  .flex(1, 0, @help_min_width);
 }

--- a/src/Wizard/WizardStep.jsx
+++ b/src/Wizard/WizardStep.jsx
@@ -13,40 +13,39 @@ export default function WizardStep({
         <h1>Step {currentStep + 1}: {title}</h1>
       </div>
 
-      { description && (
-        <div className="Wizard--contentGroup Wizard--WizardStep--description">
-          { _.isString(description) ? <p>{description}</p> : description }
-        </div>
-      )}
-
-      <div className="Wizard--WizardStep--componentWrapper">
-        <div className="Wizard--contentGroup Wizard--WizardStep--component">
-          <Component
-            {...props}
-            setWizardState={(modifications) => {
-              const newState = setWizardState(modifications);
-
-              // this conditional updates the progress bar in 2 scenarios:
-              // a) oridnarily, steps update the progress bar once they are navigated away from so
-              // that progress only increases when the user actually moves to the next step (see
-              // Wizard.jumpToPage()). However, the final page must react to validity immediately to
-              // signal completion, so this causes the final page to update the percent complete
-              // upon input rather than solely upon navigation.
-              // b) pages immediately update the progress bar if they become invalid, so that the
-              // incompleteness of the form is reflected in the UI immediately.
-              if (currentStep === totalSteps - 1 || calculatePercentComplete(newState) < percentComplete) {
-                updatePercentComplete(newState);
-              }
-            }}
-            wizardState={wizardState}
-          />
-        </div>
-
+      <div className="Wizard--WizardStep--topInfo">
+        { description && (
+          <div className="Wizard--contentGroup Wizard--WizardStep--description">
+            { _.isString(description) ? <p>{description}</p> : description }
+          </div>
+        )}
         { help && (
           <div className="Wizard--contentGroup Wizard--WizardStep--help">
             {_.isString(help) ? <p>{help}</p> : help}
           </div>
         )}
+      </div>
+
+      <div className="Wizard--contentGroup Wizard--WizardStep--component">
+        <Component
+          {...props}
+          setWizardState={(modifications) => {
+            const newState = setWizardState(modifications);
+
+            // this conditional updates the progress bar in 2 scenarios:
+            // a) oridnarily, steps update the progress bar once they are navigated away from so
+            // that progress only increases when the user actually moves to the next step (see
+            // Wizard.jumpToPage()). However, the final page must react to validity immediately to
+            // signal completion, so this causes the final page to update the percent complete
+            // upon input rather than solely upon navigation.
+            // b) pages immediately update the progress bar if they become invalid, so that the
+            // incompleteness of the form is reflected in the UI immediately.
+            if (currentStep === totalSteps - 1 || calculatePercentComplete(newState) < percentComplete) {
+              updatePercentComplete(newState);
+            }
+          }}
+          wizardState={wizardState}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
Make the spacing cleaner, and move the help text to the top upon collapse instead of to the bottom.

![screen shot 2016-11-30 at 16 07 13](https://cloud.githubusercontent.com/assets/1890926/20776738/501c267a-b717-11e6-9ebf-7eeb26dfd5ad.png)
![screen shot 2016-11-30 at 16 07 34](https://cloud.githubusercontent.com/assets/1890926/20776739/501eaee0-b717-11e6-952e-34f426ab0009.png)
