### PR TITLE
Tweak TextArea component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextArea/TextArea.less
+++ b/src/TextArea/TextArea.less
@@ -25,6 +25,7 @@
   left: @size_s;
   opacity: 1;
   background-color: @neutral_white;
+  padding-right: @size_3xs;
 }
 
 .TextArea--required {

--- a/src/TextArea/TextArea.less
+++ b/src/TextArea/TextArea.less
@@ -44,6 +44,7 @@
   display: block;
   width: 100%;
   .border--s(transparent);
+  border-left: @size_none;
   .text--line-height-3;
   .padding--top--l;
   padding-left: @size_4xs;

--- a/src/TextArea/TextArea.less
+++ b/src/TextArea/TextArea.less
@@ -41,7 +41,15 @@
   display: block;
   width: 100%;
   .border--s(transparent);
+
+  /**
+   * Use a transparent border to position the TextArea input instead of padding or a margin because
+   *  1. Text is still visible in the padding region.
+   *  2. The underlying textarea element overwrites margin values when the user adjusts the
+   *     element's height.
+   */
   border-top-width: @size_l;
+
   .text--line-height-3;
   padding: @size_none;
   background-color: transparent;

--- a/src/TextArea/TextArea.less
+++ b/src/TextArea/TextArea.less
@@ -19,23 +19,23 @@
   top: @size_xs;
   width: 100%;
   color: @neutral_dark_gray;
+}
 
-  .TextArea--label {
-    left: @size_s;
-    opacity: 1;
-    background-color: @neutral_white;
-  }
+.TextArea--label {
+  left: @size_s;
+  opacity: 1;
+  background-color: @neutral_white;
+}
 
-  .TextArea--required {
-    position: absolute;
-    right: @size_l;
-  }
+.TextArea--required {
+  position: absolute;
+  right: @size_l;
+}
 
-  .TextArea--error {
-    color: @alert_red;
-    position: absolute;
-    right: @size_l;
-  }
+.TextArea--error {
+  color: @alert_red;
+  position: absolute;
+  right: @size_l;
 }
 
 .TextArea--input {

--- a/src/TextArea/TextArea.less
+++ b/src/TextArea/TextArea.less
@@ -23,6 +23,7 @@
   .TextArea--label {
     left: @size_s;
     opacity: 1;
+    background-color: @neutral_white;
   }
 
   .TextArea--required {
@@ -44,9 +45,11 @@
   .border--s(transparent);
   .text--line-height-3;
   .padding--top--l;
+  padding-left: @size_4xs;
   background-color: transparent;
   outline: none;
   resize: vertical;
+  box-sizing: border-box;
 }
 
 &.TextArea--placeholder-shown {
@@ -78,6 +81,10 @@
   .border--s(@neutral_silver);
   color: @neutral_dark_gray;
   background: @neutral_silver;
+
+  .TextArea--label {
+    background-color: @neutral_silver;
+  }
 
   .TextArea--input {
     background: transparent;

--- a/src/TextArea/TextArea.less
+++ b/src/TextArea/TextArea.less
@@ -2,7 +2,6 @@
 
 .TextArea {
   .padding--left--s;
-  .padding--top--3xs;
   .text--regular;
   .border--s(@neutral_silver);
   position: relative;
@@ -24,8 +23,6 @@
 .TextArea--label {
   left: @size_s;
   opacity: 1;
-  background-color: @neutral_white;
-  padding-right: @size_3xs;
 }
 
 .TextArea--required {
@@ -44,10 +41,9 @@
   display: block;
   width: 100%;
   .border--s(transparent);
-  border-left: @size_none;
+  border-top-width: @size_l;
   .text--line-height-3;
-  .padding--top--l;
-  padding-left: @size_4xs;
+  padding: @size_none;
   background-color: transparent;
   outline: none;
   resize: vertical;
@@ -63,9 +59,8 @@
   .TextArea--input {
     .text--small;
     .text--caps;
-    .padding--top--xs;
-    .text--line-height-3;
     color: @neutral_dark_gray;
+    border-top-width: @size_m;
   }
 }
 
@@ -83,14 +78,6 @@
   .border--s(@neutral_silver);
   color: @neutral_dark_gray;
   background: @neutral_silver;
-
-  .TextArea--label {
-    background-color: @neutral_silver;
-  }
-
-  .TextArea--input {
-    background: transparent;
-  }
 }
 
 &.TextArea--readonly {


### PR DESCRIPTION
This PR makes some small tweaks to the new `TextArea` component:

*Before*

<img width="526" alt="before" src="https://cloud.githubusercontent.com/assets/12616928/23180323/ebdf5bd2-f825-11e6-915e-434bacccd5bf.png">

*After*

<img width="523" alt="after-1" src="https://cloud.githubusercontent.com/assets/12616928/23181873/7d317e94-f82b-11e6-8c1c-36bc99f47818.png">
<img width="523" alt="after-2" src="https://cloud.githubusercontent.com/assets/12616928/23181881/8631736e-f82b-11e6-8340-39484105afd5.png">

Regarding the expander (in the bottom-right corner of the component), it isn't misaligned in the [demo](http://clever.github.io/components/#/components/text-area) because the demo page appears to apply `box-sizing: border-box` globally.

### Update

*Post PR Review GIF*

![updated](https://cloud.githubusercontent.com/assets/12616928/23191882/105adf5c-f855-11e6-8499-b181f85a1e50.gif)