### PR TITLE
Tweak Wizard onStepComplete handlers to be async

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ to define the conditions under which their inputs are considered valid.
 | validate (required)    | Function  | Validates if the current step is complete. Provided `wizardState` as an argument, which this function is expected to examine for validity.         | None
 | help (optional)    | String or React Node | Help text to display for this step         | None
 | props (optional)    | Object | Props to provide to the component. If present, `wizardState` and `setWizardState` props are filtered out.         | {}
-| onComplete (optional) | Function | A custom action to be performed before navigating to the next step in the `Wizard`. The function should return a boolean. If it returns `false`, the `Wizard` won't navigate to the next step. The function is provided `wizardState` as an argument. | None
+| onStepComplete (optional) | Function | A custom action to be performed before navigating to the next step in the `Wizard`. The function will be provided `wizardState` as an argument and should return a promise. The `Wizard` will only proceed to the next step if the returned promise resolves to a truthy value. | None
 
 
 ##### `wizardButton` shape:

--- a/docs/WizardExample.jsx
+++ b/docs/WizardExample.jsx
@@ -44,7 +44,9 @@ class ContactStep extends React.Component {
       "A custom action for the current step. We might, for example, want to save the phone " +
       `number (${wizardState.phoneNumber}) entered on this page in a database right away.`
     );
-    return true;
+
+    // onStepComplete must return a promise.
+    return Promise.resolve(true);
   }
 
   render() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.22.3",
+  "version": "0.23.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -42,14 +42,22 @@ export class Wizard extends React.Component {
   }
 
   nextStepHandler() {
+    const {steps} = this.props;
+    const {currentStep, data} = this.state;
+
+    // If an onStepComplete handler is provided for the current step, we will only proceed to the
+    // next step if the promise returned by the handler resolves to a truthy value.
+    if (steps[currentStep].onStepComplete) {
+      steps[currentStep].onStepComplete(data).then((success) => success && this.goToNextStep());
+      return;
+    }
+    this.goToNextStep();
+  }
+
+  goToNextStep() {
     const {onComplete, steps} = this.props;
     const {currentStep, data} = this.state;
 
-    // If an onComplete handler is provided for the current step, and it returns false, we won't
-    // proceed to the next step.
-    if (steps[currentStep].onStepComplete && !steps[currentStep].onStepComplete(data)) {
-      return;
-    }
     if (currentStep === steps.length - 1) {
       onComplete(data);
       return;


### PR DESCRIPTION
**Overview:** I recently introduced the ability to define custom actions for individual `Wizard` steps, what I'm calling `onStepComplete` handlers ([PR 144](https://github.com/Clever/components/pull/144)). I'm realizing that these `onStepComplete` handlers will often need to be asynchronous. I've updated the `Wizard` component to handle this asynchronicity.

**Testing:** Tested manually by modifying [this line of code](https://github.com/Clever/components/blob/dcc789b7070405989e2a09edd6222ae05913eb09/docs/WizardExample.jsx#L49).

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)