### PR TITLE
Add a Tooltip component

### DIFF
--- a/docs/components/PropDocumentation.jsx
+++ b/docs/components/PropDocumentation.jsx
@@ -1,0 +1,77 @@
+import classnames from "classnames";
+import React, {PropTypes, PureComponent} from "react";
+
+import {Table} from "src";
+
+import "./PropDocumentation.less";
+
+
+export default class PropDocumentation extends PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {};
+  }
+
+  render() {
+    const {Column} = Table;
+    const {cssClass} = PropDocumentation;
+    const {availableProps, className, title} = this.props;
+
+    return (
+      <div className={classnames(cssClass.CONTAINER, className)}>
+        <h3 className={cssClass.TITLE}>{title}</h3>
+        <Table
+          className={cssClass.TABLE}
+          data={availableProps}
+          rowIDFn={p => p.name}
+        >
+          <Column
+            id="name"
+            header={{content: "Prop Name"}}
+            cell={{renderer: p => p.name}}
+            noWrap
+          />
+          <Column
+            id="type"
+            header={{content: "Prop Type"}}
+            cell={{renderer: p => p.type}}
+            noWrap
+          />
+          <Column
+            id="description"
+            header={{content: "Description"}}
+            cell={{renderer: p => p.description}}
+          />
+          <Column
+            id="defaultValue"
+            header={{content: "Default Value"}}
+            cell={{renderer: p => p.defaultValue || "None"}}
+            noWrap
+          />
+        </Table>
+      </div>
+    );
+  }
+}
+
+PropDocumentation.propTypes = {
+  availableProps: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    defaultValue: PropTypes.string,
+  })),
+  className: PropTypes.string,
+  title: PropTypes.string,
+};
+
+PropDocumentation.defaultProps = {
+  title: "Props:",
+};
+
+PropDocumentation.cssClass = {
+  CONTAINER: "PropDocumentation",
+  TABLE: "PropDocumentation--table",
+  TITLE: "PropDocumentation--title",
+};

--- a/docs/components/PropDocumentation.less
+++ b/docs/components/PropDocumentation.less
@@ -1,0 +1,11 @@
+@import (reference) "~less/index";
+
+
+.PropDocumentation {
+  max-width: 60rem;
+}
+
+.PropDocumentation--title {
+  .margin--none;
+  .margin--bottom--m;
+}

