### PR TITLE
prevent nested prop values from being overwritten

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ConfirmationButton/ConfirmationButton.jsx
+++ b/src/ConfirmationButton/ConfirmationButton.jsx
@@ -29,6 +29,7 @@ export class ConfirmationButton extends React.Component {
     const modalButtonProps = propsFor(ModalButton, this.props);
     const confirmButtonProps = propsFor(Button, unprefixKeys(this.props, propPrefix));
     const wrapperClass = "ConfirmationButton--dialog-buttons";
+
     return (<ModalButton {...modalButtonProps} ref="modalButton">
       {this.props.children}
       <div className={classnames(wrapperClass, this.props.className)}>
@@ -44,10 +45,8 @@ ConfirmationButton.propTypes = Object.assign({},
   ModalButton.propTypes,
   {
     className: PropTypes.string,
-    confirmButtonType: Button.propTypes.type,
-    confirmButtonText: PropTypes.string,
     onConfirm: PropTypes.func,
-  }
+  },
 );
 
 ConfirmationButton.defaultProps = Object.assign({},

--- a/src/ModalButton/ModalButton.jsx
+++ b/src/ModalButton/ModalButton.jsx
@@ -4,6 +4,8 @@ import classnames from "classnames";
 import {Button, Modal} from "..";
 import {omitKeys, prefixKeys, propsFor, unprefixKeys} from "../utils";
 
+const hoistedProps = ["closeModal", "children"];
+
 export class ModalButton extends React.Component {
   constructor(props) {
     super(props);
@@ -22,7 +24,13 @@ export class ModalButton extends React.Component {
 
   render() {
     const buttonProps = propsFor(Button, this.props);
-    const modalProps = propsFor(Modal, unprefixKeys(this.props, "modal"));
+    const modalProps = Object.assign(
+      hoistedProps.reduce((props, key) => {
+        props[key] = this.props[key];
+        return props;
+      }, {}),
+      propsFor(Modal, unprefixKeys(this.props, "modal")),
+    );
 
     return (<div className={classnames("ModalButton", this.props.className)}>
       <Button
@@ -44,7 +52,7 @@ export class ModalButton extends React.Component {
 
 // inherit properties from Button and Modal except closeModal; don't prefix children,
 // but prefix the rest of Modal's keys.
-const modalPropTypes = prefixKeys(omitKeys(Modal.propTypes, "closeModal", "children"), "modal");
+const modalPropTypes = prefixKeys(omitKeys(Modal.propTypes, ...hoistedProps), "modal");
 ModalButton.propTypes = Object.assign({}, Button.propTypes, modalPropTypes, {
   children: Modal.propTypes.children,
   onClose: React.PropTypes.func, // not required; just closes modal otherwise

--- a/src/ModalButton/ModalButton.jsx
+++ b/src/ModalButton/ModalButton.jsx
@@ -4,7 +4,7 @@ import classnames from "classnames";
 import {Button, Modal} from "..";
 import {omitKeys, prefixKeys, propsFor, unprefixKeys} from "../utils";
 
-const hoistedProps = ["closeModal", "children"];
+const excludeModalProps = ["closeModal", "children"];
 
 export class ModalButton extends React.Component {
   constructor(props) {
@@ -24,13 +24,7 @@ export class ModalButton extends React.Component {
 
   render() {
     const buttonProps = propsFor(Button, this.props);
-    const modalProps = Object.assign(
-      hoistedProps.reduce((props, key) => {
-        props[key] = this.props[key];
-        return props;
-      }, {}),
-      propsFor(Modal, unprefixKeys(this.props, "modal")),
-    );
+    const modalProps = propsFor(Modal, unprefixKeys(this.props, "modal"));
 
     return (<div className={classnames("ModalButton", this.props.className)}>
       <Button
@@ -45,19 +39,26 @@ export class ModalButton extends React.Component {
           if (this.props.onClose) this.props.onClose();
           this.hideModal();
         }}
-      /> : null}
+      >{this.props.children}</Modal> : null}
     </div>);
   }
 }
 
 // inherit properties from Button and Modal except closeModal; don't prefix children,
 // but prefix the rest of Modal's keys.
-const modalPropTypes = prefixKeys(omitKeys(Modal.propTypes, ...hoistedProps), "modal");
-ModalButton.propTypes = Object.assign({}, Button.propTypes, modalPropTypes, {
-  children: Modal.propTypes.children,
-  onClose: React.PropTypes.func, // not required; just closes modal otherwise
-});
+const modalPropTypes = prefixKeys(omitKeys(Modal.propTypes, ...excludeModalProps), "modal");
+
+ModalButton.propTypes = Object.assign({},
+  Button.propTypes,
+  modalPropTypes,
+  {
+    children: Modal.propTypes.children,
+    onClose: React.PropTypes.func, // not required; just closes modal otherwise
+  }
+);
 
 // closeModal has no default, so no need to filter out of defaultProps
-ModalButton.defaultProps = Object.assign({}, Button.defaultProps,
-                                         prefixKeys(Modal.defaultProps, "modal"));
+ModalButton.defaultProps = Object.assign({},
+  Button.defaultProps,
+  prefixKeys(Modal.defaultProps, "modal")
+);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -46,7 +46,7 @@ export function unprefixKeys(obj, prefixToRemove, lowercaseFirst = true) {
       const newKey = lowercaseFirst ? sansPrefix.charAt(0).toLowerCase() +
         sansPrefix.slice(1) : sansPrefix;
       prev[newKey] = obj[key];
-    } else {
+    } else if (!prev[key]) { // prefixed prop values take precedence over un-prefixed
       prev[key] = obj[key];
     }
     return prev;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -37,7 +37,7 @@ export function prefixKeys(obj, prefix, capitalizeFirst = true) {
 /**
  * Returns a copy of obj (Object) with prefix (String) removed from the start of each key, if it is
  * present. Lowercases the first letter of the old key if lowercaseFirst (bool) is true AND the
- * old key begins with the prefix; if the prefix is not present, the key is preserved.
+ * old key begins with the prefix.
  */
 export function unprefixKeys(obj, prefixToRemove, lowercaseFirst = true) {
   return Object.keys(obj).reduce((prev, key) => {
@@ -46,8 +46,6 @@ export function unprefixKeys(obj, prefixToRemove, lowercaseFirst = true) {
       const newKey = lowercaseFirst ? sansPrefix.charAt(0).toLowerCase() +
         sansPrefix.slice(1) : sansPrefix;
       prev[newKey] = obj[key];
-    } else if (!prev[key]) { // prefixed prop values take precedence over un-prefixed
-      prev[key] = obj[key];
     }
     return prev;
   }, {});

--- a/test/ConfirmationButton_test.jsx
+++ b/test/ConfirmationButton_test.jsx
@@ -21,6 +21,25 @@ describe("ConfirmationButton", () => {
     assert.equal(dialog_buttons.find("button").length, 2);
     assert.equal(dialog_buttons.find("button").first().text(), "Cancel");
     assert.equal(dialog_buttons.find("button").last().text(), "Confirm");
+    assert.equal(dialog_buttons.find("Button").last().props().type, ConfirmationButton.defaultProps.confirmButtonType);
+  });
+
+  it("passes button types to the confirm button", () => {
+    const confirmButtonType = "destructive";
+    const confirmationButton = mount(
+      <ConfirmationButton value="Confirm pl0x" modalTitle="A title" confirmButtonType={confirmButtonType}>
+        <p>Hello</p>
+      </ConfirmationButton>
+    );
+    assert.equal(confirmationButton.find(ModalButton).length, 1);
+
+    confirmationButton.find("button").simulate("click"); // render the modal
+    const dialog_buttons = confirmationButton.find(".ConfirmationButton--dialog-buttons");
+    assert.equal(dialog_buttons.length, 1);
+    assert.equal(dialog_buttons.find("button").length, 2);
+    assert.equal(dialog_buttons.find("button").first().text(), "Cancel");
+    assert.equal(dialog_buttons.find("button").last().text(), "Confirm");
+    assert.equal(dialog_buttons.find("Button").last().props().type, confirmButtonType);
   });
 
   it("calls onClose if present when cancel button clicked", () => {


### PR DESCRIPTION
**Overview:**
Depending on the order of props provided to a component that leverages nested components, a nested property may be overwritten.

**Testing:**
- [x] Unit tests