### PR TITLE
text-decoration none on tab hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TabBar/Tab.less
+++ b/src/TabBar/Tab.less
@@ -25,6 +25,7 @@
   &:focus,
   &:hover {
     outline: 0;
+    text-decoration: none;
   }
 
   &:focus,


### PR DESCRIPTION
**Overview:**

Clever common sets `a:hover` to have `text-decoration: underline`, which causes tabs to also underline the text as well as the tab itself on hover. Explicitly say not to underline it, so that even on hover/focus states, the style remains the same. 

### Before

![screen shot 2017-03-14 at 16 49 00](https://cloud.githubusercontent.com/assets/1890926/23927314/2ad16b58-08d6-11e7-8a48-c0d6c970b566.png)
