### PR TITLE
TextInput: allow type=email

### DIFF
--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -66,7 +66,8 @@ export class TextInput extends React.Component {
       inputNote = <span className="TextInput--error">{this.props.error}</span>;
     }
 
-    let type = (this.props.type === "password" && this.state.hidden) ? "password" : "text";
+    let type = (this.props.type === "email" || (this.props.type === "password" && this.state.hidden))
+      ? this.props.type : "text";
 
     return (
       <div className={wrapperClass}>


### PR DESCRIPTION
I'm building forms with email fields, and would like the input validation that comes "for free" with `<input type=email />` in HTML 5. 

Email is one of the few types (other than password) for the input element that makes sense as a text input: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input 

I'm open to whitelisting `search` and `url` too, but don't have concrete use cases for those right now.