### PR TITLE
Add readOnly option to Select component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ border-radius-styles:
 	@echo "Generating border-radius style definitions..."
 	@node genBorderRadius.js
 
-LINT_MAX_LESS_PROBLEMS := 184
+LINT_MAX_LESS_PROBLEMS := 178
 lint:
 	@echo "Linting files..."
 	@$(LINT) $(JS_FILES) $(JSX_FILES)

--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -16,6 +16,7 @@ export default class SelectView extends Component {
       clearable: false,
       disabled: false,
       multi: false,
+      readOnly: false,
       searchable: false,
       selectValue: null,
     };
@@ -39,6 +40,7 @@ export default class SelectView extends Component {
               clearable={this.state.clearable}
               searchable={this.state.searchable}
               multi={this.state.multi}
+              readOnly={this.state.readOnly}
               name="select"
               onChange={value => this.setState({selectValue: value})}
               options={_.range(100).map(i => ({label: \`Option \${i + 1}\`, value: \`\${i + 1}\`}))}
@@ -55,6 +57,7 @@ export default class SelectView extends Component {
               clearable={this.state.clearable}
               searchable={this.state.searchable}
               multi={this.state.multi}
+              readOnly={this.state.readOnly}
               name="select"
               onChange={value => this.setState({selectValue: value})}
               options={_.range(100).map(i => ({label: `Option ${i + 1}`, value: `${i + 1}`}))}
@@ -106,6 +109,15 @@ export default class SelectView extends Component {
             />
             {" "}
             Multi
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={this.state.readOnly}
+              onChange={({target}) => this.setState({readOnly: target.checked})}
+            />
+            {" "}
+            Read Only
           </label>
         </Example>
       </View>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -34,6 +34,7 @@ export function Select({
   optionRenderer,
   options,
   placeholder = "",
+  readOnly,
   searchable,
   value,
 }) {
@@ -44,15 +45,20 @@ export function Select({
     labelContainerClasses += ` ${cssClass.LABEL_HIDDEN}`;
   }
 
+  let reactSelectClasses = cssClass.REACT_SELECT;
+  if (readOnly) {
+    reactSelectClasses += ` ${cssClass.READ_ONLY}`;
+  }
+
   // The label container must be returned after the ReactSelect otherwise it does not get displayed
   // in the browser.
   return (
     <div className={cssClass.CONTAINER}>
       <div id={id}>
         <ReactSelect
-          className={cssClass.REACT_SELECT}
+          className={reactSelectClasses}
           clearable={clearable}
-          disabled={disabled}
+          disabled={disabled || readOnly}
           multi={multi}
           name={name}
           onChange={onChange}
@@ -76,6 +82,7 @@ Select.cssClass = {
   LABEL_CONTAINER: "Select--labelContainer",
   LABEL_HIDDEN: "Select--labelHidden",
   REACT_SELECT: "Select--ReactSelect",
+  READ_ONLY: "Select--readOnly",
 };
 
 const selectValuePropType = React.PropTypes.shape({
@@ -94,6 +101,7 @@ Select.propTypes = {
   optionRenderer: React.PropTypes.func,
   options: React.PropTypes.arrayOf(selectValuePropType),
   placeholder: React.PropTypes.string,
+  readOnly: React.PropTypes.bool,
   searchable: React.PropTypes.bool,
   value: React.PropTypes.oneOfType([
     React.PropTypes.string,

--- a/src/Select/Select.less
+++ b/src/Select/Select.less
@@ -56,6 +56,7 @@
       .Select-value {
         .margin--top--2xs;
         .margin--left--2xs;
+        padding: @size_none;
         border-color: @neutral_silver;
         color: @neutral_black;
         line-height: @size_m;

--- a/src/Select/Select.less
+++ b/src/Select/Select.less
@@ -37,12 +37,25 @@
       }
     }
 
+    &.Select--readOnly {
+      .Select-control {
+        background-color: transparent;
+        border-color: transparent;
+      }
+      .Select-arrow {
+        display: none;
+      }
+    }
+
     &.Select--multi {
       .Select-control {
         .Select-multi-value-wrapper {
-          .padding--top--m;
+          .padding--y--xs;
           .padding--left--2xs;
+          .margin--top--s;
           .Select-value {
+            .margin--top--2xs;
+            .margin--left--2xs;
             border-color: @neutral_silver;
             color: @neutral_black;
             line-height: @size_m;

--- a/src/Select/Select.less
+++ b/src/Select/Select.less
@@ -4,116 +4,114 @@
 
 .Select--container {
   position: relative;
+}
 
-  .Select--labelContainer {
-    .text--tiny;
-    color: @neutral_dark_gray;
-    position: absolute;
-    text-transform: uppercase;
-    top: @size_xs;
-    width: 100%;
+.Select--labelContainer {
+  .text--tiny;
+  color: @neutral_dark_gray;
+  position: absolute;
+  text-transform: uppercase;
+  top: @size_xs;
+  width: 100%;
 
-    &.Select--labelHidden {
-      opacity: 0 !important;
-    }
+  &.Select--labelHidden {
+    opacity: 0 !important;
+  }
+}
 
-    .Select--label {
-      left: @size_s;
-      position: absolute;
+.Select--label {
+  left: @size_s;
+  position: absolute;
+}
+
+.Select--ReactSelect {
+  // overrides styles from the exact same selector in react-select's CSS
+  &.is-focused:not(.is-open) > .Select-control {
+    border-color: @neutral_silver;
+    box-shadow: inset @size_2xs 0 @primary_blue;
+    transition: box-shadow .25s ease-out;
+  }
+
+  &.is-disabled {
+    .Select-control {
+      background-color: @neutral_silver;
     }
   }
 
-  .Select--ReactSelect {
-    // overrides styles from the exact same selector in react-select's CSS
-    &.is-focused:not(.is-open) > .Select-control {
-      border-color: @neutral_silver;
-      box-shadow: inset @size_2xs 0 @primary_blue;
-      transition: box-shadow .25s ease-out;
-    }
-
-    &.is-disabled {
-      .Select-control {
-        background-color: @neutral_silver;
-      }
-    }
-
-    &.Select--readOnly {
-      .Select-control {
-        background-color: transparent;
-        border-color: transparent;
-      }
-      .Select-arrow {
-        display: none;
-      }
-    }
-
-    &.Select--multi {
-      .Select-control {
-        .Select-multi-value-wrapper {
-          .padding--y--xs;
-          .padding--left--2xs;
-          .margin--top--s;
-          .Select-value {
-            .margin--top--2xs;
-            .margin--left--2xs;
-            border-color: @neutral_silver;
-            color: @neutral_black;
-            line-height: @size_m;
-            .Select-value-icon {
-              background-color: @neutral_silver;
-              float: right;
-              border-color: @neutral_silver;
-            }
-            .Select-value-label {
-              background-color: @neutral_off_white;
-            }
-          }
-        }
-      }
-    }
-
+  &.Select--readOnly {
     .Select-control {
-      border-radius: 0px;
-      border-color: @neutral_silver;
-      height: @size_4xl;
+      background-color: transparent;
+      border-color: transparent;
+    }
+    .Select-arrow {
+      display: none;
+    }
+  }
 
-      .Select-placeholder {
-        .padding--left--s;
-        .padding--right--s;
-        .padding--top--xs;
-        .text--small;
-        line-height: @size_2xl;
-        text-transform: uppercase;
-      }
-
-      .Select-input {
-        position: absolute;
-      }
-
-      .Select-input,
+  &.Select--multi {
+    .Select-multi-value-wrapper {
+      .padding--y--xs;
+      .padding--left--2xs;
+      .margin--top--s;
       .Select-value {
-        .padding--left--s;
-        .text--medium;
-        line-height: @size_2xl;
-        top: @size_s;
-      }
-    }
-
-    // overrides styles from the exact same selector in react-select's CSS
-    .has-value.Select--single > .Select-control .Select-value .Select-value-label,
-    .has-value.is-pseudo-focused.Select--single > .Select-control .Select-value .Select-value-label{
-      color: @neutral_black
-    }
-
-    .Select-menu-outer {
-      border-radius: @size_none;
-      border-color: @neutral_silver;
-      .Select-option {
+        .margin--top--2xs;
+        .margin--left--2xs;
+        border-color: @neutral_silver;
         color: @neutral_black;
-        &.is-focused {
-          box-shadow: inset @size_2xs 0 @primary_blue;
+        line-height: @size_m;
+        .Select-value-icon {
+          background-color: @neutral_silver;
+          float: right;
+          border-color: @neutral_silver;
+        }
+        .Select-value-label {
           background-color: @neutral_off_white;
         }
+      }
+    }
+  }
+
+  .Select-control {
+    border-radius: 0px;
+    border-color: @neutral_silver;
+    height: @size_4xl;
+
+    .Select-placeholder {
+      .padding--left--s;
+      .padding--right--s;
+      .padding--top--xs;
+      .text--small;
+      line-height: @size_2xl;
+      text-transform: uppercase;
+    }
+
+    .Select-input {
+      position: absolute;
+    }
+
+    .Select-input,
+    .Select-value {
+      .padding--left--s;
+      .text--medium;
+      line-height: @size_2xl;
+      top: @size_s;
+    }
+  }
+
+  // overrides styles from the exact same selector in react-select's CSS
+  .has-value.Select--single > .Select-control .Select-value .Select-value-label,
+  .has-value.is-pseudo-focused.Select--single > .Select-control .Select-value .Select-value-label{
+    color: @neutral_black
+  }
+
+  .Select-menu-outer {
+    border-radius: @size_none;
+    border-color: @neutral_silver;
+    .Select-option {
+      color: @neutral_black;
+      &.is-focused {
+        box-shadow: inset @size_2xs 0 @primary_blue;
+        background-color: @neutral_off_white;
       }
     }
   }


### PR DESCRIPTION
**Overview:**

Unlike other components, the `Select` component doesn't have a `readOnly` option. This PR adds that option. It also makes some minor tweaks to the `Select` components spacing when the `multi` options is set. See the screenshots below for more details.

**Screenshots/GIFs:**

*Read-only, single*
<img width="454" alt="read-only-single" src="https://cloud.githubusercontent.com/assets/12616928/23233440/b76f37e4-f903-11e6-8494-b21964d1e017.png">

*Read-only, multi*
<img width="451" alt="read-only-multi" src="https://cloud.githubusercontent.com/assets/12616928/23233447/b9638974-f903-11e6-9bba-025c95db8be4.png">

*Multi spacing, before (note the lack of bottom padding)*
<img width="411" alt="mutli-spacing-before" src="https://cloud.githubusercontent.com/assets/12616928/23233459/c4c1cfb0-f903-11e6-88fe-5d6fc9497628.png">

*Multi spacing, after*
<img width="439" alt="multi-spacing-after" src="https://cloud.githubusercontent.com/assets/12616928/23233460/c5d61d34-f903-11e6-857f-0771d20de60b.png">

**Testing:**

Tested manually in Chrome and Safari.

**Roll Out:**

- [x] Updated docs
- [x] Incremented version
- [ ] Deployed updated docs (after merging)

## Update

Also removed the left padding from the selected values when the `multi` option is set:

*Left padding gone, standard*
<img width="441" alt="left-padding-gone" src="https://cloud.githubusercontent.com/assets/12616928/23235612/fa7fde06-f90a-11e6-9ab3-81807c59de3f.png">


*Left padding gone, read-only*
<img width="445" alt="left-padding-gone-read-only" src="https://cloud.githubusercontent.com/assets/12616928/23235613/fbb74782-f90a-11e6-9b2a-139c62395db0.png">