### PR TITLE
Add optional rowClassNameFn prop to Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ Table component supporting sorting, filtering and pagination.
 | pageSize (optional) | Number | The number of data rows to display on each page. | 10
 | paginated (optional) | Boolean | Whether or not to enable pagination. See `pageSize` | false
 | rowIDFn (required) | Function | Called with data for a single row. Should return the unique ID for that row. | None
+| rowClassNameFn (optional) | Function | Called with data with a single row. Returns an additional className for the row. | None
 
 **API**
 

--- a/docs/components/TableView.jsx
+++ b/docs/components/TableView.jsx
@@ -79,6 +79,7 @@ export default class TableView extends PureComponent {
               paginated
               pageSize={9}
               rowIDFn={r => r.id}
+              rowClassNameFn={r => r.age < 10 ? "additionalClass" : null}
             >
               <Table.Column
                 id="details"
@@ -172,6 +173,7 @@ export default class TableView extends PureComponent {
               paginated
               pageSize={9}
               rowIDFn={r => r.id}
+              rowClassNameFn={r => (r.age < 10 ? "additionalClass" : null)}
             >
               <Table.Column
                 id="details"
@@ -257,6 +259,7 @@ export default class TableView extends PureComponent {
               paginated
               pageSize={9}
               rowIDFn={r => r.id}
+              rowClassNameFn={r => r.age < 10 ? "additionalClass" : null}
             >
               <Table.Column
                 id="details"
@@ -317,6 +320,7 @@ export default class TableView extends PureComponent {
               paginated
               pageSize={9}
               rowIDFn={r => r.id}
+              rowClassNameFn={r => (r.age < 10 ? "additionalClass" : null)}
             >
               <Table.Column
                 id="details"

--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -247,6 +247,7 @@ export class Table extends Component {
       fixed,
       paginated,
       rowIDFn,
+      rowClassNameFn,
       onRowClick,
     } = this.props;
     const {cssClass} = Table;
@@ -271,7 +272,11 @@ export class Table extends Component {
             </tr>
           ) : displayedData.map(rowData =>
             <tr
-              className={classnames(cssClass.ROW, onRowClick && cssClass.CLICKABLE_ROW)}
+              className={classnames(
+                cssClass.ROW,
+                onRowClick && cssClass.CLICKABLE_ROW,
+                rowClassNameFn && rowClassNameFn(rowData)
+              )}
               key={rowIDFn(rowData)}
               onClick={e => onRowClick && onRowClick(e, rowIDFn(rowData))}
             >
@@ -314,6 +319,7 @@ Table.propTypes = {
   pageSize: PropTypes.number,
   paginated: PropTypes.bool,
   rowIDFn: PropTypes.func.isRequired,
+  rowClassNameFn: PropTypes.func,
 
   // these must all be set together
   lazy: PropTypes.bool,


### PR DESCRIPTION
Supports (optional) conditional row styling by applying a function that dynamically applies a new className to a `<tr>` based on the row data. Tested with `make dev-server` locally and verified that the expected data had the desired className with Inspect Element.

I chose not to apply more styles to the example/demo table since it's a pretty complex example already, and this is an optional prop not required in the general use case, but you can inspect the element and see the class name.