### PR TITLE
Add transform-code-string.

### DIFF
--- a/docs/components/Example/ExampleCode.jsx
+++ b/docs/components/Example/ExampleCode.jsx
@@ -1,0 +1,17 @@
+import React, {PropTypes} from "react";
+
+
+/**
+ * ExampleCode allows you to specify what portion of code to reveal in the code
+ * window.
+ */
+export default function ExampleCode({children}) {
+  return <div>{children}</div>;
+}
+
+ExampleCode.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]).isRequired,
+};

--- a/docs/components/Example/index.js
+++ b/docs/components/Example/index.js
@@ -1,5 +1,6 @@
 import Example from "./Example";
+import ExampleCode from "./ExampleCode";
 import CodeSample from "./CodeSample";
 
 export default Example;
-export {CodeSample};
+export {CodeSample, ExampleCode};

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "babel-plugin-transform-object-assign": "~6.5.0",
     "babel-plugin-transform-object-rest-spread": "~6.8.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "~6.6.0",
     "babel-preset-react": "~6.5.0",
     "babel-preset-stage-3": "^6.22.0",

--- a/transform-code-string.js
+++ b/transform-code-string.js
@@ -1,0 +1,90 @@
+/**
+ * transform-code-string is a babel plugin that sets the `code` property of
+ * <Example> jsx elements to the code of its children as a string. If there is
+ * an ancestor <ExampleCode> element, the code of that element is used instead.
+ */
+
+
+/**
+ * getInnerCode returns the code inside the JSX element referred to by path.
+ */
+function getInnerCode(path) {
+  var start = path.node.openingElement.end + 1;
+  var end = path.node.closingElement.start;
+  return path.hub.file.code.slice(start, end);
+}
+
+module.exports = function TransformCodeString(babel) {
+  var t = babel.types;
+
+  /**
+   * exampleCodeRetriever looks for an <ExampleCode> element within path, and
+   * sets `state.code` to the inner code if it finds one.
+   */
+  var exampleCodeRetriever = {
+    JSXElement(path, state) {
+      if (!t.isJSXIdentifier(path.node.openingElement.name, {name: "ExampleCode"})) {
+        return;
+      }
+      if (t.isJSXIdentifier(path.node.openingElement.name, {name: "Example"})) {
+        /*
+         * If we encounter a nested <Example> element, stop the search. In
+         * (contrived) cases like
+         *   <Example>
+         *     <Example>
+         *       <ExampleCode>foo</ExampleCode>
+         *     </Example>
+         *   </Example>
+         * we want the outer example's code to be everything, but the inner
+         * example's code to be just "foo".
+         */
+        path.stop();
+        return;
+      }
+      state.code = getInnerCode(path);
+      path.stop();
+    },
+  };
+
+  /**
+   * hasCodeAttr returns true if the JSX element referred to by path has a
+   * property named `code`.
+   */
+  function hasCodeAttr(path) {
+    function isCodeAttr(a) {
+      return t.isJSXIdentifier(a.name, {name: "code"});
+    }
+    return path.node.openingElement.attributes.some(isCodeAttr);
+  }
+
+  return {
+    inherits: require("babel-plugin-syntax-jsx"),
+    visitor: {
+      JSXElement(path) {
+        if (!t.isJSXIdentifier(path.node.openingElement.name, {name: "Example"})) {
+          return;
+        }
+        if (hasCodeAttr(path)) {
+          // don't overwrite "code" property if it is set manually
+          return;
+        }
+
+        var code;
+        var s = {};
+        path.traverse(exampleCodeRetriever, s);
+        if (s.code) {
+          code = s.code;
+        } else {
+          code = getInnerCode(path);
+        }
+
+        path.node.openingElement.attributes.push(
+          t.jSXAttribute(
+            t.jSXIdentifier("code"),
+            t.jSXExpressionContainer(t.stringLiteral(code))
+          )
+        );
+      },
+    },
+  };
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const autoprefixer = require("autoprefixer");
 
 module.exports = {
-  entry: ["babel-polyfill", "./docs/docs.jsx"],
+  entry: "./docs/docs.jsx",
   output: {
     path: "docs",
     filename: "bundle.js",
@@ -35,7 +35,6 @@ module.exports = {
         exclude: /node_modules/,
         loader: "babel",
         query: {
-          presets: ["react", "es2015", "stage-3"],
           plugins: [`${__dirname}/transform-code-string`],
         },
       },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,7 @@ module.exports = {
         loader: "babel",
         query: {
           presets: ["react", "es2015", "stage-3"],
+          plugins: [`${__dirname}/transform-code-string`],
         },
       },
     ],


### PR DESCRIPTION
Adds a babel plugin to fill in the the `code` property on `<Example>` components so that we don't have to duplicate our code all over the place. If the `code` prop is set manually, then this plugin does nothing so you can still override the default behavior.

This PR doesn't actually remove any of the manually-set `code` props, I did that separately in https://github.com/Clever/components/pull/162.