### PR TITLE
Call onClick only if it exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.18.9",
+  "version": "0.18.10",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/LeftNav/LeftNav.jsx
+++ b/src/LeftNav/LeftNav.jsx
@@ -32,7 +32,9 @@ export class LeftNav extends React.Component {
         return React.cloneElement(child, {
           onClick: () => {
             this.setState({openNavGroup: null});
-            child.props.onClick();
+            if (child.props.onClick) {
+              child.props.onClick();
+            }
           },
         });
       }


### PR DESCRIPTION
In #135 we made it so you no longer needed to pass `onClick` to `NavItem`s. This caused this line of code to fail. Now we only try to call the `onClick` function if it exists. 

Verified this fix works. 