### PR TITLE
larger page buttons in Table footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.23.9",
+  "version": "0.23.10",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table/Footer.jsx
+++ b/src/Table/Footer.jsx
@@ -61,7 +61,8 @@ export default function Footer({currentPage, numColumns, numPages, onPageChange,
               className={cssClass.BUTTON_SCROLL}
               disabled={currentPage === 1}
               onClick={() => selectPage(currentPage - 1)}
-              type="linkPlain"
+              type="link"
+              size="small"
               value="Prev"
             />
             <div className={cssClass.PAGE_NUMBERS}>
@@ -71,7 +72,8 @@ export default function Footer({currentPage, numColumns, numPages, onPageChange,
                   className={cssClass.BUTTON_PAGE}
                   key={1}
                   onClick={() => selectPage(1)}
-                  type="linkPlain"
+                  type="link"
+                  size="small"
                   value="1"
                 />
               )}
@@ -88,7 +90,8 @@ export default function Footer({currentPage, numColumns, numPages, onPageChange,
                   )}
                   key={pageNumber}
                   onClick={() => selectPage(pageNumber)}
-                  type="linkPlain"
+                  type="link"
+                  size="small"
                   value={`${pageNumber}`}
                 />
               ))}
@@ -104,7 +107,8 @@ export default function Footer({currentPage, numColumns, numPages, onPageChange,
                   className={cssClass.BUTTON_PAGE}
                   key={numPages}
                   onClick={() => selectPage(numPages)}
-                  type="linkPlain"
+                  type="link"
+                  size="small"
                   value={`${numPages}`}
                 />
               )}
@@ -113,7 +117,8 @@ export default function Footer({currentPage, numColumns, numPages, onPageChange,
               className={cssClass.BUTTON_SCROLL}
               disabled={currentPage === numPages && !lengthUnknown}
               onClick={() => selectPage(currentPage + 1, numPages)}
-              type="linkPlain"
+              type="link"
+              size="small"
               value="Next"
             />
           </div>

--- a/src/Table/Footer.less
+++ b/src/Table/Footer.less
@@ -9,7 +9,6 @@
 }
 
 .Table--footer--cell {
-  font-size: @size_s;
   padding: @size_s;
   text-align: center;
   position: relative;


### PR DESCRIPTION
**Jira:** https://clever.atlassian.net/browse/CLASSROOMS-1450

**Overview:** The buttons to navigate through pages of the `Table` component are pretty small. Make them a bit bigger.

**Screenshots/GIFs:** 
This gif involves me tabbing through a page with the new table footer (initial), and then one with the old footer with smaller buttons for comparison.
![bigger-footer-buttons](https://cloud.githubusercontent.com/assets/918819/25158582/7dccdc0e-245e-11e7-8eb0-59670bde8deb.gif)
