### PR TITLE
Added a "DollarAmount" component for rendering dollar values

### DIFF
--- a/docs/components/DollarAmountView.jsx
+++ b/docs/components/DollarAmountView.jsx
@@ -77,7 +77,7 @@ export default class DollarAmountView extends Component {
             `}
           </CodeSample>
         </div>
-  
+
         <Example
           code={`
             <p>Base Value: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number}</DollarAmount></p>
@@ -89,7 +89,7 @@ export default class DollarAmountView extends Component {
           <p>Plus a smidge: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number + 0.3333}</DollarAmount></p>
           {this.renderConfig()}
         </Example>
-  
+
         <PropDocumentation
           availableProps={[
             {

--- a/docs/components/DollarAmountView.jsx
+++ b/docs/components/DollarAmountView.jsx
@@ -26,36 +26,36 @@ export default class DollarAmountView extends Component {
 
     return (
       <div className={cssClass.CONFIG_CONTAINER}>
-	<div className={cssClass.CONFIG}>
-	  Amount:
-	  <SegmentedControl
-	    className={cssClass.CONFIG_OPTIONS}
-	    onSelect={value => this.setState({number: value})}
-	    options={Object.keys(NumberOptions).map(n => ({content: n, value: NumberOptions[n]}))}
-	    value={number}
-	  />
-	</div>
-	<div className={cssClass.CONFIG}>
-	  Dollar Format:
-	  <SegmentedControl
-	    className={cssClass.CONFIG_OPTIONS}
-	    onSelect={value => this.setState({alwaysShowCents: value})}
-	    options={[
-	      {content: "Regular", value: "no"},
-	      {content: "Always Show Cents", value: "yes"},
-	    ]}
-	    value={alwaysShowCents}
-	  />
-	  <SegmentedControl
-	    className={cssClass.CONFIG_OPTIONS}
-	    onSelect={value => this.setState({zeroIsFree: value})}
-	    options={[
-	      {content: "Regular", value: "no"},
-	      {content: "Zero is 'Free'", value: "yes"},
-	    ]}
-	    value={zeroIsFree}
-	  />
-	</div>
+        <div className={cssClass.CONFIG}>
+          Amount:
+          <SegmentedControl
+            className={cssClass.CONFIG_OPTIONS}
+            onSelect={value => this.setState({number: value})}
+            options={Object.keys(NumberOptions).map(n => ({content: n, value: NumberOptions[n]}))}
+            value={number}
+          />
+        </div>
+        <div className={cssClass.CONFIG}>
+          Dollar Format:
+          <SegmentedControl
+            className={cssClass.CONFIG_OPTIONS}
+            onSelect={value => this.setState({alwaysShowCents: value})}
+            options={[
+              {content: "Regular", value: "no"},
+              {content: "Always Show Cents", value: "yes"},
+            ]}
+            value={alwaysShowCents}
+          />
+          <SegmentedControl
+            className={cssClass.CONFIG_OPTIONS}
+            onSelect={value => this.setState({zeroIsFree: value})}
+            options={[
+              {content: "Regular", value: "no"},
+              {content: "Zero is 'Free'", value: "yes"},
+            ]}
+            value={zeroIsFree}
+          />
+        </div>
       </div>
     );
   }

--- a/docs/components/DollarAmountView.jsx
+++ b/docs/components/DollarAmountView.jsx
@@ -1,0 +1,142 @@
+import React, {Component} from "react";
+
+import Example, {CodeSample} from "./Example";
+import PropDocumentation from "./PropDocumentation";
+import View from "./View";
+import {SegmentedControl} from "src";
+import {DollarAmount} from "src";
+
+import "./DollarAmountView.less";
+
+
+export default class DollarAmountView extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      number: DollarAmountView.NumberOptions.MANY,
+      alwaysShowCents: "no",
+      zeroIsFree: "no",
+    };
+  }
+
+  renderConfig() {
+    const {cssClass, NumberOptions} = DollarAmountView;
+    const {number, alwaysShowCents, zeroIsFree} = this.state;
+
+    return (
+      <div className={cssClass.CONFIG_CONTAINER}>
+	<div className={cssClass.CONFIG}>
+	  Amount:
+	  <SegmentedControl
+	    className={cssClass.CONFIG_OPTIONS}
+	    onSelect={value => this.setState({number: value})}
+	    options={Object.keys(NumberOptions).map(n => ({content: n, value: NumberOptions[n]}))}
+	    value={number}
+	  />
+	</div>
+	<div className={cssClass.CONFIG}>
+	  Dollar Format:
+	  <SegmentedControl
+	    className={cssClass.CONFIG_OPTIONS}
+	    onSelect={value => this.setState({alwaysShowCents: value})}
+	    options={[
+	      {content: "Regular", value: "no"},
+	      {content: "Always Show Cents", value: "yes"},
+	    ]}
+	    value={alwaysShowCents}
+	  />
+	  <SegmentedControl
+	    className={cssClass.CONFIG_OPTIONS}
+	    onSelect={value => this.setState({zeroIsFree: value})}
+	    options={[
+	      {content: "Regular", value: "no"},
+	      {content: "Zero is 'Free'", value: "yes"},
+	    ]}
+	    value={zeroIsFree}
+	  />
+	</div>
+      </div>
+    );
+  }
+
+  render() {
+    const {cssClass} = DollarAmountView;
+    let {number, alwaysShowCents, zeroIsFree} = this.state;
+
+    alwaysShowCents = alwaysShowCents === "yes";
+    zeroIsFree = zeroIsFree === "yes";
+
+    return (
+      <View className={cssClass.CONTAINER} title="DollarAmount" sourcePath="src/DollarAmount/DollarAmount.jsx">
+	<div className={cssClass.INTRO}>
+	  <p>Provides a convenient wrapper for displaying dollar values.</p>
+	  <CodeSample>
+	    {`
+	      import {DollarAmount} from "clever-components";
+	    `}
+	  </CodeSample>
+	</div>
+
+	<Example
+	  code={`
+	    <p>Base Value: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number}</DollarAmount></p>
+	    <p>Plus a smidge: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number + 0.3333}</DollarAmount></p>
+	  `}
+	  title="Defaults to not showing cents if the value is an integer, but showing cents if value is a float"
+	>
+	  <p>Base Value: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number}</DollarAmount></p>
+	  <p>Plus a smidge: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number + 0.3333}</DollarAmount></p>
+	  {this.renderConfig()}
+	</Example>
+
+	<PropDocumentation
+	  availableProps={[
+	    {
+	      name: "children",
+	      type: "number or string",
+	      description: "The number (or string representation thereof).",
+	      defaultValue: "0",
+	    },
+	    {
+	      name: "className",
+	      type: "string",
+	      description: "Optional additional classname to apply to the DollarAmount span.",
+	    },
+	    {
+	      name: "alwaysShowCents",
+	      type: "bool",
+	      description: "Always include two decimal points, even if the value is an integer",
+	      defaultValue: "false",
+	    },
+	    {
+	      name: "zeroIsFree",
+	      type: "bool",
+	      description: "A value of zero should be represented as the string 'Free'",
+	      defaultValue: "false",
+	    },
+	  ]}
+	  className={cssClass.PROPS}
+	/>
+      </View>
+    );
+  }
+}
+
+DollarAmountView.NumberOptions = {
+  ZERO: 0,
+  ONE: 1,
+  DECIMAL: 123.123415,
+  FEW: 500,
+  MANY: 51234,
+  LEGION: 92345678,
+};
+
+DollarAmountView.cssClass = {
+  CONFIG_CONTAINER: "DollarAmountView--configContainer",
+  CONFIG_OPTIONS: "DollarAmountView--configOptions",
+  CONFIG: "DollarAmountView--config",
+  CONTAINER: "DollarAmountView",
+  INTRO: "DollarAmountView--intro",
+  PROPS: "DollarAmountView--props",
+};

