### PR TITLE
don't make help push other stuff down

### DIFF
--- a/docs/WizardExample.jsx
+++ b/docs/WizardExample.jsx
@@ -231,13 +231,19 @@ export default class WizardExample extends React.Component {
           handler: (wizardState, {resetWizard}) => resetWizard(),
           buttonValue: "Clear and start over",
         }]}
-        help={this.state.showHelp && <p>
-          Need any help? Check out our&nbsp;
-          <Button
-            onClick={() => alert("LOL, no help for you!")} type="link"
-            value="Support Center." style={{padding: 0}}
-          />
-        </p>}
+        help={this.state.showHelp && (
+          <div>
+            <h4 style={{marginTop: 0}}>Need any help?</h4>
+            <p>Don't fret! We got you!</p>
+            <p>
+              Check out our&nbsp;
+              <Button
+                onClick={() => alert("LOL, no help for you!")} type="link"
+                value="Support Center." style={{padding: 0}}
+              />
+            </p>
+          </div>
+        )}
         seekable={this.state.seekable}
         hideProgressBar={this.state.hideProgressBar}
       />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.17.16",
+  "version": "0.17.17",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Wizard/Wizard.less
+++ b/src/Wizard/Wizard.less
@@ -138,4 +138,8 @@
 .Wizard--WizardStep--help {
   min-width: @help_min_width;
   .flex(1, 0, @help_min_width);
+  &:not(.Wizard--WizardStep--helpCollapsed) {
+    height: 0;
+    overflow: visible;
+  }
 }

--- a/src/Wizard/WizardStep.jsx
+++ b/src/Wizard/WizardStep.jsx
@@ -1,54 +1,97 @@
 import React, {PropTypes} from "react";
 import _ from "lodash";
+import classnames from "classnames";
 
