### PR TITLE
Don't create style.css file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ build: clean es5 styles docs
 styles:
 	@echo "Building stylesheet"
 	@$(WEBPACK) --config webpack_styles.config.js
-	@cp dist/css/style* dist/css/style.css
 
 sizing-styles:
 	@echo "Generating sizing style definitions..."


### PR DESCRIPTION
**Jira:**
[SEC-436](https://clever.atlassian.net/browse/sec-436)

**Overview:**
This change removes the `style.css` file, so that it doesn't get added to `https://assets.clever.com/design/style.css`, so that we can start caching all assets for a year in the users browsers (see https://github.com/Clever/ci-scripts/pull/23).

I can't tell anywhere were the `style.css` file is being used, so this *should* be a no-op.

**Roll Out:**
- Before merging:
  - [ ] Updated docs
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