--- a/docs/components/DollarAmountView.jsx
+++ b/docs/components/DollarAmountView.jsx
@@ -69,55 +69,55 @@ export default class DollarAmountView extends Component {
 
     return (
       <View className={cssClass.CONTAINER} title="DollarAmount" sourcePath="src/DollarAmount/DollarAmount.jsx">
-	<div className={cssClass.INTRO}>
-	  <p>Provides a convenient wrapper for displaying dollar values.</p>
-	  <CodeSample>
-	    {`
-	      import {DollarAmount} from "clever-components";
-	    `}
-	  </CodeSample>
-	</div>
-
-	<Example
-	  code={`
-	    <p>Base Value: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number}</DollarAmount></p>
-	    <p>Plus a smidge: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number + 0.3333}</DollarAmount></p>
-	  `}
-	  title="Defaults to not showing cents if the value is an integer, but showing cents if value is a float"
-	>
-	  <p>Base Value: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number}</DollarAmount></p>
-	  <p>Plus a smidge: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number + 0.3333}</DollarAmount></p>
-	  {this.renderConfig()}
-	</Example>
-
-	<PropDocumentation
-	  availableProps={[
-	    {
-	      name: "children",
-	      type: "number or string",
-	      description: "The number (or string representation thereof).",
-	      defaultValue: "0",
-	    },
-	    {
-	      name: "className",
-	      type: "string",
-	      description: "Optional additional classname to apply to the DollarAmount span.",
-	    },
-	    {
-	      name: "alwaysShowCents",
-	      type: "bool",
-	      description: "Always include two decimal points, even if the value is an integer",
-	      defaultValue: "false",
-	    },
-	    {
-	      name: "zeroIsFree",
-	      type: "bool",
-	      description: "A value of zero should be represented as the string 'Free'",
-	      defaultValue: "false",
-	    },
-	  ]}
-	  className={cssClass.PROPS}
-	/>
+        <div className={cssClass.INTRO}>
+          <p>Provides a convenient wrapper for displaying dollar values.</p>
+          <CodeSample>
+            {`
+              import {DollarAmount} from "clever-components";
+            `}
+          </CodeSample>
+        </div>
+  
+        <Example
+          code={`
+            <p>Base Value: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number}</DollarAmount></p>
+            <p>Plus a smidge: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number + 0.3333}</DollarAmount></p>
+          `}
+          title="Defaults to not showing cents if the value is an integer, but showing cents if value is a float"
+        >
+          <p>Base Value: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number}</DollarAmount></p>
+          <p>Plus a smidge: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number + 0.3333}</DollarAmount></p>
+          {this.renderConfig()}
+        </Example>
+  
+        <PropDocumentation
+          availableProps={[
+            {
+              name: "children",
+              type: "number or string",
+              description: "The number (or string representation thereof).",
+              defaultValue: "0",
+            },
+            {
+              name: "className",
+              type: "string",
+              description: "Optional additional classname to apply to the DollarAmount span.",
+            },
+            {
+              name: "alwaysShowCents",
+              type: "bool",
+              description: "Always include two decimal points, even if the value is an integer",
+              defaultValue: "false",
+            },
+            {
+              name: "zeroIsFree",
+              type: "bool",
+              description: "A value of zero should be represented as the string 'Free'",
+              defaultValue: "false",
+            },
+          ]}
+          className={cssClass.PROPS}
+        />
       </View>
     );
   }