-export default function WizardStep({
-  title, description, Component, setWizardState, currentStep, wizardState, help,
-  percentComplete, calculatePercentComplete, updatePercentComplete, totalSteps,
-  componentProps,
-}) {
-  const props = _.omit(componentProps || {}, ["wizardState", "setWizardState"]);
-  return (
-    <div className="Wizard--WizardStep">
-      <div className="Wizard--WizardStep--title">
-        <h1>Step {currentStep + 1}: {title}</h1>
+// 58.25 rem = width of sidebar + width of left column
+const COLLAPSE_BREAKPOINT_WIDTH_REM = 58.25;
+
+export default class WizardStep extends React.Component {
+  constructor(props) {
+    super(props);
+
+    // NOTE: if a webpage explicitly changes the font size on the html element, this may be
+    // incorrect, as rem is calculated against the browser-set font-size, not that of the html
+    // element.
+    // NOTE: this assumes the font size is expressed in px.
+    const fontSize = window.getComputedStyle(document.getElementsByTagName("html")[0])["font-size"];
+    this.state = {
+      renderedStepWidth: null,
+      collapseBreakpointWidth: COLLAPSE_BREAKPOINT_WIDTH_REM * parseFloat(fontSize),
+    };
+    this.updateDimensions = this.updateDimensions.bind(this);
+  }
+
+  componentDidMount() {
+    this.updateDimensions();
+    window.addEventListener("resize", this.updateDimensions);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("resize", this.updateDimensions);
+  }
+
+  updateDimensions() {
+    const renderedStepWidth = this.component.offsetWidth;
+    this.setState({
+      helpTextCollapsed: this.state.collapseBreakpointWidth > renderedStepWidth,
+    });
+  }
+
+  render() {
+    const {
+      title, description, Component, setWizardState, currentStep, wizardState, help,
+      percentComplete, calculatePercentComplete, updatePercentComplete, totalSteps,
+      componentProps,
+    } = this.props;
+    const props = _.omit(componentProps || {}, ["wizardState", "setWizardState"]);
+    return (
+      <div className="Wizard--WizardStep" ref={(e) => { this.component = e; }}>
+        <div className="Wizard--WizardStep--title">
+          <h1>Step {currentStep + 1}: {title}</h1>
+        </div>
+
+        <div className="Wizard--WizardStep--topInfo">
+          { description && (
+            <div className="Wizard--contentGroup Wizard--WizardStep--description">
+              { _.isString(description) ? <p>{description}</p> : description }
+            </div>
+          )}
+          { help && (
+            <div
+              className={classnames(
+                "Wizard--contentGroup", "Wizard--WizardStep--help",
+                this.state.helpTextCollapsed && "Wizard--WizardStep--helpCollapsed"
+              )}
+            >
+              {_.isString(help) ? <p>{help}</p> : help}
+            </div>
+          )}
+        </div>
+
+        <div className="Wizard--contentGroup Wizard--WizardStep--component">
+          <Component
+            {...props}
+            setWizardState={(modifications) => {
+              const newState = setWizardState(modifications);
+
+              // this conditional updates the progress bar in 2 scenarios:
+              // a) oridnarily, steps update the progress bar once they are navigated away from so
+              // that progress only increases when the user actually moves to the next step (see
+              // Wizard.jumpToPage()). However, the final page must react to validity immediately to
+              // signal completion, so this causes the final page to update the percent complete
+              // upon input rather than solely upon navigation.
+              // b) pages immediately update the progress bar if they become invalid, so that the
+              // incompleteness of the form is reflected in the UI immediately.
+              if (currentStep === totalSteps - 1 || calculatePercentComplete(newState) < percentComplete) {
+                updatePercentComplete(newState);
+              }
+            }}
+            wizardState={wizardState}
+          />
+        </div>
       </div>
-
-      <div className="Wizard--WizardStep--topInfo">
-        { description && (
-          <div className="Wizard--contentGroup Wizard--WizardStep--description">
-            { _.isString(description) ? <p>{description}</p> : description }
-          </div>
-        )}
-        { help && (
-          <div className="Wizard--contentGroup Wizard--WizardStep--help">
-            {_.isString(help) ? <p>{help}</p> : help}
-          </div>
-        )}
-      </div>
-
-      <div className="Wizard--contentGroup Wizard--WizardStep--component">
-        <Component
-          {...props}
-          setWizardState={(modifications) => {
-            const newState = setWizardState(modifications);
-
-            // this conditional updates the progress bar in 2 scenarios:
-            // a) oridnarily, steps update the progress bar once they are navigated away from so
-            // that progress only increases when the user actually moves to the next step (see
-            // Wizard.jumpToPage()). However, the final page must react to validity immediately to
-            // signal completion, so this causes the final page to update the percent complete
-            // upon input rather than solely upon navigation.
-            // b) pages immediately update the progress bar if they become invalid, so that the
-            // incompleteness of the form is reflected in the UI immediately.
-            if (currentStep === totalSteps - 1 || calculatePercentComplete(newState) < percentComplete) {
-              updatePercentComplete(newState);
-            }
-          }}
-          wizardState={wizardState}
-        />
-      </div>
-    </div>
-  );
+    );
+  }
 }
 
 WizardStep.propTypes = {


### PR DESCRIPTION
Had to use Javascript to detect whether or not the help text collapsed or not. This is now brittle to the width of the page.

Perhaps I should just do the movement in JS entirely... though that might be confusing to screen readers since the flow of the DOM would change?

### Before:

![screen shot 2016-11-30 at 18 36 55](https://cloud.githubusercontent.com/assets/1890926/20779860/0b569ee8-b72c-11e6-9785-1dfa443c85e1.png)

### After:

![screen shot 2016-11-30 at 18 36 42](https://cloud.githubusercontent.com/assets/1890926/20779859/0b54184e-b72c-11e6-9bcf-794550f787ee.png)

### Video:
![help-text-overflow](https://cloud.githubusercontent.com/assets/1890926/20805962/cf115ff4-b7ad-11e6-9285-ef1d89538c09.gif)
