### PR TITLE
Lazy table length unknown

### DIFF
--- a/docs/components/TableView.jsx
+++ b/docs/components/TableView.jsx
@@ -38,6 +38,9 @@ export default class TableView extends PureComponent {
       });
     }
     this.setState({tableData});
+    if (this._lazyTable) {
+      this._lazyTable.lazyReset();
+    }
   }
 
   render() {
@@ -47,10 +50,10 @@ export default class TableView extends PureComponent {
     const getDataLazily = async ({startingAfter, pageSize}) => {
       let start = 0;
       if (startingAfter != null) {
-        start = _.findIndex(tableData, r => r.id === startingAfter);
+        start = _.findIndex(tableData, r => r.id === startingAfter) + 1;
       }
       await new Promise(resolve => setTimeout(resolve, 1000));
-      return tableData.slice(start + 1, start + pageSize + 1);
+      return tableData.slice(start, start + pageSize);
     };
 
     return (
@@ -235,15 +238,16 @@ export default class TableView extends PureComponent {
         <Example
           code={`
             <Table
+              ref={t => {this._lazyTable = t;}}
               lazy
               getData={
                 async ({startingAfter, pageSize}) => {
                   let start = 0;
                   if (startingAfter != null) {
-                    start = _.findIndex(tableData, r => r.id === startingAfter);
+                    start = _.findIndex(tableData, r => r.id === startingAfter) + 1;
                   }
                   await new Promise(resolve => setTimeout(resolve, 1000));
-                  return tableData.slice(start + 1, start + pageSize + 1);
+                  return tableData.slice(start, start + pageSize);
                 }
               }
               numRows={tableData.length}
@@ -303,6 +307,7 @@ export default class TableView extends PureComponent {
           <h2>Lazy Table</h2>
           <div style={{marginTop: "20px"}}>
             <Table
+              ref={t => {this._lazyTable = t;}}
               lazy
               getData={getDataLazily}
               numRows={tableData.length}

--- a/src/Table/Footer.jsx
+++ b/src/Table/Footer.jsx
@@ -12,7 +12,7 @@ require("./Footer.less");
  * Pagination footer for the Table component.
  * Only rendered if there are at least 2 pages of data available.
  */
-export default function Footer({currentPage, numColumns, numPages, onPageChange, showLastPage, isLoading}) {
+export default function Footer({currentPage, numColumns, numPages, onPageChange, showLastPage, isLoading, lengthUnknown}) {
   const {cssClass, VISIBLE_PAGE_RANGE_SIZE} = Footer;
 
   const renderEllipsis = () => <span className={cssClass.ELLIPSIS}>&hellip;</span>;
@@ -25,7 +25,7 @@ export default function Footer({currentPage, numColumns, numPages, onPageChange,
     onPageChange(page);
   };
 
-  if (numPages < 2) {
+  if (numPages < 2 && !lengthUnknown) {
     return null;
   }
 
@@ -96,7 +96,8 @@ export default function Footer({currentPage, numColumns, numPages, onPageChange,
                 * Show ellipsis if there's at least one omitted page number between the end of the
                 * visible range and the last page number.
                 */}
-              {visibleRange[VISIBLE_PAGE_RANGE_SIZE - 1] < numPages - 1 && renderEllipsis()}
+              {(visibleRange[VISIBLE_PAGE_RANGE_SIZE - 1] < numPages - 1 || lengthUnknown) &&
+                renderEllipsis()}
               {/* Make sure the last page is always visible. */}
               {visibleRange[VISIBLE_PAGE_RANGE_SIZE - 1] < numPages && showLastPage && (
                 <Button
@@ -110,7 +111,7 @@ export default function Footer({currentPage, numColumns, numPages, onPageChange,
             </div>
             <Button
               className={cssClass.BUTTON_SCROLL}
-              disabled={currentPage === numPages}
+              disabled={currentPage === numPages && !lengthUnknown}
               onClick={() => selectPage(currentPage + 1, numPages)}
               type="linkPlain"
               value="Next"
@@ -129,6 +130,7 @@ Footer.propTypes = {
   numPages: PropTypes.number.isRequired,
   showLastPage: PropTypes.bool,
   isLoading: PropTypes.bool,
+  lengthUnknown: PropTypes.bool,
 };
 
 Footer.defaultProps = {

--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -25,10 +25,8 @@ export class Table extends Component {
           console.error(`Table: prop "${p}" may not be set if "lazy"`);
         }
       }
-      for (const p of ["getData"]) {
-        if (!props[p]) {
-          console.error(`Table: prop "${p}" must be set if "lazy"`);
-        }
+      if (!props.getData) {
+        console.error("Table: prop \"getData\" must be set if \"lazy\"");
       }
     } else {
       if (!props.data) {


### PR DESCRIPTION
**Overview:**
The lazy table is nice, but sometimes we want a lazy table and we don't even know how many total items will exist in the table. This adds support by that for handling the case where `numRows` isn't defined.

**Screenshots/GIFs:**
![lazy-table-2](https://cloud.githubusercontent.com/assets/184140/24781058/9b3809ce-1af1-11e7-973e-212a0ad2dbb5.gif)

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