--- a/docs/components/SideBar/SideBar.jsx
+++ b/docs/components/SideBar/SideBar.jsx
@@ -39,6 +39,7 @@ export default function SideBar({className}) {
         <NavLink href="/components/table">Table</NavLink>
         <NavLink href="/components/text-area">TextArea</NavLink>
         <NavLink href="/components/text-input">TextInput</NavLink>
+        <NavLink href="/components/tooltip">Tooltip</NavLink>
         <NavLink href="/components/wizard">Wizard</NavLink>
       </NavGroup>
       <NavGroup title="LESS">

--- a/docs/components/TooltipView.jsx
+++ b/docs/components/TooltipView.jsx
@@ -1,0 +1,193 @@
+import _ from "lodash";
+import classnames from "classnames";
+import loremIpsum from "lorem-ipsum";
+import React, {Component} from "react";
+
+import Example from "./Example";
+import PropDocumentation from "./PropDocumentation";
+import View from "./View";
+import {Button, SegmentedControl, Tooltip} from "src";
+
+import "./TooltipView.less";
+
+
+export default class TooltipView extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      placement: Tooltip.Placement.RIGHT,
+      textAlign: Tooltip.Align.LEFT,
+    };
+  }
+
+  render() {
+    const {cssClass} = TooltipView;
+    const {placement, textAlign} = this.state;
+
+    return (
+      <View className={cssClass.CONTAINER} title="Tooltip">
+        <Example
+          code={`
+            <div className={cssClass.EXAMPLE}>
+              Simple
+              {" "}
+              <Tooltip
+                content="Here is a simple tooltip."
+                placement={placement}
+                textAlign={textAlign}
+              >
+                <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
+              </Tooltip>
+            </div>
+            <div className={cssClass.EXAMPLE}>
+              HTML + long text
+              {" "}
+              <Tooltip
+                content={
+                  <div>
+                    Here is a tooltip with long text to demonstrate wrapping and HTML formatting.
+                    <br />
+                    <br />
+                    {loremIpsum({count: 3, units: "sentences"})}
+                  </div>
+                }
+                placement={placement}
+                textAlign={textAlign}
+              >
+                <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
+              </Tooltip>
+            </div>
+            <div className={cssClass.EXAMPLE}>
+              With focusable trigger
+              {" "}
+              <Tooltip
+                content="Tooltips can be triggered by focus as well."
+                placement={placement}
+                textAlign={textAlign}
+              >
+                <span
+                  className={classnames("fa fa-question-circle", cssClass.TRIGGER)}
+                  ref="focusableTrigger"
+                  tabIndex={0}
+                />
+              </Tooltip>
+            </div>
+          `}
+        >
+          <div className={cssClass.DEMO_CONTAINER}>
+            <div className={cssClass.EXAMPLE}>
+              Simple
+              {" "}
+              <Tooltip
+                content="Here is a simple tooltip."
+                placement={placement}
+                textAlign={textAlign}
+              >
+                <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
+              </Tooltip>
+            </div>
+            <div className={cssClass.EXAMPLE}>
+              HTML + long text
+              {" "}
+              <Tooltip
+                content={
+                  <div>
+                    Here is a tooltip with long text to demonstrate wrapping and HTML formatting.
+                    <br />
+                    <br />
+                    {loremIpsum({count: 3, units: "sentences"})}
+                  </div>
+                }
+                placement={placement}
+                textAlign={textAlign}
+              >
+                <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
+              </Tooltip>
+            </div>
+            <div className={cssClass.EXAMPLE}>
+              With focusable trigger
+              {" "}
+              <Tooltip
+                content="Tooltips can be triggered by focus as well."
+                placement={placement}
+                textAlign={textAlign}
+              >
+                <span
+                  className={classnames("fa fa-question-circle", cssClass.TRIGGER)}
+                  ref="focusableTrigger"
+                  tabIndex={0}
+                />
+              </Tooltip>
+            </div>
+          </div>
+          <div className={cssClass.CONFIG}>
+            Placement:
+            <SegmentedControl
+              className={cssClass.CONFIG_OPTIONS}
+              defaultValue={placement}
+              onSelect={value => this.setState({placement: value})}
+              options={_.map(Tooltip.Placement, p => ({content: p, value: p}))}
+            />
+          </div>
+          <div className={cssClass.CONFIG}>
+            Text alignment:
+            <SegmentedControl
+              className={cssClass.CONFIG_OPTIONS}
+              defaultValue={textAlign}
+              onSelect={value => this.setState({textAlign: value})}
+              options={_.map(Tooltip.Align, p => ({content: p, value: p}))}
+            />
+          </div>
+          <div className={cssClass.FOCUS_CONTROL}>
+            <Button
+              onClick={() => this.refs.focusableTrigger.focus()}
+              type="linkPlain"
+              value="Click to focus on tooltip trigger"
+            />
+          </div>
+        </Example>
+        <PropDocumentation
+          availableProps={[
+            {
+              name: "children",
+              type: "Node",
+              description:
+                "A single element to serve as a trigger for the tooltip. Must support " +
+                "passthrough props to work properly.",
+            },
+            {
+              name: "content",
+              type: "Node",
+              description: "The string or HTML tooltip content.",
+            },
+            {
+              name: "placement",
+              type: "Tooltip.Placement",
+              description: "Placement of the tooltip, relative to the trigger element.",
+              defaultValue: "Tooltip.Placement.RIGHT",
+            },
+            {
+              name: "textAlign",
+              type: "Tooltip.Align",
+              description: "Alignment of the tooltip text content.",
+              defaultValue: "Tooltip.Align.LEFT",
+            },
+          ]}
+          className={cssClass.PROPS}
+        />
+      </View>
+    );
+  }
+}
+
+TooltipView.cssClass = {
+  CONFIG_OPTIONS: "TooltipView--configOptions",
+  CONFIG: "TooltipView--config",
+  CONTAINER: "TooltipView",
+  DEMO_CONTAINER: "TooltipView--demoContainer",
+  EXAMPLE: "TooltipView--example",
+  FOCUS_CONTROL: "TooltipView--focusControl",
+  PROPS: "TooltipView--props",
+  TRIGGER: "TooltipView--tooltipTrigger",
+};

