### PR TITLE
Add custom actions for individual Wizard steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ to define the conditions under which their inputs are considered valid.
 | validate (required)    | Function  | Validates if the current step is complete. Provided `wizardState` as an argument, which this function is expected to examine for validity.         | None
 | help (optional)    | String or React Node | Help text to display for this step         | None
 | props (optional)    | Object | Props to provide to the component. If present, `wizardState` and `setWizardState` props are filtered out.         | {}
+| onComplete (optional) | Function | A custom action to be performed before navigating to the next step in the `Wizard`. The function should return a boolean. If it returns `false`, the `Wizard` won't navigate to the next step. The function is provided `wizardState` as an argument. | None
 
 
 ##### `wizardButton` shape:

--- a/docs/WizardExample.jsx
+++ b/docs/WizardExample.jsx
@@ -39,6 +39,14 @@ class ContactStep extends React.Component {
     return true;
   }
 
+  static onComplete(wizardState) {
+    alert(
+      "A custom action for the current step. We might, for example, want to save the phone " +
+      `number (${wizardState.phoneNumber}) entered on this page in a database right away.`
+    );
+    return true;
+  }
+
   render() {
     const {wizardState, setWizardState} = this.props;
     return (
@@ -157,6 +165,7 @@ export default class WizardExample extends React.Component {
         component: ContactStep,
         validate: ContactStep.validate,
         nextButtonValue: "Save contact",
+        onComplete: ContactStep.onComplete,
       },
       {
         title: "Review",

--- a/docs/WizardExample.jsx
+++ b/docs/WizardExample.jsx
@@ -39,7 +39,7 @@ class ContactStep extends React.Component {
     return true;
   }
 
-  static onComplete(wizardState) {
+  static onStepComplete(wizardState) {
     alert(
       "A custom action for the current step. We might, for example, want to save the phone " +
       `number (${wizardState.phoneNumber}) entered on this page in a database right away.`
@@ -165,7 +165,7 @@ export default class WizardExample extends React.Component {
         component: ContactStep,
         validate: ContactStep.validate,
         nextButtonValue: "Save contact",
-        onComplete: ContactStep.onComplete,
+        onStepComplete: ContactStep.onStepComplete,
       },
       {
         title: "Review",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -42,12 +42,12 @@ export class Wizard extends React.Component {
   }
 
   nextStepHandler() {
-    const {steps, onComplete} = this.props;
+    const {onComplete, steps} = this.props;
     const {currentStep, data} = this.state;
 
     // If an onComplete handler is provided for the current step, and it returns false, we won't
     // proceed to the next step.
-    if (steps[currentStep].onComplete && !steps[currentStep].onComplete(data)) {
+    if (steps[currentStep].onStepComplete && !steps[currentStep].onStepComplete(data)) {
       return;
     }
     if (currentStep === steps.length - 1) {
@@ -202,7 +202,7 @@ Wizard.propTypes = {
     validate: PropTypes.func.isRequired,
     help: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     props: PropTypes.object,
-    onComplete: PropTypes.func,
+    onStepComplete: PropTypes.func,
   })).isRequired,
   nextButtonValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   prevButtonValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -42,11 +42,19 @@ export class Wizard extends React.Component {
   }
 
   nextStepHandler() {
-    if (this.state.currentStep === this.props.steps.length - 1) {
-      this.props.onComplete(this.state.data);
+    const {steps, onComplete} = this.props;
+    const {currentStep, data} = this.state;
+
+    // If an onComplete handler is provided for the current step, and it returns false, we won't
+    // proceed to the next step.
+    if (steps[currentStep].onComplete && !steps[currentStep].onComplete(data)) {
       return;
     }
-    const nextStep = Math.min(this.state.currentStep + 1);
+    if (currentStep === steps.length - 1) {
+      onComplete(data);
+      return;
+    }
+    const nextStep = Math.min(currentStep + 1);
     this.jumpToStep(nextStep);
   }
 
@@ -194,6 +202,7 @@ Wizard.propTypes = {
     validate: PropTypes.func.isRequired,
     help: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     props: PropTypes.object,
+    onComplete: PropTypes.func,
   })).isRequired,
   nextButtonValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   prevButtonValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),


### PR DESCRIPTION
**Overview:**

This PR adds the ability to define custom actions for individual `Wizard` steps. For a project that I'm currently working on, I need to store data in Mongo at intermediate steps in a `Wizard`.

**Screenshots/GIFs:**

![wizard-update](https://cloud.githubusercontent.com/assets/12616928/24274279/79ee8a62-0fe4-11e7-89c0-b761cc714c82.gif)

**Roll Out:**
- Before merging:
  - [x] Updated docs
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)