### PR TITLE
[TabBar] Add transitions for tabbar size changes.

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,7 +3,7 @@
     "block-no-empty": null,
     "block-opening-brace-space-before": "always",
     "color-no-invalid-hex": true,
-    "declaration-colon-space-after": "always",
+    "declaration-colon-space-after": "always-single-line",
     "declaration-property-value-whitelist": [{
       "/color/": ["/@neutral_white/", "/@neutral_off_white/", "/@neutral_silver/", "/@neutral_gray/", "/@neutral_dark_gray/", "/@neutral_black/", "/@primary_blue/", "/@alert_green/", "/@alert_red/", "/@alert_orange/", "/@accent_aqua/", "/@accent_purple/", "/@accent_aqua/", "/@accent_pink/", "transparent" ]
     }],
@@ -13,7 +13,7 @@
     }],
     "no-duplicate-selectors": true,
     "selector-no-id": true,
-    "value-list-comma-newline-after": "never-multi-line",
+    "value-list-comma-newline-after": "always-multi-line",
     "unit-whitelist": ["em", "rem", "%", "s", "vh", "ms"],
   }
 }

--- a/src/TabBar/Tab.less
+++ b/src/TabBar/Tab.less
@@ -14,7 +14,12 @@
   font-family: inherit;
   font-size: inherit;
   text-decoration: none;
-  transition: background-color 0.25s ease-out, border-color 0.25s ease-out, color 0.25s ease-out;
+  transition:
+    background-color .25s ease-out,
+    border-color .25s ease-out,
+    color .25s ease-out,
+    margin .25s ease-out,
+    padding .25s ease-out;
 
   &:active,
   &:focus,

--- a/src/TabBar/TabBar.less
+++ b/src/TabBar/TabBar.less
@@ -2,6 +2,10 @@
 @import (reference) "../less/index";
 
 
+.TabBar {
+  transition: font-size .25s ease-out, box-shadow .25s ease-out;
+}
+
 .TabBar--small {
   .text--small;
   box-shadow: inset 0 -@tabBorderWidthSmall @neutral_silver;


### PR DESCRIPTION
Add transitions for the margin/padding and text size of the TabBar for use cases that involve switching the tab size (currently, in the apps-dashboard District Profile header).

![tabbar-transition-15](https://cloud.githubusercontent.com/assets/16216084/21373602/06e1a872-c6d5-11e6-8f32-64d75fecbc2d.gif)

(Would switch to using the `@transitionPromptly` constant, but want to do that later in a breaking revision, since it would require updating the header collapse transition to match. Might as well wait until we move the header into clever-components.)