### PR TITLE
remove height 100% table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table/Table.less
+++ b/src/Table/Table.less
@@ -7,7 +7,6 @@
   color: @neutral_black;
   font-family: "Proxima Nova";
   font-size: 0.875rem;
-  height: 100%;
   width: 100%;
 
   &.Table--fixed {


### PR DESCRIPTION
**Jira:**
none

**Overview:**
table height 100% causes tables in containers with height to stretch out in an ugly way.

**Screenshots/GIFs:**
Before

![screen shot 2017-03-09 at 18 51 48](https://cloud.githubusercontent.com/assets/1890926/23780113/b0c73c14-04f9-11e7-8bb3-f44b3c26d1cd.png)

After

![screen shot 2017-03-09 at 18 52 11](https://cloud.githubusercontent.com/assets/1890926/23780112/b0c5dbee-04f9-11e7-99cc-4f23787d1b78.png)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
