### PR TITLE
Table row hover tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ border-radius-styles:
 	@echo "Generating border-radius style definitions..."
 	@node genBorderRadius.js
 
-LINT_MAX_LESS_PROBLEMS := 141
+LINT_MAX_LESS_PROBLEMS := 140
 lint:
 	@echo "Linting files..."
 	@$(LINT) $(JS_FILES) $(JSX_FILES)

--- a/docs/components/TableView.jsx
+++ b/docs/components/TableView.jsx
@@ -7,10 +7,14 @@ import Example from "./Example";
 import View from "./View";
 import {Button, ModalButton, Table, TextInput} from "src";
 
+import "./TableView.less";
+
+
 export default class TableView extends PureComponent {
   constructor(props) {
     super(props);
     this.state = {
+      enableRowClick: true,
       tableFilter: "",
     };
   }
@@ -38,7 +42,7 @@ export default class TableView extends PureComponent {
 
   render() {
     const {cssClass} = TableView;
-    const {tableData} = this.state;
+    const {enableRowClick, tableData} = this.state;
 
     return (
       <View className={cssClass.CONTAINER} title="Table">
@@ -55,7 +59,10 @@ export default class TableView extends PureComponent {
               ref="table"
               onPageChange={page => console.log("Table page changed:", page)}
               onSortChange={sortState => console.log("Table sort changed:", sortState)}
-              onRowClick={(e, row) => console.log("Table row clicked:", row)}
+              onRowClick={enableRowClick
+                ? (e, row) => console.log("Table row clicked:", row)
+                : undefined
+              }
               onViewChange={data => console.log("New rows:", data.map(d => d.id))}
               paginated
               pageSize={9}
@@ -145,7 +152,10 @@ export default class TableView extends PureComponent {
               ref="table"
               onPageChange={page => console.log("Table page changed:", page)}
               onSortChange={sortState => console.log("Table sort changed:", sortState)}
-              onRowClick={(e, row) => console.log("Table row clicked:", row)}
+              onRowClick={enableRowClick
+                ? (e, row) => console.log("Table row clicked:", row)
+                : undefined
+              }
               onViewChange={data => console.log("Table view changed:", data.map(d => d.id))}
               paginated
               pageSize={9}
@@ -202,6 +212,15 @@ export default class TableView extends PureComponent {
               />
             </Table>
           </div>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={enableRowClick}
+              onChange={({target}) => this.setState({enableRowClick: target.checked})}
+            />
+            {" "}
+            Clickable rows (see console)
+          </label>
         </Example>
       </View>
     );
@@ -209,5 +228,6 @@ export default class TableView extends PureComponent {
 }
 
 TableView.cssClass = {
+  CONFIG: "TableView--config",
   CONTAINER: "TableView",
 };

--- a/docs/components/TableView.less
+++ b/docs/components/TableView.less
@@ -1,0 +1,12 @@
+@import (reference) "~less/index";
+
+
+.TableView--config {
+  .margin--y--s;
+  .margin--left--none;
+  .margin--right--xs;
+  .text--small;
+  cursor: pointer;
+  display: inline-block;
+  text-transform: uppercase;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -151,7 +151,7 @@ export class Table extends Component {
             <tr
               className={classnames(cssClass.ROW, onRowClick && cssClass.CLICKABLE_ROW)}
               key={rowIDFn(rowData)}
-              onClick={e => onRowClick(e, rowIDFn(rowData))}
+              onClick={e => onRowClick && onRowClick(e, rowIDFn(rowData))}
             >
               {columns.map(({props: col}) => (
                 <Cell className={col.cell.className} key={col.id} noWrap={col.noWrap}>
@@ -195,7 +195,6 @@ Table.defaultProps = {
   filter: () => true,
   onPageChange: () => {},
   onSortChange: () => {},
-  onRowClick: () => {},
   pageSize: DEFAULT_PAGE_SIZE,
 };
 

--- a/src/Table/Table.less
+++ b/src/Table/Table.less
@@ -1,6 +1,5 @@
-@import "../less/colors.less";
-@import "../less/fonts.less";
-@import "../less/sizing.less";
+@import "../less/index.less";
+
 
 .Table {
   border-collapse: collapse;
@@ -9,9 +8,10 @@
   font-size: 0.875rem;
   width: 100%;
 
-  &.Table--fixed {
-    table-layout: fixed;
-  }
+}
+
+&.Table--fixed {
+  table-layout: fixed;
 }
 
 .Table--no_data_cell {
@@ -20,12 +20,12 @@
   text-align: center;
 }
 
-.Table--body {
-  .Table--row {
-    border-bottom: @size_4xs solid @neutral_silver;
-    &.Table--clickable_row:hover {
-      .tint(background-color, @neutral_silver, 5);
-      cursor: pointer;
-    }
-  }
+.Table--row {
+  .border--bottom--s(@neutral_silver);
+  transition: background-color @timingImmediately ease-out;
+}
+
+&.Table--clickable_row:hover {
+  .tint(background-color, @neutral_silver, 5);
+  cursor: pointer;
 }

--- a/test/Table/Table_test.jsx
+++ b/test/Table/Table_test.jsx
@@ -241,7 +241,6 @@ describe("Table", () => {
     for (let i = 0; i < rows.length; i++) {
       const event = {};
       rows.at(i).simulate("click", event);
-      // rows.at(i).props().onClick();
       sinon.assert.calledWith(onRowClick, event, DATA[i].id);
     }
   });

--- a/test/Table/Table_test.jsx
+++ b/test/Table/Table_test.jsx
@@ -11,6 +11,7 @@ import Header from "../../src/Table/Header";
 import sortDirection from "../../src/Table/sortDirection";
 import {Table} from "../../src/Table/Table";
 
+
 const DATA = [{
   id: "item_1",
   name: "Item 1",
@@ -24,7 +25,6 @@ const DATA = [{
   name: "Item 3",
   description: "The third item.",
 }];
-
 
 describe("Table", () => {
   const {cssClass} = Table;
@@ -220,5 +220,29 @@ describe("Table", () => {
     assert.equal(footer.props().currentPage, 2, "Incorrect currrentPage prop value.");
     assert.equal(footer.props().numColumns, 2, "Incorrect numColumns prop value.");
     assert.equal(footer.props().numPages, DATA.length, "Incorrect numPages prop value.");
+  });
+
+  it("disables clickable rows if onRowClick is not specified", () => {
+    const table = newTable();
+    assert.equal(0, table.find(`.${cssClass.CLICKABLE_ROW}`).length);
+  });
+
+  it("enables clickable rows if onRowClick is specified", () => {
+    const table = newTable({onRowClick: sinon.stub()});
+    assert.equal(DATA.length, table.find(`.${cssClass.CLICKABLE_ROW}`).length);
+  });
+
+  it("invokes onRowClick with the selected row id", () => {
+    const onRowClick = sinon.stub();
+
+    const table = newTable({onRowClick});
+    const rows = table.find(`.${cssClass.CLICKABLE_ROW}`);
+
+    for (let i = 0; i < rows.length; i++) {
+      const event = {};
+      rows.at(i).simulate("click", event);
+      // rows.at(i).props().onClick();
+      sinon.assert.calledWith(onRowClick, event, DATA[i].id);
+    }
   });
 });


### PR DESCRIPTION
**Jira:** N/A

**Overview:**
- Remove hover state and pointer cursor when onRowClick isn't specified.
- Add slight transition to hover state so it's less jumpy.
- Add unit tests for onRowClick.

**Screenshots/GIFs:**
![https://gyazo.com/6c19fd66acdcabc6d35ba48b2c126001](https://i.gyazo.com/6c19fd66acdcabc6d35ba48b2c126001.gif)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
