### PR TITLE
Make sure button-like anchor controls have explicit block display styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.17.19",
+  "version": "0.17.20",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -26,6 +26,7 @@ a, button {
     border-bottom-width: @borderWidthL;
     box-sizing: border-box;
     cursor: pointer;
+    display: inline-block;
     font-family: "Proxima Nova";
     font-weight: 600;
     text-decoration: none;
@@ -124,7 +125,7 @@ a, button {
 
   /* Match surroundings even more. */
   &.Button--plain {
-    color: inherit;  
+    color: inherit;
     font-weight: inherit;
     text-align: inherit;
   }

--- a/src/TabBar/Tab.less
+++ b/src/TabBar/Tab.less
@@ -10,6 +10,7 @@
   box-sizing: border-box;
   color: @neutral_dark_gray;
   cursor: pointer;
+  display: inline-block;
   font-family: inherit;
   font-size: inherit;
   text-decoration: none;


### PR DESCRIPTION
Related: https://clever.atlassian.net/browse/FEE-18

Some browsers (correctly) ignore spacing/sizing styles for inline elements.
Set anchor buttons to `display: inline-block` to keep display consistent with the pure button counterparts.

[Patch bump to v0.17.20]

**Before:**
<img width="649" alt="screen shot 2016-12-15 at 1 53 10 pm" src="https://cloud.githubusercontent.com/assets/16216084/21243478/e42d345a-c2cd-11e6-97cc-cc7369182017.png">

**After:**
<img width="679" alt="screen shot 2016-12-15 at 1 53 24 pm" src="https://cloud.githubusercontent.com/assets/16216084/21243483/e838cdd4-c2cd-11e6-986e-e66385864cd0.png">
