### PR TITLE
Add new component styles to components.less

### DIFF
--- a/bin/new_component
+++ b/bin/new_component
@@ -7,7 +7,7 @@ NAME=$1
 IDX_FILE=../src/index.js
 SRC_FILE=../src/$NAME/$NAME.jsx
 LESS_FILE=../src/$NAME/$NAME.less
-LESS_IDX_FILE=../src/less/index.less
+LESS_COMPONENTS_FILE=../src/less/components.less
 TEST_FILE=../test/${NAME}_test.jsx
 
 # Error if directory cannot be created
@@ -23,8 +23,8 @@ sed "s/COMPONENT_NAME/$NAME/" ./example_component.jsx.txt > $SRC_FILE
 sed "s/COMPONENT_NAME/$NAME/" ./example_stylesheet.less.txt > $LESS_FILE
 sed "s/COMPONENT_NAME/$NAME/" ./example_test.jsx.txt > $TEST_FILE
 
-# Add styles to index.less
-echo "@import \"../$NAME/$NAME\";" >> $LESS_IDX_FILE
+# Add components styles to components.less
+echo "@import \"../$NAME/$NAME\";" >> $LESS_COMPONENTS_FILE
 
 GREEN='\033[0;32m'
 DEFAULT='\033[0m'


### PR DESCRIPTION
Update new_component script to match #87, which import component styles in components.less instead of index.less (which in turn imports components.less and utilities.less).

Tested locally by creating a new component and verifying it was added to components.less and that the other files are still created as expected.