### PR TITLE
Inline-block button to match base buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ConfirmationButton/ConfirmationButton.jsx
+++ b/src/ConfirmationButton/ConfirmationButton.jsx
@@ -28,7 +28,7 @@ export class ConfirmationButton extends React.Component {
     return (<ModalButton {...modalButtonProps} ref="modalButton">
       {this.props.children}
       <div className="ConfirmationButton--dialog-buttons">
-        <Button type="secondary" value="Cancel" onClick={this.handleCancel} />
+        <Button type="link" value="Cancel" onClick={this.handleCancel} />
         <Button {...confirmButtonProps} onClick={this.handleConfirm} />
       </div>
     </ModalButton>);

--- a/src/ConfirmationButton/ConfirmationButton.less
+++ b/src/ConfirmationButton/ConfirmationButton.less
@@ -5,3 +5,7 @@
     margin-right: 10px;
   }
 }
+
+.ModalButton {
+  display: inline-block;
+}


### PR DESCRIPTION
**Overview:**
ConfirmationButton was block element instead of inline-block giving it a different layout behavior from all other buttons. Also, default Cancel is now a link button.

**Screenshots/GIFs:**
Old - Two confirm buttons next to each other
![image](https://cloud.githubusercontent.com/assets/835698/23523644/9cf04a4a-ff3c-11e6-8233-7af20a871b26.png)

New - Two confirm buttons next to each other
![image](https://cloud.githubusercontent.com/assets/835698/23523677/b415b9da-ff3c-11e6-9086-d9292242e419.png)

Old - cancel button
![image](https://cloud.githubusercontent.com/assets/835698/23523690/ca2e7de2-ff3c-11e6-8d51-f806a4703caf.png)

New - cancel button
![image](https://cloud.githubusercontent.com/assets/835698/23523698/d4300590-ff3c-11e6-8ac3-c386b200caa3.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