--- a/docs/components/TooltipView.less
+++ b/docs/components/TooltipView.less
@@ -1,0 +1,41 @@
+@import (reference) "~less/index";
+
+
+.TooltipView--example {
+  .margin--right--l;
+  display: inline-block;
+}
+
+.TooltipView--tooltipTrigger {
+  color: @neutral_gray;
+  cursor: pointer;
+  transition: color 150ms ease-out;
+
+  &:focus,
+  &:hover {
+    color: @neutral_dark_gray;
+    outline: 0;
+  }
+}
+
+.TooltipView--props {
+  .margin--top--l;
+}
+
+.TooltipView--config {
+  .text--caps;
+  .text--small;
+  .margin--right--l;
+  .margin--top--m;
+  display: inline-block;
+}
+
+.TooltipView--configOptions {
+  .margin--left--2xs;
+  display: inline-block;
+}
+
+.TooltipView--focusControl {
+  .margin--top--s;
+  .text--small;
+}

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -26,6 +26,7 @@ import TabBarView from "./components/TabBarView";
 import TableView from "./components/TableView";
 import TextAreaView from "./components/TextAreaView";
 import TextInputView from "./components/TextInputView";
+import TooltipView from "./components/TooltipView";
 import TypographyView from "./components/TypographyView";
 import UITextView from "./components/UITextView";
 import WizardView from "./components/WizardView";