--- a/docs/components/DollarAmountView.less
+++ b/docs/components/DollarAmountView.less
@@ -1,0 +1,27 @@
+@import (reference) "~less/index";
+
+.DollarAmountView--intro {
+  .margin--bottom--xl;
+}
+
+.DollarAmountView--configContainer {
+  .margin--top--m;
+}
+
+.DollarAmountView--config {
+  .text--caps;
+  .text--small;
+
+  &:not(:last-child) {
+    .margin--bottom--s;
+  }
+}
+
+.DollarAmountView--configOptions {
+  .margin--left--2xs;
+  display: inline-block;
+}
+
+.DollarAmountView--props {
+  .margin--top--l;
+}

--- a/docs/components/SideBar/SideBar.jsx
+++ b/docs/components/SideBar/SideBar.jsx
@@ -28,7 +28,7 @@ export default function SideBar({className}) {
         <NavLink href="/components/confirmation-button">ConfirmationButton</NavLink>
         <NavLink href="/components/copyable-input">CopyableInput</NavLink>
         <NavLink href="/components/count">Count</NavLink>
-	<NavLink href="/components/dollar-amount">DollarValue</NavLink>
+        <NavLink href="/components/dollar-amount">DollarValue</NavLink>
         <NavLink href="/components/flex-box">FlexBox</NavLink>
         <NavLink href="/components/file-input">FileInput</NavLink>
         <NavLink href="/components/grid">Grid</NavLink>

--- a/docs/components/SideBar/SideBar.jsx
+++ b/docs/components/SideBar/SideBar.jsx
@@ -28,6 +28,7 @@ export default function SideBar({className}) {
         <NavLink href="/components/confirmation-button">ConfirmationButton</NavLink>
         <NavLink href="/components/copyable-input">CopyableInput</NavLink>
         <NavLink href="/components/count">Count</NavLink>
+	<NavLink href="/components/dollar-amount">DollarValue</NavLink>
         <NavLink href="/components/flex-box">FlexBox</NavLink>
         <NavLink href="/components/file-input">FileInput</NavLink>
         <NavLink href="/components/grid">Grid</NavLink>

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -7,6 +7,7 @@ import ColorsView from "./components/ColorsView";
 import ConfirmationButtonView from "./components/ConfirmationButtonView";
 import CopyableInputView from "./components/CopyableInputView";
 import CountView from "./components/CountView";
+import DollarAmountView from "./components/DollarAmountView";
 import FileInputView from "./components/FileInputView";
 import FlexBoxView from "./components/FlexBoxView";
 import GettingStartedView from "./components/GettingStartedView";
@@ -57,6 +58,7 @@ render((
         <Route path="confirmation-button(/*)" component={ConfirmationButtonView} />
         <Route path="copyable-input(/*)" component={CopyableInputView} />
         <Route path="count(/*)" component={CountView} />
+	<Route path="dollar-amount(/*)" component={DollarAmountView} />
         <Route path="flex-box(/*)" component={FlexBoxView} />
         <Route path="file-input(/*)" component={FileInputView} />
         <Route path="grid(/*)" component={GridView} />

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -58,7 +58,7 @@ render((
         <Route path="confirmation-button(/*)" component={ConfirmationButtonView} />
         <Route path="copyable-input(/*)" component={CopyableInputView} />
         <Route path="count(/*)" component={CountView} />
-	<Route path="dollar-amount(/*)" component={DollarAmountView} />
+	      <Route path="dollar-amount(/*)" component={DollarAmountView} />
         <Route path="flex-box(/*)" component={FlexBoxView} />
         <Route path="file-input(/*)" component={FileInputView} />
         <Route path="grid(/*)" component={GridView} />

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -58,7 +58,7 @@ render((
         <Route path="confirmation-button(/*)" component={ConfirmationButtonView} />
         <Route path="copyable-input(/*)" component={CopyableInputView} />
         <Route path="count(/*)" component={CountView} />
-	      <Route path="dollar-amount(/*)" component={DollarAmountView} />
+        <Route path="dollar-amount(/*)" component={DollarAmountView} />
         <Route path="flex-box(/*)" component={FlexBoxView} />
         <Route path="file-input(/*)" component={FileInputView} />
         <Route path="grid(/*)" component={GridView} />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.24.0",
+  "version": "0.23.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "clever-components",
   "version": "0.23.2",
+  "version": "0.24.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.23.2",
-  "version": "0.24.1",
+  "version": "0.24.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/DollarAmount/DollarAmount.jsx
+++ b/src/DollarAmount/DollarAmount.jsx
@@ -28,7 +28,7 @@ export default class DollarAmount extends PureComponent {
 
     return (
       <span className={classnames(cssClass.CONTAINER, className)}>
-	      {format(children, zeroIsFree, alwaysShowCents)}
+        {format(children, zeroIsFree, alwaysShowCents)}
       </span>
     );
   }

--- a/src/DollarAmount/DollarAmount.jsx
+++ b/src/DollarAmount/DollarAmount.jsx
@@ -1,0 +1,49 @@
+import classnames from "classnames";
+import numeral from "numeral";
+import React, {PropTypes, PureComponent} from "react";
+
+
+/**
+ * Provides consistent dollar value formatting (e.g. 4123456 -> $4,123,456)
+ */
+export default class DollarAmount extends PureComponent {
+  static format(number, zeroIsFree = false, alwaysShowCents = false) {
+    const rawNumber = parseFloat(number || 0);
+
+    if (isNaN(rawNumber)) {
+      throw new Error("A number is required.");
+    }
+
+    if (rawNumber === 0 && zeroIsFree) {
+      return "Free";
+    }
+
+    const format = alwaysShowCents ? "$0,0.00" : "$0,0[.]00";
+    return numeral(rawNumber).format(format);
+  }
+
+  render() {
+    const {cssClass, format} = DollarAmount;
+    const {children, className, zeroIsFree, alwaysShowCents} = this.props;
+
+    return (
+      <span className={classnames(cssClass.CONTAINER, className)}>
+	{format(children, zeroIsFree, alwaysShowCents)}
+      </span>
+    );
+  }
+}
+
+DollarAmount.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  className: PropTypes.string,
+  zeroIsFree: PropTypes.bool,
+  alwaysShowCents: PropTypes.bool,
+};
+
+DollarAmount.cssClass = {
+  CONTAINER: "DollarAmount",
+};

--- a/src/DollarAmount/DollarAmount.jsx
+++ b/src/DollarAmount/DollarAmount.jsx
@@ -28,7 +28,7 @@ export default class DollarAmount extends PureComponent {
 
     return (
       <span className={classnames(cssClass.CONTAINER, className)}>
-	{format(children, zeroIsFree, alwaysShowCents)}
+	      {format(children, zeroIsFree, alwaysShowCents)}
       </span>
     );
   }

--- a/src/DollarAmount/index.js
+++ b/src/DollarAmount/index.js
@@ -1,0 +1,3 @@
+import DollarAmount from "./DollarAmount";
+
+export default DollarAmount;

--- a/src/index.js
+++ b/src/index.js
@@ -27,3 +27,6 @@ export {FileInput} from "./FileInput/FileInput";
 export * from "./InfoPanel";
 export {Number};
 export {Count};
+
+import DollarAmount from "./DollarAmount";
+export {DollarAmount};

--- a/test/DollarAmount_test.jsx
+++ b/test/DollarAmount_test.jsx
@@ -1,0 +1,53 @@
+import assert from "assert";
+import React from "react";
+import {shallow} from "enzyme";
+
+import DollarAmount from "../src/DollarAmount";
+
+
+describe("DollarAmount", () => {
+  it("handles small integer amounts", () => {
+    assert.equal("$24", shallow(<DollarAmount>{24}</DollarAmount>).text());
+    assert.equal("$678", shallow(<DollarAmount>{678}</DollarAmount>).text());
+  });
+
+  it("handles larger interger amounts", () => {
+    assert.equal("$5,123", shallow(<DollarAmount>{5123}</DollarAmount>).text());
+    assert.equal("$6,789,345", shallow(<DollarAmount>{6789345}</DollarAmount>).text());
+  });
+
+  it("handles decimal amounts", () => {
+    assert.equal("$5.33", shallow(<DollarAmount>{5.3333333}</DollarAmount>).text());
+    assert.equal("$0.33", shallow(<DollarAmount>{1.0 / 3}</DollarAmount>).text());
+  });
+
+  it("handles cents appropriately", () => {
+    assert.equal("$5", shallow(<DollarAmount>{5}</DollarAmount>).text());
+    assert.equal("$5.00", shallow(<DollarAmount alwaysShowCents>{5}</DollarAmount>).text());
+    assert.equal("$5.33", shallow(<DollarAmount>{5.3333333}</DollarAmount>).text());
+    assert.equal("$5.33", shallow(<DollarAmount alwaysShowCents>{5.3333333}</DollarAmount>).text());
+  });
+
+  it("handles zero appropriately", () => {
+    assert.equal("$0", shallow(<DollarAmount>{0}</DollarAmount>).text());
+    assert.equal("$0.00", shallow(<DollarAmount alwaysShowCents>{0}</DollarAmount>).text());
+    assert.equal("Free", shallow(<DollarAmount zeroIsFree>{0}</DollarAmount>).text());
+  });
+
+  it("handles string number inputs", () => {
+    assert.equal("$5,123", shallow(<DollarAmount>5123</DollarAmount>).text());
+    assert.equal("$125.33", shallow(<DollarAmount>125.3333</DollarAmount>).text());
+    assert.equal("$0", shallow(<DollarAmount>0</DollarAmount>).text());
+  });
+
+  it("supports non-React formatting", () => {
+    assert.equal("$5,123", DollarAmount.format(5123));
+    assert.equal("$125.33", DollarAmount.format("125.333333"));
+    assert.equal("Free", DollarAmount.format(0, true));
+  });
+
+  it("throws for non-numeric input", () => {
+    assert.throws(() => shallow(<DollarAmount>nope</DollarAmount>));
+    assert.throws(() => DollarAmount.format("nope", true));
+  });
+});


### PR DESCRIPTION
**Jira:**
None

**Overview:**
It's useful to have a component that takes care of formatting currency values in a helpful and consistent way (1234 => $1,234; 0 => "Free"). This component does that. Similar to, but different than, the Number component.

**Screenshots/GIFs:**
![dollaramount](https://cloud.githubusercontent.com/assets/1316859/24537413/c3b82c36-1596-11e7-93f5-0a7872af33f8.gif)

**Testing:**
- [X] Unit tests
- Manual tests:
  - [X] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [X] Updated docs
  - [X] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