@@ -59,6 +60,7 @@ render((
         <Route path="select(/*)" component={SelectView} />
         <Route path="tab-bar(/*)" component={TabBarView} />
         <Route path="text-area(/*)" component={TextAreaView} />
+        <Route path="tooltip" component={TooltipView} />
         <Route path="table(/*)" component={TableView} />
         <Route path="text-input(/*)" component={TextInputView} />
         <Route path="wizard(/*)" component={WizardView} />

--- a/package.json
+++ b/package.json
@@ -14,6 +14,14 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
+  "dependencies": {
+    "classnames": "^2.2.5",
+    "less": "^2.6.1",
+    "lodash": "^4.14.1",
+    "react-bootstrap": "^0.30.0",
+    "react-copy-to-clipboard": "^4.2.1",
+    "react-select": "^1.0.0-beta14"
+  },
   "devDependencies": {
     "autoprefixer": "^6.5.3",
     "babel-cli": "~6.0.0",
@@ -26,15 +34,19 @@
     "babel-preset-es2015": "~6.6.0",
     "babel-preset-react": "~6.5.0",
     "babel-register": "~6.7.2",
+    "css-loader": "^0.23.1",
     "enzyme": "^2.2.0",
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^6.2.0",
     "eslint-import-resolver-webpack": "^0.7.0",
     "eslint-plugin-react": "^4.2.3",
     "extract-text-webpack-plugin": "^1.0.1",
+    "file-loader": "^0.8.5",
     "ignore-styles": "^5.0.1",
     "jsdom": "^8.4.0",
     "jsdom-global": "^1.7.0",
+    "jsx-loader": "^0.13.2",
+    "less-loader": "^2.2.3",
     "lorem-ipsum": "^1.0.3",
     "mocha": "^2.4.5",
     "postcss-loader": "^1.1.1",
@@ -44,24 +56,12 @@
     "react-dom": "~15.3.0",
     "react-router": "^3.0.0",
     "sinon": "^1.17.3",
-    "webpack": "^1.12.14",
-    "webpack-dev-server": "^1.14.1"
+    "style-loader": "^0.13.0",
+    "url-loader": "^0.5.7",
+    "webpack": "^1.13.2",
+    "webpack-dev-server": "^1.16.1"
   },
   "scripts": {
     "dev-server": "node_modules/.bin/webpack-dev-server --content-base docs/ --inline --watch"
-  },
-  "dependencies": {
-    "classnames": "^2.2.5",
-    "css-loader": "^0.23.1",
-    "file-loader": "^0.8.5",
-    "jsx-loader": "^0.13.2",
-    "less": "^2.6.1",
-    "less-loader": "^2.2.3",
-    "lodash": "^4.14.1",
-    "react-copy-to-clipboard": "^4.2.1",
-    "react-select": "^1.0.0-beta14",
-    "style-loader": "^0.13.0",
-    "stylelint-webpack-plugin": "^0.4.0",
-    "url-loader": "^0.5.7"
   }
 }

--- a/src/Tooltip/ReactBootstrapTooltip.less
+++ b/src/Tooltip/ReactBootstrapTooltip.less
@@ -1,0 +1,212 @@
+/* stylelint-disable unit-whitelist */
+/*!
+ * Bootstrap v3.3.7 (http://getbootstrap.com)
+ * Copyright 2011-2016 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+
+/*!
+ * Generated using the Bootstrap Customizer
+ * (http://getbootstrap.com/customize/?id=783806bb63dc8616a5f2e0e3224030c4)
+ */
+/*!
+ * Bootstrap v3.3.7 (http://getbootstrap.com)
+ * Copyright 2011-2016 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+
+@import (reference) "../less/index";
+
+.fade {
+  opacity: 0;
+  -webkit-transition: opacity 0.15s linear;
+  -o-transition: opacity 0.15s linear;
+  transition: opacity 0.15s linear;
+}
+
+.fade.in {
+  opacity: 1;
+}
+
+.tooltip {
+  position: absolute;
+  z-index: 1070;
+  display: block;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  letter-spacing: normal;
+  line-break: auto;
+  line-height: 1.42857143;
+  text-align: left;
+  text-align: start;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  white-space: normal;
+  word-break: normal;
+  word-spacing: normal;
+  word-wrap: normal;
+  font-size: 12px;
+  opacity: 0;
+  filter: alpha(opacity=0);
+}
+
+.tooltip.in {
+  opacity: 0.9;
+  filter: alpha(opacity=90);
+}
+
+.tooltip.top {
+  margin-top: -3px;
+  padding: 5px 0;
+}
+
+.tooltip.right {
+  margin-left: 3px;
+  padding: 0 5px;
+}
+
+.tooltip.bottom {
+  margin-top: 3px;
+  padding: 5px 0;
+}
+
+.tooltip.left {
+  margin-left: -3px;
+  padding: 0 5px;
+}
+
+.tooltip-inner {
+  max-width: 200px;
+  padding: 3px 8px;
+  color: @neutral_white;
+  text-align: center;
+  background-color: @neutral_black;
+  border-radius: 4px;
+}
+
+.tooltip-arrow {
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+}
+
+.tooltip.top .tooltip-arrow {
+  bottom: 0;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px 5px 0;
+  border-top-color: @neutral_black;
+}
+
+.tooltip.top-left .tooltip-arrow {
+  bottom: 0;
+  right: 5px;
+  margin-bottom: -5px;
+  border-width: 5px 5px 0;
+  border-top-color: @neutral_black;
+}
+
+.tooltip.top-right .tooltip-arrow {
+  bottom: 0;
+  left: 5px;
+  margin-bottom: -5px;
+  border-width: 5px 5px 0;
+  border-top-color: @neutral_black;
+}
+
+.tooltip.right .tooltip-arrow {
+  top: 50%;
+  left: 0;
+  margin-top: -5px;
+  border-width: 5px 5px 5px 0;
+  border-right-color: @neutral_black;
+}
+
+.tooltip.left .tooltip-arrow {
+  top: 50%;
+  right: 0;
+  margin-top: -5px;
+  border-width: 5px 0 5px 5px;
+  border-left-color: @neutral_black;
+}
+
+.tooltip.bottom .tooltip-arrow {
+  top: 0;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 0 5px 5px;
+  border-bottom-color: @neutral_black;
+}
+
+.tooltip.bottom-left .tooltip-arrow {
+  top: 0;
+  right: 5px;
+  margin-top: -5px;
+  border-width: 0 5px 5px;
+  border-bottom-color: @neutral_black;
+}
+
+.tooltip.bottom-right .tooltip-arrow {
+  top: 0;
+  left: 5px;
+  margin-top: -5px;
+  border-width: 0 5px 5px;
+  border-bottom-color: @neutral_black;
+}
+
+.clearfix:before,
+.clearfix:after {
+  content: " ";
+  display: table;
+}
+
+.clearfix:after {
+  clear: both;
+}
+
+.center-block {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.pull-right {
+  float: right !important;
+}
+
+.pull-left {
+  float: left !important;
+}
+
+.hide {
+  display: none !important;
+}
+
+.show {
+  display: block !important;
+}
+
+.invisible {
+  visibility: hidden;
+}
+
+.text-hide {
+  font: 0/0 a;
+  color: transparent;
+  text-shadow: none;
+  background-color: transparent;
+  border: 0;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.affix {
+  position: fixed;
+}

--- a/src/Tooltip/Tooltip.jsx
+++ b/src/Tooltip/Tooltip.jsx
@@ -1,0 +1,72 @@
+import _ from "lodash";
+
+import classnames from "classnames";
+import BootstrapTooltip from "react-bootstrap/lib/Tooltip";
+import OverlayTrigger from "react-bootstrap/lib/OverlayTrigger";
+import React, {Component, PropTypes} from "react";
+
+require("./Tooltip.less");
+
+
+/**
+ * Standardized tooltip component with fade-in/out transition and customizable positioning.
+ */
+export default class Tooltip extends Component {
+  constructor(props) {
+    super(props);
+
+    // react-bootstrap Tooltips require an id. We simply autogenerate them with sequential numbers.
+    this.id = `Tooltip-${Tooltip.nextID++}`;
+  }
+
+  render() {
+    const {cssClass} = Tooltip;
+    const {children, content, placement, textAlign} = this.props;
+
+    const tooltip = (
+      <BootstrapTooltip id={this.id}>
+        <div className={classnames(cssClass.CONTENT, `${cssClass.CONTENT}--${textAlign}`)}>
+          {content}
+        </div>
+      </BootstrapTooltip>
+    );
+
+    return (
+      <OverlayTrigger overlay={tooltip} placement={placement}>
+        {children}
+      </OverlayTrigger>
+    );
+  }
+}
+
+Tooltip.nextID = 0;
+
+Tooltip.Align = {
+  CENTER: "center",
+  JUSTIFY: "justify",
+  LEFT: "left",
+  RIGHT: "right",
+};
+
+Tooltip.Placement = {
+  BOTTOM: "bottom",
+  LEFT: "left",
+  RIGHT: "right",
+  TOP: "top",
+};
+
+Tooltip.propTypes = {
+  children: PropTypes.node.isRequired,
+  content: PropTypes.node.isRequired,
+  placement: PropTypes.oneOf(_.values(Tooltip.Placement)),
+  textAlign: PropTypes.oneOf(_.values(Tooltip.Align)),
+};
+
+Tooltip.defaultProps = {
+  placement: "top",
+  textAlign: "left",
+};
+
+Tooltip.cssClass = {
+  CONTENT: "Tooltip--content",
+};

--- a/src/Tooltip/Tooltip.less
+++ b/src/Tooltip/Tooltip.less
@@ -1,0 +1,29 @@
+@import "../less/index";
+
+@import "./ReactBootstrapTooltip";
+
+
+.Tooltip--content {
+  display: inline-block;
+  padding: 0;
+  .padding--y--xs;
+  word-break: break-all;
+  // Better breaking for webkit browsers (non-IE, basically):
+  word-break: break-word;
+}
+
+.Tooltip--content--center {
+  text-align: center;
+}
+
+.Tooltip--content--justify {
+  text-align: justify;
+}
+
+.Tooltip--content--left {
+  text-align: left;
+}
+
+.Tooltip--content--right {
+  text-align: right;
+}

--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -1,0 +1,3 @@
+import Tooltip from "./Tooltip";
+
+export {Tooltip};

--- a/src/index.js
+++ b/src/index.js
@@ -15,3 +15,4 @@ export {LeftNav} from "./LeftNav/LeftNav";
 export {Wizard} from "./Wizard/Wizard";
 export {ProgressBar} from "./ProgressBar/ProgressBar";
 export {TextArea} from "./TextArea/TextArea";
+export {Tooltip} from "./Tooltip";


### PR DESCRIPTION
**Jira:** https://clever.atlassian.net/browse/FEE-51

**Overview:**
Adding a new tooltip component - pre-requisite for the Label component (https://github.com/Clever/components/pull/130).

**Screenshots/GIFs:**
![tooltip](https://cloud.githubusercontent.com/assets/16216084/23591918/75d526a6-01ad-11e7-9af8-55d845dd315e.gif)

<img width="995" alt="screen shot 2017-03-05 at 2 16 25 pm" src="https://cloud.githubusercontent.com/assets/16216084/23591971/5ae37860-01ae-11e7-905d-08ea353ba38a.png">

**Testing:**
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
