### PR TITLE
docs: Remove unnecessary code prop in <Example>s.

### DIFF
--- a/docs/components/ButtonView.jsx
+++ b/docs/components/ButtonView.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {Link} from "react-router";
 
-import Example from "./Example";
+import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import {Button} from "src";
@@ -26,38 +26,22 @@ export default function ButtonView() {
         {" | "}
         <Link to="/components/modal-button">Modal Button</Link>
       </p>
-      <Example
-        title="Button Sizing"
-        code={`
-          <Button type="primary" size="large" value="Large" />
-          <Button type="primary" size="regular" value="Regular" />
-          <Button type="primary" size="small" value="Small" />
-        `}
-      >
+      <Example title="Button Sizing">
         <Button type="primary" size="large" value="Large" />
         <Button type="primary" size="regular" value="Regular" />
         <Button type="primary" size="small" value="Small" />
       </Example>
 
-      <Example
-        title="Button Types"
-        code={`
+      <Example title="Button Types">
+        <ExampleCode>
           <Button type="primary" value="Primary" />
           <Button type="secondary" value="Secondary" />
           <Button type="destructive" value="Destructive" />
           <Button disabled value="Disabled" />
           <Button type="link" href="http://clever.com" value="Link" />
           <Button disabled type="link" href="http://clever.com" value="Disabled Link" />
-          <Button type="linkPlain" href="http://google.com" value="plain link" />
-        `}
-      >
-        <Button type="primary" value="Primary" />
-        <Button type="secondary" value="Secondary" />
-        <Button type="destructive" value="Destructive" />
-        <Button disabled value="Disabled" />
-        <Button type="link" href="http://clever.com" value="Link" />
-        <Button disabled type="link" href="http://clever.com" value="Disabled Link" />
-        <Button type="linkPlain" href="http://google.com" value="Plain Link" />
+          <Button type="linkPlain" href="http://google.com" value="Plain Link" />
+        </ExampleCode>
         <p>
           Here is a <Button type="linkPlain" href="//google.com" value="plain link" /> with no
           margin/padding.
@@ -68,58 +52,14 @@ export default function ButtonView() {
         </p>
       </Example>
 
-      <Example
-        title="Button-as-Link"
-        code={`
-          <Button type="primary" href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />
-          <Button type="secondary" href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />
-          <Button type="destructive" href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />
-          <Button disabled href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />
-        `}
-      >
+      <Example title="Button-as-Link">
         <Button type="primary" href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />
         <Button type="secondary" href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />
         <Button type="destructive" href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />
         <Button disabled href="http://lmgtfy.com/?q=button-as-link" value="LMGTFY" />
       </Example>
 
-      <Example
-        title="Button with HTML content"
-        code={`
-          <Button type="primary" value={<span className="fa fa-search" />} />
-          <Button
-            type="destructive"
-            value={(
-              <div>
-                <span className="fa fa-trash" />
-                {" "}
-                Remove
-              </div>
-            )}
-          />
-          <Button
-            disabled
-            value={(
-              <div>
-                <span className="fa fa-spin fa-spinner" />
-                {" "}
-                Saving...
-              </div>
-            )}
-          />
-          <Button
-            href="http://wikipedia.org"
-            type="link"
-            value={(
-              <span>
-                <span className="fa fa-external-link" />
-                {" "}
-                Learn more
-              </span>
-            )}
-          />
-        `}
-      >
+      <Example title="Button with HTML content">
         <Button type="primary" value={<span className="fa fa-search" />} />
         <Button
           type="destructive"

--- a/docs/components/ConfirmationButtonView.jsx
+++ b/docs/components/ConfirmationButtonView.jsx
@@ -23,21 +23,7 @@ export default class ConfirmationButtonView extends Component {
           buttons when clicked.
         </p>
 
-        <Example
-          code={`
-            <ConfirmationButton
-              type="primary"
-              confirmButtonType="destructive"
-              modalTitle="Are you sure?"
-              onClick={() => console.log("ConfirmationButton: modal opened!")}
-              onClose={() => console.log("ConfirmationButton: modal closed!")}
-              onConfirm={() => console.log("ConfirmationButton: confirmed!")}
-              value="Submit for confirmation"
-            >
-              <p>This action requires confirmation. Please confirm!</p>
-            </ConfirmationButton>
-          `}
-        >
+        <Example>
           <ConfirmationButton
             type="primary"
             confirmButtonType="destructive"

--- a/docs/components/CopyableInputView.jsx
+++ b/docs/components/CopyableInputView.jsx
@@ -1,6 +1,6 @@
 import React, {Component} from "react";
 
-import Example from "./Example";
+import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import {CopyableInput} from "src";
@@ -32,39 +32,24 @@ export default class CopyableInputView extends Component {
           clipboard. Ideal for passwords and other secret keys.
         </p>
 
-        <Example
-          code={`
-            <CopyableInput
-              enableCopy
-              disabled={this.state.disabled}
-              required={this.state.required}
-              enableShow={this.state.obscured}
-              error={this.state.hasError ? "Enter a valid email address" : null}
-              type={this.state.obscured ? "password" : "text"}
-              label="CopyableInput Label"
-              name="CopyableInputName"
-              placeholder="CopyableInput Placeholder"
-              onChange={e => this.setState({inputValue: e.target.value})}
-              value={this.state.inputValue}
-              readOnly={this.state.readOnly}
-            />
-          `}
-        >
+        <Example>
           <div className={cssClass.INPUT_CONTAINER}>
-            <CopyableInput
-              enableCopy
-              disabled={this.state.disabled}
-              readOnly={this.state.readOnly}
-              required={this.state.required}
-              enableShow={this.state.obscured}
-              error={this.state.hasError ? "Enter a valid email address" : null}
-              type={this.state.obscured ? "password" : "text"}
-              label="CopyableInput Label"
-              name="CopyableInputName"
-              placeholder="CopyableInput Placeholder"
-              onChange={e => this.setState({inputValue: e.target.value})}
-              value={this.state.inputValue}
-            />
+            <ExampleCode>
+              <CopyableInput
+                enableCopy
+                disabled={this.state.disabled}
+                readOnly={this.state.readOnly}
+                required={this.state.required}
+                enableShow={this.state.obscured}
+                error={this.state.hasError ? "Enter a valid email address" : null}
+                type={this.state.obscured ? "password" : "text"}
+                label="CopyableInput Label"
+                name="CopyableInputName"
+                placeholder="CopyableInput Placeholder"
+                onChange={e => this.setState({inputValue: e.target.value})}
+                value={this.state.inputValue}
+              />
+            </ExampleCode>
           </div>
           <label className={cssClass.CONFIG}>
             <input

--- a/docs/components/CountView.jsx
+++ b/docs/components/CountView.jsx
@@ -1,7 +1,7 @@
 import React, {Component} from "react";
 import {Link} from "react-router";
 
-import Example, {CodeSample} from "./Example";
+import Example, {ExampleCode, CodeSample} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import {Count, SegmentedControl} from "src";
@@ -73,27 +73,27 @@ export default class CountView extends Component {
         </div>
 
         <Example
-          code={`
-            🐝 <Count short={shouldShorten} singular="bee">{number}</Count>
-          `}
           title="Defaults to the singular form with an appended 's' if no plural is given:"
         >
-          🐝 <Count short={shouldShorten} singular="bee">{number}</Count>
+          <ExampleCode>
+            🐝 <Count short={shouldShorten} singular="bee">{number}</Count>
+          </ExampleCode>
           {this.renderConfig()}
         </Example>
 
         <Example
-          code={`
-            🐝 <Count short={shouldShorten} singular="bee. 😐" plural="BEES!! 😱">{number}</Count>
-          `}
           title="A custom plural form can be specified:"
         >
-          🐝 <Count short={shouldShorten} singular="bee. 😐" plural="BEES!! 😱">{number}</Count>
+          <ExampleCode>
+            🐝 <Count short={shouldShorten} singular="bee. 😐" plural="BEES!! 😱">{number}</Count>
+          </ExampleCode>
           {this.renderConfig()}
         </Example>
 
         <Example
-          code={`
+          title="Specify `zeroOverride` to modify the text in the 0 case:"
+        >
+          <ExampleCode>
             🐝
             {" "}
             <Count
@@ -104,19 +104,7 @@ export default class CountView extends Component {
             >
               {number}
             </Count>
-          `}
-          title="Specify `zeroOverride` to modify the text in the 0 case:"
-        >
-          🐝
-          {" "}
-          <Count
-            short={shouldShorten}
-            singular="bee. 😐"
-            plural="BEES!! 😱"
-            zeroOverride="🚫😌"
-          >
-            {number}
-          </Count>
+          </ExampleCode>
           {this.renderConfig()}
         </Example>
 

--- a/docs/components/DatePickerView.jsx
+++ b/docs/components/DatePickerView.jsx
@@ -21,15 +21,7 @@ export default class DatePickerView extends Component {
     return (
       <View className={cssClass.CONTAINER} title="DatePicker" sourcePath="src/DatePicker/DatePicker.jsx">
         <p>DatePickers can be rendered simply, with an onClose action similar to modals and an onChange similar to buttons. Onchange values are returned as momentjs dates.</p>
-        <Example
-          code={`
-            {this.state.showPicker1 && <DatePicker
-              title="Pick a date"
-              onChange={(date) => console.log(date)}
-              onClose={() => this.setState({showPicker1: false})}
-            />}
-          `}
-        >
+        <Example>
           <Button value="Show Picker" type="primary" onClick={() => this.setState({showPicker1: true})} />
           {this.state.showPicker1 && <DatePicker
             title="Pick a date"
@@ -39,16 +31,7 @@ export default class DatePickerView extends Component {
         </Example>
 
         <p>The default date is today, but you can also pass in a string or Date object. You can also pass in a custom title.</p>
-        <Example
-          code={`
-            {this.state.showPicker2 && <DatePicker
-              title="Date in the past"
-              onChange={(date) => console.log(date)}
-              onClose={() => this.setState({showPicker2: false})}
-              value="3/12/2017"
-            />}
-          `}
-        >
+        <Example>
           <Button value="Show Picker" type="primary" onClick={() => this.setState({showPicker2: true})} />
           {this.state.showPicker2 && <DatePicker
             title="Date in the past"
@@ -59,39 +42,7 @@ export default class DatePickerView extends Component {
         </Example>
 
         <p>You have quite a bit of flexibility; you can pass in a React node to the title, add in a footer, or pass props directly to the datepicker for things like min/max dates.</p>
-        <Example
-          code={`
-            {this.state.showPicker3 && <DatePicker
-              title={(<div>Set Launch Date <FontAwesome name="question-circle" /> </div>)}
-              onChange={(date) => console.log(date)}
-              onClose={() => this.setState({showPicker3: false})}
-              footer={
-          <FlexBox className={cssClass.BUTTON_BAR} justify={Justify.BETWEEN}>
-            <FlexItem>
-              <Button
-                size="small"
-                type="link"
-                value="Launch Now"
-                onClick={()=>console.log("Launch Now")}
-              />
-            </FlexItem>
-            <FlexItem>
-              <Button
-                className={cssClass.RIGHT_BUTTON}
-                size="small"
-                type="primary"
-                value="Reschedule"
-                onClick={()=>console.log("Reschedule")}
-              />
-            </FlexItem>
-          </FlexBox>
-              }
-              datePickerProps={{
-          minDate: moment().add(1, "day"),
-          maxDate: moment().add(6, "months"),
-              }}
-          `}
-        >
+        <Example>
           <Button value="Show Picker" type="primary" onClick={() => this.setState({showPicker3: true})} />
           {this.state.showPicker3 && <DatePicker
             title={(<div>Set Launch Date <FontAwesome name="question-circle" /> </div>)}

--- a/docs/components/DollarAmountView.jsx
+++ b/docs/components/DollarAmountView.jsx
@@ -1,6 +1,6 @@
 import React, {Component} from "react";
 
-import Example, {CodeSample} from "./Example";
+import Example, {CodeSample, ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import {SegmentedControl} from "src";
@@ -79,14 +79,12 @@ export default class DollarAmountView extends Component {
         </div>
 
         <Example
-          code={`
-            <p>Base Value: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number}</DollarAmount></p>
-            <p>Plus a smidge: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number + 0.3333}</DollarAmount></p>
-          `}
           title="Defaults to not showing cents if the value is an integer, but showing cents if value is a float"
         >
-          <p>Base Value: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number}</DollarAmount></p>
-          <p>Plus a smidge: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number + 0.3333}</DollarAmount></p>
+          <ExampleCode>
+            <p>Base Value: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number}</DollarAmount></p>
+            <p>Plus a smidge: <DollarAmount alwaysShowCents={alwaysShowCents} zeroIsFree={zeroIsFree}>{number + 0.3333}</DollarAmount></p>
+          </ExampleCode>
           {this.renderConfig()}
         </Example>
 

--- a/docs/components/DropdownButtonView.jsx
+++ b/docs/components/DropdownButtonView.jsx
@@ -3,7 +3,7 @@ import Fade from "react-bootstrap/lib/Fade";
 import React, {Component} from "react";
 import {Link} from "react-router";
 
-import Example, {CodeSample} from "./Example";
+import Example, {CodeSample, ExampleCode} from "./Example";
 import Hello from "./DropdownButtonViewData";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
@@ -125,41 +125,26 @@ export default class DropdownButtonView extends Component {
           </CodeSample>
         </div>
 
-        <Example
-          code={`
-            <DropdownButton
-              disabled={disabled}
-              label="Say Hello"
-              onClick={() => this.say("Hello")}
-              size={size}
-              type={type}
-            >
-              {Object.keys(samples).map(countryCode => (
-                <Option key={countryCode} onClick={() => this.say(samples[countryCode].hello)}>
-                  {samples[countryCode].country}
-                </Option>
-              ))}
-            </DropdownButton>
-          `}
-          title="Basic Usage:"
-        >
+        <Example title="Basic Usage:">
           <Fade in={!goodbye} timeout={1000}>
             <span className={cssClass.HELLO}>{hello}</span>
           </Fade>
           <FlexBox alignItems={ItemAlign.CENTER}>
-            <DropdownButton
-              disabled={disabled}
-              label="Say Hello"
-              onClick={() => this.say("Hello")}
-              size={size}
-              type={type}
-            >
-              {Object.keys(samples).map(countryCode => (
-                <Option key={countryCode} onClick={() => this.say(samples[countryCode].hello)}>
-                  {samples[countryCode].country}
-                </Option>
-              ))}
-            </DropdownButton>
+            <ExampleCode>
+              <DropdownButton
+                disabled={disabled}
+                label="Say Hello"
+                onClick={() => this.say("Hello")}
+                size={size}
+                type={type}
+              >
+                {Object.keys(samples).map(countryCode => (
+                  <Option key={countryCode} onClick={() => this.say(samples[countryCode].hello)}>
+                    {samples[countryCode].country}
+                  </Option>
+                ))}
+              </DropdownButton>
+            </ExampleCode>
             <Button
               className={cssClass.MORE_SAMPLES}
               onClick={() => this.moreSamples()}
@@ -170,8 +155,8 @@ export default class DropdownButtonView extends Component {
           {this.renderConfig()}
         </Example>
 
-        <Example
-          code={`
+        <Example title="With Fixed Width:">
+          <ExampleCode>
             <DropdownButton
               className={cssClass.DROPDOWN_WIDTH_400PX}
               disabled={disabled}
@@ -184,26 +169,12 @@ export default class DropdownButtonView extends Component {
                 Secondary option labels will wrap if they are longer than the main one.
               </Option>
             </DropdownButton>
-          `}
-          title="With Fixed Width:"
-        >
-          <DropdownButton
-            className={cssClass.DROPDOWN_WIDTH_400PX}
-            disabled={disabled}
-            label="A really really long label"
-            size={size}
-            type={type}
-          >
-            <Option>Another really really long label.</Option>
-            <Option>
-              Secondary option labels will wrap if they are longer than the main one.
-            </Option>
-          </DropdownButton>
+          </ExampleCode>
           {this.renderConfig()}
         </Example>
 
-        <Example
-          code={`
+        <Example title="With HREFs:">
+          <ExampleCode>
             <DropdownButton
               disabled={disabled}
               label="EdTech News"
@@ -217,41 +188,19 @@ export default class DropdownButtonView extends Component {
               <Option href="http://www.edtechmagazine.com">EdTech Magazine</Option>
               <Option href="http://www.techlearning.com">Tech & Learning</Option>
             </DropdownButton>
-          `}
-          title="With HREFs:"
-        >
-          <DropdownButton
-            disabled={disabled}
-            label="EdTech News"
-            href="http://google.com/search?q=edtech+news"
-            size={size}
-            type={type}
-          >
-            <Option href="http://www.centerdigitaled.com">Converge</Option>
-            <Option href="http://www.example.com" disabled>Disabled Option</Option>
-            <Option href="http://www.edsurge.com">EdSurge</Option>
-            <Option href="http://www.edtechmagazine.com">EdTech Magazine</Option>
-            <Option href="http://www.techlearning.com">Tech & Learning</Option>
-          </DropdownButton>
+          </ExampleCode>
           {this.renderConfig()}
         </Example>
 
-        <Example
-          code={`
+        <Example title="With Single-Button Fallback:">
+          <p>If no options are available, no toggle is rendered with the primary action.</p>
+          <ExampleCode>
             <DropdownButton disabled={disabled} label="Primary action" size={size} type={type}>
               {emptyArray.map(secondaryAction => (
                 <Option key={secondaryAction}>{secondaryAction}</Option>
               ))}
             </DropdownButton>
-          `}
-          title="With Single-Button Fallback:"
-        >
-          <p>If no options are available, no toggle is rendered with the primary action.</p>
-          <DropdownButton disabled={disabled} label="Primary action" size={size} type={type}>
-            {emptyArray.map(secondaryAction => (
-              <Option key={secondaryAction}>{secondaryAction}</Option>
-            ))}
-          </DropdownButton>
+          </ExampleCode>
           {this.renderConfig()}
         </Example>
 

--- a/docs/components/FileInputView.jsx
+++ b/docs/components/FileInputView.jsx
@@ -1,23 +1,9 @@
 import React from "react";
 
-import Example from "./Example";
+import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import {FileInput} from "src";
-
-function store(file, {progress, success}) {
-  let progressPercent = 0;
-  progress(progressPercent);
-  const intervalID = setInterval(() => {
-    if (progressPercent !== 100) {
-      progressPercent += 5;
-      progress(progressPercent);
-    } else {
-      success();
-      clearInterval(intervalID);
-    }
-  }, 100);
-}
 
 export default function FileInputView() {
   const {cssClass} = FileInputView;
@@ -25,33 +11,28 @@ export default function FileInputView() {
   return (
     <View className={cssClass.CONTAINER} title="FileInput">
       <p>An input component that allows users to drag and drop (or click and select) files.</p>
-      <Example
-        code={`
-          // Example store function using filestack
-          async function store(file, {success, error, progress}) => {
-            try {
-              await filestack.upload(file, {
-                onProgress: (p) => { progress(p); }
-              });
-              success();
-            } catch (e) {
-              error(e);
-            }
-          }
-
-          <FileInput
-            label="Icon"
-            store={store}
-            accept="image/png"
-          />
-        `}
-      >
+      <Example>
         <div>
-          <FileInput
-            label="Icon"
-            store={store}
-            accept="image/png"
-          />
+          <ExampleCode>
+            <FileInput
+              label="Icon"
+              accept="image/png"
+              store={(file, {progress, success}) => {
+                // Example store function using filestack
+                let progressPercent = 0;
+                progress(progressPercent);
+                const intervalID = setInterval(() => {
+                  if (progressPercent !== 100) {
+                    progressPercent += 5;
+                    progress(progressPercent);
+                  } else {
+                    success();
+                    clearInterval(intervalID);
+                  }
+                }, 100);
+              }}
+            />
+          </ExampleCode>
           <p>Takes a <code>store</code> function which is called when the user has selected a file that should be uploaded.
           The caller is responsible for calling 3 provided callbacks:</p>
           <ul>

--- a/docs/components/GridView.jsx
+++ b/docs/components/GridView.jsx
@@ -53,12 +53,7 @@ export default class GridView extends PureComponent {
           will wrap onto the following line.
         </p>
 
-        <Example
-          title="Single Layout"
-          code={`
-            // TODO
-          `}
-        >
+        <Example title="Single Layout">
           <Grid className="outlined resizable">
             <Row grow>{this.renderCol(2)}{this.renderCol(7)}{this.renderCol(3)}</Row>
             <Row grow>
@@ -68,12 +63,7 @@ export default class GridView extends PureComponent {
           </Grid>
         </Example>
 
-        <Example
-          title="Single Layout (with gutters)"
-          code={`
-            // TODO
-          `}
-        >
+        <Example title="Single Layout (with gutters)">
           <Grid className="outlined resizable">
             <Row className="margin--bottom--xs" grow>
               {this.renderCol(2, "padding--right--xs")}
@@ -90,12 +80,7 @@ export default class GridView extends PureComponent {
           </Grid>
         </Example>
 
-        <Example
-          title="Mixed Layouts"
-          code={`
-            // TODO
-          `}
-        >
+        <Example title="Mixed Layouts">
           <Grid className="outlined resizable">
             <Row grow>
               {this.renderCol({
@@ -128,12 +113,7 @@ export default class GridView extends PureComponent {
           </Grid>
         </Example>
 
-        <Example
-          title="Nested Grids"
-          code={`
-            // TODO
-          `}
-        >
+        <Example title="Nested Grids">
           <Grid className="items--center outlined resizable" style={{height: "400px", minWidth: "550px"}}>
             <Row className="shaded outlined" style={{marginBottom: "1rem"}}>
               <Col span={12} className="flexbox justify--center">
@@ -154,12 +134,7 @@ export default class GridView extends PureComponent {
           </Grid>
         </Example>
 
-        <Example
-          title="Standalone Row"
-          code={`
-            // TODO
-          `}
-        >
+        <Example title="Standalone Row">
           <Row>
             {this.renderCol(3, "padding--right--xs")}
             {this.renderCol(3, "padding--right--xs")}

--- a/docs/components/InfoPanelView.jsx
+++ b/docs/components/InfoPanelView.jsx
@@ -24,28 +24,15 @@ export default class InfoPanelView extends React.Component {
 
     return (
       <View className={cssClass.CONTAINER} title="InfoPanel">
-        <Example
-          code={`
-            <InfoPanel title="Info Panel Title">
-              <InfoPanelColumn>
-                <p>column 1 content</p>
-              </InfoPanelColumn>
-              <InfoPanelColumn>
-                <p>column 2 content</p>
-              </InfoPanelColumn>
-            </InfoPanel>
-          `}
-        >
-          <div>
-            <InfoPanel title="Info Panel Title">
-              <InfoPanelColumn>
-                <p>column 1 content</p>
-              </InfoPanelColumn>
-              <InfoPanelColumn>
-                <p>column 2 content</p>
-              </InfoPanelColumn>
-            </InfoPanel>
-          </div>
+        <Example>
+          <InfoPanel title="Info Panel Title">
+            <InfoPanelColumn>
+              <p>column 1 content</p>
+            </InfoPanelColumn>
+            <InfoPanelColumn>
+              <p>column 2 content</p>
+            </InfoPanelColumn>
+          </InfoPanel>
         </Example>
 
         <PropDocumentation

--- a/docs/components/LabelView.jsx
+++ b/docs/components/LabelView.jsx
@@ -2,7 +2,7 @@ import _ from "lodash";
 import loremIpsum from "lorem-ipsum";
 import React, {Component} from "react";
 
-import Example from "./Example";
+import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import {Button, Label, SegmentedControl, Tooltip} from "src";
@@ -35,74 +35,43 @@ export default class LabelView extends Component {
           They can be particularly useful when displaying a list or table of information as a visual
           aid for a user scanning through the information.
         </p>
-        <Example
-          code={`
-            <h4 className={cssClass.EXAMPLE}>
-              Labels are inline by default
-              <Label className={cssClass.LABEL} color={color} size={size}>
-                Simple Label
-              </Label>
-            </h4>
-            <h4 className={cssClass.EXAMPLE}>
-              And can vary in size and color
-              <Label className={cssClass.LABEL} color={color} size={size}>
-                With HTML Content <span className={"fa fa-check-circle"} />
-              </Label>
-              <Label
-                className={cssClass.LABEL}
-                color={color}
-                ref="focusableLabel"
-                size={size}
-                tooltip={
-                  <div>
-                    This label has a tooltip. It has a lot to say.
-                    <br />
-                    <br />
-                    {loremIpsum({count: 3, units: "sentences"})}
-                  </div>
-                }
-                tooltipPlacement={tooltipPlacement}
-                tooltipTextAlign={tooltipTextAlign}
-              >
-                With Tooltip
-              </Label>
-            </h4>
-          `}
-        >
+        <Example>
           <div className={cssClass.DEMO_CONTAINER}>
-            <h4 className={cssClass.EXAMPLE}>
-              Labels are inline by default
-              <Label className={cssClass.LABEL} color={color} size={size}>
-                Simple Label
-              </Label>
-            </h4>
-            <h4 className={cssClass.EXAMPLE}>
-              And can vary in size and color
-              <Label className={cssClass.LABEL} color={color} size={size}>
-                With HTML Content <span className={"fa fa-check-circle"} />
-              </Label>
-            </h4>
-            <h4 className={cssClass.EXAMPLE}>
-              They can include an optional tooltip with hover state shading
-              <Label
-                className={cssClass.LABEL}
-                color={color}
-                ref="focusableLabel"
-                size={size}
-                tooltip={
-                  <div>
-                    This label has a tooltip. It has a lot to say.
-                    <br />
-                    <br />
-                    {loremIpsum({count: 3, units: "sentences"})}
-                  </div>
-                }
-                tooltipPlacement={tooltipPlacement}
-                tooltipTextAlign={tooltipTextAlign}
-              >
-                With Tooltip
-              </Label>
-            </h4>
+            <ExampleCode>
+              <h4 className={cssClass.EXAMPLE}>
+                Labels are inline by default
+                <Label className={cssClass.LABEL} color={color} size={size}>
+                  Simple Label
+                </Label>
+              </h4>
+              <h4 className={cssClass.EXAMPLE}>
+                And can vary in size and color
+                <Label className={cssClass.LABEL} color={color} size={size}>
+                  With HTML Content <span className={"fa fa-check-circle"} />
+                </Label>
+              </h4>
+              <h4 className={cssClass.EXAMPLE}>
+                They can include an optional tooltip with hover state shading
+                <Label
+                  className={cssClass.LABEL}
+                  color={color}
+                  ref="focusableLabel"
+                  size={size}
+                  tooltip={
+                    <div>
+                      This label has a tooltip. It has a lot to say.
+                      <br />
+                      <br />
+                      {loremIpsum({count: 3, units: "sentences"})}
+                    </div>
+                  }
+                  tooltipPlacement={tooltipPlacement}
+                  tooltipTextAlign={tooltipTextAlign}
+                >
+                  With Tooltip
+                </Label>
+              </h4>
+            </ExampleCode>
           </div>
           <div className={cssClass.CONFIG_CONTAINER}>
             <div className={cssClass.CONFIG}>

--- a/docs/components/LessStyleGuideView.jsx
+++ b/docs/components/LessStyleGuideView.jsx
@@ -91,7 +91,6 @@ export default function LessStyleGuideView() {
             There are also a set of shade and tint mixin functions for variations on the core colors.</p>
 
             <Example
-              title=""
               code={`
                 .Header--StatusBox {
                   font-size: 16px;
@@ -108,7 +107,6 @@ export default function LessStyleGuideView() {
             </Example>
 
             <Example
-              title=""
               code={`
                 .Header--StatusBox {
                   .padding--x--m;
@@ -130,7 +128,6 @@ export default function LessStyleGuideView() {
             e.g. <code>:focus</code>, or pseudo-selectors, e.g. <code>::first-leter</code></p>
 
             <Example
-              title=""
               code={`
                 .TabBar {
                   transition: font-size .25s ease-out, box-shadow .25s ease-out;
@@ -160,7 +157,6 @@ export default function LessStyleGuideView() {
             </Example>
 
             <Example
-              title=""
               code={`
                 .TabBar {
                   transition: font-size .25s ease-out, box-shadow .25s ease-out;
@@ -189,7 +185,6 @@ export default function LessStyleGuideView() {
             and diverges from the goals of the design system.</p>
 
             <Example
-              title=""
               code={`
                 .Alert .TabBar .TabBar--Tab {
                   .border--bottom--m(@alertRed);
@@ -208,7 +203,6 @@ export default function LessStyleGuideView() {
             </Example>
 
             <Example
-              title=""
               code={`
                 .TabBar--Tab--alert {
                   .border--bottom--m(@alertRed);

--- a/docs/components/ModalButtonView.jsx
+++ b/docs/components/ModalButtonView.jsx
@@ -23,20 +23,7 @@ export default class ModalButtonView extends Component {
           This component is a <code>Button</code> that triggers the appearance of a modal when clicked.
         </p>
 
-        <Example
-          code={`
-            <ModalButton
-              type="primary"
-              modalTitle="Helpful info"
-              onClick={() => console.log("ModalButton: modal opened!")}
-              onClose={() => console.log("ModalButton: modal closed!")}
-              value="More info"
-            >
-              <p>{loremIpsum({count: 1, units: "paragraphs"})}</p>
-              <p>{loremIpsum({count: 1, units: "paragraphs"})}</p>
-            </ModalButton>
-          `}
-        >
+        <Example>
           <ModalButton
             type="primary"
             modalTitle="Helpful info"

--- a/docs/components/ModalView.jsx
+++ b/docs/components/ModalView.jsx
@@ -23,36 +23,7 @@ export default class ModalView extends Component {
           This component wraps your content and displays it in a modal and obscures the underlying content.
         </p>
 
-        <Example
-          code={`
-            <Button
-              type="primary"
-              onClick={() => this.setState({isModalOpen: true})}
-              value="Open Modal"
-            />
-            {this.state.isModalOpen && (
-              <Modal
-                title="Hello Modal"
-                closeModal={() => this.setState({isModalOpen: false})}
-              >
-                <p>{loremIpsum({count: 1, units: "paragraphs"})}</p>
-                <p>{loremIpsum({count: 1, units: "paragraphs"})}</p>
-                <footer>
-                  <Button
-                    value="Never mind"
-                    type="link"
-                    onClick={() => this.setState({isModalOpen: false})}
-                  />
-                  <Button
-                    value="Sounds good"
-                    type="primary"
-                    onClick={() => this.setState({isModalOpen: false})}
-                  />
-                </footer>
-              </Modal>
-            )}
-          `}
-        >
+        <Example>
           <Button
             type="primary"
             onClick={() => this.setState({isModalOpen: true})}

--- a/docs/components/NumberView.jsx
+++ b/docs/components/NumberView.jsx
@@ -1,6 +1,6 @@
 import React, {Component} from "react";
 
-import Example from "./Example";
+import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import {Number, SegmentedControl} from "src";
@@ -28,28 +28,50 @@ export default class NumberView extends Component {
       <View className={cssClass.CONTAINER} title="Number" sourcePath="src/Number/Number.jsx">
         <p>Provides consistent number formatting for long numbers, with optional shortening.</p>
 
-        <Example
-          code={`
-            <div className={cssClass.EXAMPLE}>
-              <p>
-                8 {arrow} <Number short={shouldShorten}>{8}</Number>
-              </p>
-              <p>
-                999 {arrow} <Number short={shouldShorten}>{999}</Number>
-              </p>
-            </div>
-          `}
-          title="Short numbers are left unchanged:"
-        >
+        <Example title="Short numbers are left unchanged:">
           <div className={cssClass.DEMO_CONTAINER}>
-            <div className={cssClass.EXAMPLE}>
-              <p>
-                8 {arrow} <Number short={shouldShorten}>{8}</Number>
-              </p>
-              <p>
-                999 {arrow} <Number short={shouldShorten}>{999}</Number>
-              </p>
+            <ExampleCode>
+              <div className={cssClass.EXAMPLE}>
+                <p>
+                  8 {arrow} <Number short={shouldShorten}>{8}</Number>
+                </p>
+                <p>
+                  999 {arrow} <Number short={shouldShorten}>{999}</Number>
+                </p>
+              </div>
+            </ExampleCode>
+          </div>
+          <div className={cssClass.CONFIG_CONTAINER}>
+            <div className={cssClass.CONFIG}>
+              Format:
+              <SegmentedControl
+                className={cssClass.CONFIG_OPTIONS}
+                value={format}
+                onSelect={value => this.setState({format: value})}
+                options={[
+                  {content: "Regular", value: "regular"},
+                  {content: "Short", value: "short"},
+                ]}
+              />
             </div>
+          </div>
+        </Example>
+
+        <Example title="Formatting kicks in starting at 1000:">
+          <div className={cssClass.DEMO_CONTAINER}>
+            <ExampleCode>
+              <div className={cssClass.EXAMPLE}>
+                <p>
+                  1000 {arrow} <Number short={shouldShorten}>{1000}</Number>
+                </p>
+                <p>
+                  907312456 {arrow} <Number short={shouldShorten}>{907312456}</Number>
+                </p>
+                <p>
+                  7089123456 {arrow} <Number short={shouldShorten}>{7089123456}</Number>
+                </p>
+              </div>
+            </ExampleCode>
           </div>
           <div className={cssClass.CONFIG_CONTAINER}>
             <div className={cssClass.CONFIG}>
@@ -68,72 +90,19 @@ export default class NumberView extends Component {
         </Example>
 
         <Example
-          code={`
-            <div className={cssClass.EXAMPLE}>
-              <p>
-                1000 {arrow} <Number short={shouldShorten}>{1000}</Number>
-              </p>
-              <p>
-                907312456 {arrow} <Number short={shouldShorten}>{907312456}</Number>
-              </p>
-              <p>
-                7089123456 {arrow} <Number short={shouldShorten}>{7089123456}</Number>
-              </p>
-            </div>
-          `}
-          title="Formatting kicks in starting at 1000:"
-        >
-          <div className={cssClass.DEMO_CONTAINER}>
-            <div className={cssClass.EXAMPLE}>
-              <p>
-                1000 {arrow} <Number short={shouldShorten}>{1000}</Number>
-              </p>
-              <p>
-                907312456 {arrow} <Number short={shouldShorten}>{907312456}</Number>
-              </p>
-              <p>
-                7089123456 {arrow} <Number short={shouldShorten}>{7089123456}</Number>
-              </p>
-            </div>
-          </div>
-          <div className={cssClass.CONFIG_CONTAINER}>
-            <div className={cssClass.CONFIG}>
-              Format:
-              <SegmentedControl
-                className={cssClass.CONFIG_OPTIONS}
-                value={format}
-                onSelect={value => this.setState({format: value})}
-                options={[
-                  {content: "Regular", value: "regular"},
-                  {content: "Short", value: "short"},
-                ]}
-              />
-            </div>
-          </div>
-        </Example>
-
-        <Example
-          code={`
-            <div className={cssClass.EXAMPLE}>
-              <p>
-                5678 {arrow} <Number short={shouldShorten}>5678</Number>
-              </p>
-              <p>
-                1234567 {arrow} <Number short={shouldShorten}>{"1234567"}</Number>
-              </p>
-            </div>
-          `}
           title="Numbers can be specified as text, as long as they can be parsed as integers:"
         >
           <div className={cssClass.DEMO_CONTAINER}>
-            <div className={cssClass.EXAMPLE}>
-              <p>
-                5678 {arrow} <Number short={shouldShorten}>5678</Number>
-              </p>
-              <p>
-                1234567 {arrow} <Number short={shouldShorten}>{"1234567"}</Number>
-              </p>
-            </div>
+            <ExampleCode>
+              <div className={cssClass.EXAMPLE}>
+                <p>
+                  5678 {arrow} <Number short={shouldShorten}>5678</Number>
+                </p>
+                <p>
+                  1234567 {arrow} <Number short={shouldShorten}>{"1234567"}</Number>
+                </p>
+              </div>
+            </ExampleCode>
           </div>
           <div className={cssClass.CONFIG_CONTAINER}>
             <div className={cssClass.CONFIG}>
@@ -152,25 +121,16 @@ export default class NumberView extends Component {
         </Example>
 
         <Example
-          code={`
-            <div className={cssClass.EXAMPLE}>
-              <p>
-                12345 {arrow} {Number.format(12345, shouldShorten)}
-              </p>
-              <p>
-                This may be useful in cases where a plain string is needed (e.g. when assigning a
-                prop that requires a string value).
-              </p>
-            </div>
-          `}
           title="Formatting can be done directly, without rendering the component:"
         >
           <div className={cssClass.DEMO_CONTAINER}>
-            <div className={cssClass.EXAMPLE}>
-              <p>
-                12345 {arrow} {Number.format(12345, shouldShorten)}
-              </p>
-            </div>
+            <ExampleCode>
+              <div className={cssClass.EXAMPLE}>
+                <p>
+                  12345 {arrow} {Number.format(12345, shouldShorten)}
+                </p>
+              </div>
+            </ExampleCode>
             This may be useful in cases where a plain string is needed (e.g. when assigning a
             prop that requires a string value).
           </div>

--- a/docs/components/ProgressBarView.jsx
+++ b/docs/components/ProgressBarView.jsx
@@ -37,23 +37,11 @@ export default class ProgressBarView extends Component {
             />
           </label>
         </h3>
-        <Example
-          title="Horizontal"
-          code={`
-            <ProgressBar percentage={this.state.progress} length="500px" />
-            <ProgressBar percentage={this.state.progress} direction="left" length="500px" />
-          `}
-        >
+        <Example title="Horizontal">
           <ProgressBar percentage={this.state.progress} length="500px" />
           <ProgressBar percentage={this.state.progress} direction="left" length="500px" />
         </Example>
-        <Example
-          title="Vertical"
-          code={`
-            <ProgressBar percentage={this.state.progress} direction="down" length="200px" />
-            <ProgressBar percentage={this.state.progress} direction="up" length="200px" />
-          `}
-        >
+        <Example title="Vertical">
           <ProgressBar percentage={this.state.progress} direction="down" length="200px" />
           <ProgressBar percentage={this.state.progress} direction="up" length="200px" />
         </Example>

--- a/docs/components/SegmentedControlView.jsx
+++ b/docs/components/SegmentedControlView.jsx
@@ -23,36 +23,7 @@ export default class SegmentedControlView extends Component {
           when a user needs to select one of a handful of options.
         </p>
 
-        <Example
-          title="Basic"
-          code={`
-            <SegmentedControl
-              onSelect={(option) => console.log(\`Option \${option} selected\`)}
-              options={[
-                {
-                  content: (
-                    <span>
-                      1 - HTML Content <span className="fa fa-question-circle" />
-                    </span>
-                  ),
-                  value: "one",
-                },
-                {
-                  content: "2 - Plain Text",
-                  value: "two",
-                },
-                {
-                  content: (
-                    <span>
-                      3 - HTML Content <span className="fa fa-spinner fa-spin" />
-                    </span>
-                  ),
-                  value: "three",
-                },
-              ]}
-            />
-          `}
-        >
+        <Example title="Basic">
           <SegmentedControl
             onSelect={(option) => console.log(`Option ${option} selected`)}
             options={[
@@ -79,30 +50,7 @@ export default class SegmentedControlView extends Component {
             ]}
           />
         </Example>
-        <Example
-          title="With Disabled Option"
-          code={`
-            <SegmentedControl
-              defaultValue="two"
-              onSelect={(option) => console.log(\`Option \${option} selected\`)}
-              options={[
-                {
-                  content: "Option 1",
-                  value: "one",
-                },
-                {
-                  content: "2 - Default",
-                  value: "two",
-                },
-                {
-                  content: "3 - Option Disabled",
-                  disabled: true,
-                  value: "three",
-                },
-              ]}
-            />
-          `}
-        >
+        <Example title="With Disabled Option">
           <SegmentedControl
             defaultValue="two"
             onSelect={(option) => console.log(`Option ${option} selected`)}
@@ -123,30 +71,7 @@ export default class SegmentedControlView extends Component {
             ]}
           />
         </Example>
-        <Example
-          title="Control Disabled"
-          code={`
-            <SegmentedControl
-              defaultValue="two"
-              disabled
-              onSelect={(option) => console.log(\`Option \${option} selected\`)}
-              options={[
-                {
-                  content: "1 - Control Disabled",
-                  value: "one",
-                },
-                {
-                  content: "2 - Selected and Control Disabled",
-                  value: "two",
-                },
-                {
-                  content: "3 - Control Disabled",
-                  value: "three",
-                },
-              ]}
-            />
-          `}
-        >
+        <Example title="Control Disabled">
           <SegmentedControl
             defaultValue="two"
             disabled

--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import React, {Component} from "react";
 
-import Example from "./Example";
+import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import {Select} from "src";
@@ -37,39 +37,24 @@ export default class SelectView extends Component {
           list.
         </p>
 
-        <Example
-          code={`
-            <Select
-              id="select"
-              label="Select Label"
-              disabled={this.state.disabled}
-              clearable={this.state.clearable}
-              searchable={this.state.searchable}
-              multi={this.state.multi}
-              readOnly={this.state.readOnly}
-              name="select"
-              onChange={value => this.setState({selectValue: value})}
-              options={_.range(100).map(i => ({label: \`Option \${i + 1}\`, value: \`\${i + 1}\`}))}
-              placeholder="Select Placeholder"
-              value={this.state.selectValue}
-            />
-          `}
-        >
+        <Example>
           <div className={cssClass.INPUT_CONTAINER}>
-            <Select
-              id="select"
-              label="Select Label"
-              disabled={this.state.disabled}
-              clearable={this.state.clearable}
-              searchable={this.state.searchable}
-              multi={this.state.multi}
-              readOnly={this.state.readOnly}
-              name="select"
-              onChange={value => this.setState({selectValue: value})}
-              options={_.range(100).map(i => ({label: `Option ${i + 1}`, value: `${i + 1}`}))}
-              placeholder="Select Placeholder"
-              value={this.state.selectValue}
-            />
+            <ExampleCode>
+              <Select
+                id="select"
+                label="Select Label"
+                disabled={this.state.disabled}
+                clearable={this.state.clearable}
+                searchable={this.state.searchable}
+                multi={this.state.multi}
+                readOnly={this.state.readOnly}
+                name="select"
+                onChange={value => this.setState({selectValue: value})}
+                options={_.range(100).map(i => ({label: `Option ${i + 1}`, value: `${i + 1}`}))}
+                placeholder="Select Placeholder"
+                value={this.state.selectValue}
+              />
+            </ExampleCode>
           </div>
           <label className={cssClass.CONFIG}>
             <input

--- a/docs/components/SizingView.jsx
+++ b/docs/components/SizingView.jsx
@@ -44,7 +44,6 @@ export default class SizingView extends PureComponent {
             </Col>
             <Col span={4} className="flexbox self--start padding--right--l">
               <Example
-                title=""
                 code={`
                   <style>
                     .Size--m {

--- a/docs/components/TableView.jsx
+++ b/docs/components/TableView.jsx
@@ -3,7 +3,7 @@ import _ from "lodash";
 import loremIpsum from "lorem-ipsum";
 import React, {PureComponent} from "react";
 
-import Example from "./Example";
+import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import {Button, ModalButton, Table, TextInput} from "src";
@@ -48,96 +48,13 @@ export default class TableView extends PureComponent {
     const {cssClass} = TableView;
     const {enableRowClick, tableData} = this.state;
 
-    const getDataLazily = async ({startingAfter, pageSize}) => {
-      let start = 0;
-      if (startingAfter != null) {
-        start = _.findIndex(tableData, r => r.id === startingAfter) + 1;
-      }
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      return tableData.slice(start, start + pageSize);
-    };
-
     return (
       <View className={cssClass.CONTAINER} title="Table">
         <p>
           This table component supports sorting, filtering, and pagination. There is also a lazy loading
           table available for very large sets of data.
         </p>
-        <Example
-          code={`
-            <Table
-              data={tableData}
-              filter={rowData => !this.state.tableFilter || _.includes(
-                [rowData.name.first, rowData.name.last].join(" "),
-                this.state.tableFilter.trim().toLowerCase()
-              )}
-              initialPage={24}
-              initialSortState={{columnID: "name", direction: Table.sortDirection.ASCENDING}}
-              ref="table"
-              onPageChange={page => console.log("Table page changed:", page)}
-              onSortChange={sortState => console.log("Table sort changed:", sortState)}
-              onRowClick={enableRowClick
-                ? (e, row) => console.log("Table row clicked:", row)
-                : undefined
-              }
-              onViewChange={data => console.log("New rows:", data.map(d => d.id))}
-              paginated
-              pageSize={9}
-              rowIDFn={r => r.id}
-              rowClassNameFn={r => r.age < 10 ? "additionalClass" : null}
-            >
-              <Table.Column
-                id="details"
-                cell={{renderer: r => (
-                  <ModalButton
-                    type="link"
-                    size="small"
-                    value={"\u2630 Details"}
-                    modalTitle="Details"
-                  >
-                    <p style={{whiteSpace: "normal"}}>{r.notes}</p>
-                  </ModalButton>
-                )}}
-                noWrap
-              />
-
-              <Table.Column
-                id="name"
-                header={{content: "Name"}}
-                cell={{
-                  className: "capitalize",
-                  renderer: r => [r.name.first, r.name.last].join(" "),
-                }}
-                sortable
-                sortValueFn={r => [r.name.first, r.name.last].join(" ")}
-                width="25%"
-              />
-
-              <Table.Column
-                id="age"
-                header={{content: "Age"}}
-                cell={{renderer: r => r.age}}
-                sortable
-                sortValueFn={r => r.age}
-              />
-
-              <Table.Column
-                id="status"
-                header={{content: "Status"}}
-                cell={{renderer: r => r.status}}
-                sortable
-                sortValueFn={r => r.status}
-              />
-
-              <Table.Column
-                id="notes"
-                header={{content: "Notes"}}
-                cell={{renderer: r => r.notes}}
-                width="100%"
-              />
-            </Table>
-          `}
-        >
+        <Example>
           <Button
             onClick={() => {
               this._reload(Math.random() * 5000);
@@ -159,77 +76,79 @@ export default class TableView extends PureComponent {
             />
           </div>
           <div style={{marginTop: "20px"}}>
-            <Table
-              data={tableData}
-              filter={rowData => !this.state.tableFilter || _.includes(
-                [rowData.name.first, rowData.name.last].join(" "),
-                this.state.tableFilter.trim().toLowerCase()
-              )}
-              initialPage={24}
-              initialSortState={{columnID: "name", direction: Table.sortDirection.ASCENDING}}
-              ref="table"
-              onPageChange={page => console.log("Table page changed:", page)}
-              onSortChange={sortState => console.log("Table sort changed:", sortState)}
-              onRowClick={enableRowClick
-                ? (e, row) => console.log("Table row clicked:", row)
-                : undefined
-              }
-              onViewChange={data => console.log("Table view changed:", data.map(d => d.id))}
-              paginated
-              pageSize={9}
-              rowIDFn={r => r.id}
-              rowClassNameFn={r => (r.age < 10 ? "additionalClass" : null)}
-            >
-              <Table.Column
-                id="details"
-                cell={{renderer: r => (
-                  <ModalButton
-                    type="link"
-                    size="small"
-                    value={"\u2630 Details"}
-                    modalTitle="Details"
-                  >
-                    <p style={{whiteSpace: "normal"}}>{r.notes}</p>
-                  </ModalButton>
-                )}}
-                noWrap
-              />
+            <ExampleCode>
+              <Table
+                data={tableData}
+                filter={rowData => !this.state.tableFilter || _.includes(
+                  [rowData.name.first, rowData.name.last].join(" "),
+                  this.state.tableFilter.trim().toLowerCase()
+                )}
+                initialPage={24}
+                initialSortState={{columnID: "name", direction: Table.sortDirection.ASCENDING}}
+                ref="table"
+                onPageChange={page => console.log("Table page changed:", page)}
+                onSortChange={sortState => console.log("Table sort changed:", sortState)}
+                onRowClick={enableRowClick
+                  ? (e, row) => console.log("Table row clicked:", row)
+                  : undefined
+                }
+                onViewChange={data => console.log("Table view changed:", data.map(d => d.id))}
+                paginated
+                pageSize={9}
+                rowIDFn={r => r.id}
+                rowClassNameFn={r => (r.age < 10 ? "additionalClass" : null)}
+              >
+                <Table.Column
+                  id="details"
+                  cell={{renderer: r => (
+                    <ModalButton
+                      type="link"
+                      size="small"
+                      value={"\u2630 Details"}
+                      modalTitle="Details"
+                    >
+                      <p style={{whiteSpace: "normal"}}>{r.notes}</p>
+                    </ModalButton>
+                  )}}
+                  noWrap
+                />
 
-              <Table.Column
-                id="name"
-                header={{content: "Name"}}
-                cell={{
-                  className: "capitalize",
-                  renderer: r => [r.name.first, r.name.last].join(" "),
-                }}
-                sortable
-                sortValueFn={r => [r.name.first, r.name.last].join(" ")}
-                width="25%"
-              />
+                <Table.Column
+                  id="name"
+                  header={{content: "Name"}}
+                  cell={{
+                    className: "capitalize",
+                    renderer: r => [r.name.first, r.name.last].join(" "),
+                  }}
+                  sortable
+                  sortValueFn={r => [r.name.first, r.name.last].join(" ")}
+                  width="25%"
+                />
 
-              <Table.Column
-                id="age"
-                header={{content: "Age"}}
-                cell={{renderer: r => r.age}}
-                sortable
-                sortValueFn={r => r.age}
-              />
+                <Table.Column
+                  id="age"
+                  header={{content: "Age"}}
+                  cell={{renderer: r => r.age}}
+                  sortable
+                  sortValueFn={r => r.age}
+                />
 
-              <Table.Column
-                id="status"
-                header={{content: "Status"}}
-                cell={{renderer: r => r.status}}
-                sortable
-                sortValueFn={r => r.status}
-              />
+                <Table.Column
+                  id="status"
+                  header={{content: "Status"}}
+                  cell={{renderer: r => r.status}}
+                  sortable
+                  sortValueFn={r => r.status}
+                />
 
-              <Table.Column
-                id="notes"
-                header={{content: "Notes"}}
-                cell={{renderer: r => r.notes}}
-                width="100%"
-              />
-            </Table>
+                <Table.Column
+                  id="notes"
+                  header={{content: "Notes"}}
+                  cell={{renderer: r => r.notes}}
+                  width="100%"
+                />
+              </Table>
+            </ExampleCode>
           </div>
           <label className={cssClass.CONFIG}>
             <input
@@ -381,136 +300,71 @@ export default class TableView extends PureComponent {
           title="Table.Column"
         />
 
-        <Example
-          code={`
-            <Table
-              ref={t => {this._lazyTable = t;}}
-              lazy
-              getData={
-                async ({startingAfter, pageSize}) => {
-                  let start = 0;
-                  if (startingAfter != null) {
-                    start = _.findIndex(tableData, r => r.id === startingAfter) + 1;
-                  }
-                  await new Promise(resolve => setTimeout(resolve, 1000));
-                  return tableData.slice(start, start + pageSize);
-                }
+        <Example title="Lazy Table">
+          <Table
+            ref={t => {this._lazyTable = t;}}
+            lazy
+            getData={async ({startingAfter, pageSize}) => {
+              let start = 0;
+              if (startingAfter != null) {
+                start = _.findIndex(tableData, r => r.id === startingAfter) + 1;
               }
-              numRows={tableData.length}
-              onPageChange={page => console.log("Table page changed:", page)}
-              onSortChange={sortState => console.log("Table sort changed:", sortState)}
-              onViewChange={data => console.log("Table view changed:", data.map(d => d.id))}
-              paginated
-              pageSize={9}
-              rowIDFn={r => r.id}
-              rowClassNameFn={r => r.age < 10 ? "additionalClass" : null}
-            >
-              <Table.Column
-                id="details"
-                cell={{renderer: r => (
-                  <ModalButton
-                    type="link"
-                    size="small"
-                    value={"\u2630 Details"}
-                    modalTitle="Details"
-                  >
-                    <p style={{whiteSpace: "normal"}}>{r.notes}</p>
-                  </ModalButton>
-                )}}
-                noWrap
-              />
+              await new Promise(resolve => setTimeout(resolve, 1000));
+              return tableData.slice(start, start + pageSize);
+            }}
+            numRows={tableData.length}
+            onPageChange={page => console.log("Table page changed:", page)}
+            onSortChange={sortState => console.log("Table sort changed:", sortState)}
+            onViewChange={data => console.log("Table view changed:", data.map(d => d.id))}
+            paginated
+            pageSize={9}
+            rowIDFn={r => r.id}
+            rowClassNameFn={r => (r.age < 10 ? "additionalClass" : null)}
+          >
+            <Table.Column
+              id="details"
+              cell={{renderer: r => (
+                <ModalButton
+                  type="link"
+                  size="small"
+                  value={"\u2630 Details"}
+                  modalTitle="Details"
+                >
+                  <p style={{whiteSpace: "normal"}}>{r.notes}</p>
+                </ModalButton>
+              )}}
+              noWrap
+            />
 
-              <Table.Column
-                id="name"
-                header={{content: "Name"}}
-                cell={{
-                  className: "capitalize",
-                  renderer: r => [r.name.first, r.name.last].join(" "),
-                }}
-                width="25%"
-              />
+            <Table.Column
+              id="name"
+              header={{content: "Name"}}
+              cell={{
+                className: "capitalize",
+                renderer: r => [r.name.first, r.name.last].join(" "),
+              }}
+              width="25%"
+            />
 
-              <Table.Column
-                id="age"
-                header={{content: "Age"}}
-                cell={{renderer: r => r.age}}
-              />
+            <Table.Column
+              id="age"
+              header={{content: "Age"}}
+              cell={{renderer: r => r.age}}
+            />
 
-              <Table.Column
-                id="status"
-                header={{content: "Status"}}
-                cell={{renderer: r => r.status}}
-              />
+            <Table.Column
+              id="status"
+              header={{content: "Status"}}
+              cell={{renderer: r => r.status}}
+            />
 
-              <Table.Column
-                id="notes"
-                header={{content: "Notes"}}
-                cell={{renderer: r => r.notes}}
-                width="100%"
-              />
-            </Table>
-          `}
-        >
-          <h2>Lazy Table</h2>
-          <div style={{marginTop: "20px"}}>
-            <Table
-              ref={t => {this._lazyTable = t;}}
-              lazy
-              getData={getDataLazily}
-              numRows={tableData.length}
-              onPageChange={page => console.log("Table page changed:", page)}
-              onSortChange={sortState => console.log("Table sort changed:", sortState)}
-              onViewChange={data => console.log("Table view changed:", data.map(d => d.id))}
-              paginated
-              pageSize={9}
-              rowIDFn={r => r.id}
-              rowClassNameFn={r => (r.age < 10 ? "additionalClass" : null)}
-            >
-              <Table.Column
-                id="details"
-                cell={{renderer: r => (
-                  <ModalButton
-                    type="link"
-                    size="small"
-                    value={"\u2630 Details"}
-                    modalTitle="Details"
-                  >
-                    <p style={{whiteSpace: "normal"}}>{r.notes}</p>
-                  </ModalButton>
-                )}}
-                noWrap
-              />
-
-              <Table.Column
-                id="name"
-                header={{content: "Name"}}
-                cell={{
-                  className: "capitalize",
-                  renderer: r => [r.name.first, r.name.last].join(" "),
-                }}
-                width="25%"
-              />
-
-              <Table.Column
-                id="age"
-                header={{content: "Age"}}
-                cell={{renderer: r => r.age}}
-              />
-
-              <Table.Column
-                id="status"
-                header={{content: "Status"}}
-                cell={{renderer: r => r.status}}
-              />
-
-              <Table.Column
-                id="notes"
-                header={{content: "Notes"}}
-                cell={{renderer: r => r.notes}}
-                width="100%"
-              />
-            </Table>
-          </div>
+            <Table.Column
+              id="notes"
+              header={{content: "Notes"}}
+              cell={{renderer: r => r.notes}}
+              width="100%"
+            />
+          </Table>
         </Example>
       </View>
     );

--- a/docs/components/TextAreaView.jsx
+++ b/docs/components/TextAreaView.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import Example from "./Example";
+import Example, {ExampleCode} from "./Example";
 import View from "./View";
 import {TextArea} from "src";
 import PropDocumentation from "./PropDocumentation";
@@ -28,22 +28,8 @@ export default class TextAreaView extends React.Component {
           This component is a <code>textarea</code> that lets the user input multiple lines of text.
         </p>
 
-        <Example
-          code={`
-            <TextArea
-              disabled={this.state.disabled}
-              name="TextAreaName"
-              label="TextArea Label"
-              readOnly={this.state.readOnly}
-              required={this.state.required}
-              spellCheck={this.state.spellCheck}
-              placeholder="TextArea Placeholder"
-              onChange={e => this.setState({inputValue: e.target.value})}
-              value={this.state.inputValue}
-            />
-          `}
-        >
-          <div>
+        <Example>
+          <ExampleCode>
             <TextArea
               disabled={this.state.disabled}
               name="TextAreaName"
@@ -56,7 +42,7 @@ export default class TextAreaView extends React.Component {
               onChange={e => this.setState({inputValue: e.target.value})}
               value={this.state.inputValue}
             />
-          </div>
+          </ExampleCode>
           <label className={cssClass.CONFIG}>
             <input
               type="checkbox"

--- a/docs/components/TextInputView.jsx
+++ b/docs/components/TextInputView.jsx
@@ -1,6 +1,6 @@
 import React, {Component} from "react";
 
-import Example from "./Example";
+import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import {TextInput} from "src";
@@ -31,40 +31,24 @@ export default class TextInputView extends Component {
           This is your standard <code>input type="text"</code> component.
         </p>
 
-        <Example
-          code={`
-            <TextInput
-              disabled={this.state.disabled}
-              readOnly={this.state.readOnly}
-              required={this.state.required}
-              enableShow={this.state.obscured}
-              error={this.state.hasError ? "Enter a valid email address" : null}
-              type={this.state.obscured ? "password" : "text"}
-              label="TextInput Label"
-              name="TextInputName"
-              placeholder="TextInput Placeholder"
-              onChange={e => this.setState({inputValue: e.target.value})}
-              value={this.state.inputValue}
-              //You can pass additional properties as well to the inner input element
-              onMouseOver={e => {console.log("mouseover!", e)}}
-            />
-          `}
-        >
+        <Example>
           <div className={cssClass.INPUT_CONTAINER}>
-            <TextInput
-              disabled={this.state.disabled}
-              readOnly={this.state.readOnly}
-              required={this.state.required}
-              enableShow={this.state.obscured}
-              error={this.state.hasError ? "Invalid password" : null}
-              type={this.state.obscured ? "password" : "text"}
-              label="TextInput Label"
-              name="TextInputName"
-              placeholder="TextInput Placeholder"
-              onChange={e => this.setState({inputValue: e.target.value})}
-              value={this.state.inputValue}
-              onMouseOver={e => {console.log("mouseover!", e);}}
-            />
+            <ExampleCode>
+              <TextInput
+                disabled={this.state.disabled}
+                readOnly={this.state.readOnly}
+                required={this.state.required}
+                enableShow={this.state.obscured}
+                error={this.state.hasError ? "Invalid password" : null}
+                type={this.state.obscured ? "password" : "text"}
+                label="TextInput Label"
+                name="TextInputName"
+                placeholder="TextInput Placeholder"
+                onChange={e => this.setState({inputValue: e.target.value})}
+                value={this.state.inputValue}
+                onMouseOver={e => {console.log("mouseover!", e);}}
+              />
+            </ExampleCode>
           </div>
           <label className={cssClass.CONFIG}>
             <input

--- a/docs/components/TooltipView.jsx
+++ b/docs/components/TooltipView.jsx
@@ -3,7 +3,7 @@ import classnames from "classnames";
 import loremIpsum from "lorem-ipsum";
 import React, {Component} from "react";
 
-import Example from "./Example";
+import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import {Button, SegmentedControl, Tooltip} from "src";
@@ -27,99 +27,54 @@ export default class TooltipView extends Component {
 
     return (
       <View className={cssClass.CONTAINER} title="Tooltip">
-        <Example
-          code={`
-            <div className={cssClass.EXAMPLE}>
-              Simple
-              {" "}
-              <Tooltip
-                content="Here is a simple tooltip."
-                placement={placement}
-                textAlign={textAlign}
-              >
-                <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
-              </Tooltip>
-            </div>
-            <div className={cssClass.EXAMPLE}>
-              HTML + long text
-              {" "}
-              <Tooltip
-                content={
-                  <div>
-                    Here is a tooltip with long text to demonstrate wrapping and HTML formatting.
-                    <br />
-                    <br />
-                    {loremIpsum({count: 3, units: "sentences"})}
-                  </div>
-                }
-                placement={placement}
-                textAlign={textAlign}
-              >
-                <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
-              </Tooltip>
-            </div>
-            <div className={cssClass.EXAMPLE}>
-              With focusable trigger
-              {" "}
-              <Tooltip
-                content="Tooltips can be triggered by focus as well."
-                placement={placement}
-                textAlign={textAlign}
-              >
-                <span
-                  className={classnames("fa fa-question-circle", cssClass.TRIGGER)}
-                  ref="focusableTrigger"
-                  tabIndex={0}
-                />
-              </Tooltip>
-            </div>
-          `}
-        >
+        <Example>
           <div className={cssClass.DEMO_CONTAINER}>
-            <div className={cssClass.EXAMPLE}>
-              Simple
-              {" "}
-              <Tooltip
-                content="Here is a simple tooltip."
-                placement={placement}
-                textAlign={textAlign}
-              >
-                <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
-              </Tooltip>
-            </div>
-            <div className={cssClass.EXAMPLE}>
-              HTML + long text
-              {" "}
-              <Tooltip
-                content={
-                  <div>
-                    Here is a tooltip with long text to demonstrate wrapping and HTML formatting.
-                    <br />
-                    <br />
-                    {loremIpsum({count: 3, units: "sentences"})}
-                  </div>
-                }
-                placement={placement}
-                textAlign={textAlign}
-              >
-                <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
-              </Tooltip>
-            </div>
-            <div className={cssClass.EXAMPLE}>
-              With focusable trigger
-              {" "}
-              <Tooltip
-                content="Tooltips can be triggered by focus as well."
-                placement={placement}
-                textAlign={textAlign}
-              >
-                <span
-                  className={classnames("fa fa-question-circle", cssClass.TRIGGER)}
-                  ref="focusableTrigger"
-                  tabIndex={0}
-                />
-              </Tooltip>
-            </div>
+            <ExampleCode>
+              <div className={cssClass.EXAMPLE}>
+                Simple
+                {" "}
+                <Tooltip
+                  content="Here is a simple tooltip."
+                  placement={placement}
+                  textAlign={textAlign}
+                >
+                  <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
+                </Tooltip>
+              </div>
+              <div className={cssClass.EXAMPLE}>
+                HTML + long text
+                {" "}
+                <Tooltip
+                  content={
+                    <div>
+                      Here is a tooltip with long text to demonstrate wrapping and HTML formatting.
+                      <br />
+                      <br />
+                      {loremIpsum({count: 3, units: "sentences"})}
+                    </div>
+                  }
+                  placement={placement}
+                  textAlign={textAlign}
+                >
+                  <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
+                </Tooltip>
+              </div>
+              <div className={cssClass.EXAMPLE}>
+                With focusable trigger
+                {" "}
+                <Tooltip
+                  content="Tooltips can be triggered by focus as well."
+                  placement={placement}
+                  textAlign={textAlign}
+                >
+                  <span
+                    className={classnames("fa fa-question-circle", cssClass.TRIGGER)}
+                    ref="focusableTrigger"
+                    tabIndex={0}
+                  />
+                </Tooltip>
+              </div>
+            </ExampleCode>
           </div>
           <div className={cssClass.CONFIG}>
             Placement:

--- a/docs/components/TypographyView.jsx
+++ b/docs/components/TypographyView.jsx
@@ -46,18 +46,7 @@ export default class TypographyView extends PureComponent {
               </div>
             </Col>
             <Col span={4} className="flexbox">
-              <Example
-                title=""
-                code={`
-                  <p className="text--colossal">Colossal</p>
-                  <p className="text--gargantuan">Gargantuan</p>
-                  <p className="text--huge">Huge</p>
-                  <p className="text--large">Large</p>
-                  <p className="text--medium">Medium</p>
-                  <p className="text--small">Small</p>
-                  <p className="text--tiny">Tiny</p>
-                `}
-              >
+              <Example>
                 <p className="text--colossal margin--none">Colossal</p>
                 <p className="text--gargantuan margin--none">Gargantuan</p>
                 <p className="text--huge margin--none">Huge</p>
@@ -79,16 +68,7 @@ export default class TypographyView extends PureComponent {
               </div>
             </Col>
             <Col span={4} className="flexbox">
-              <Example
-                title=""
-                code={`
-                  <p className="text--light">Proxima Nova Light</p>
-                  <p className="text--regular">Proxima Nova Regular</p>
-                  <p className="text--semi-bold">Proxima Nova Semibold</p>
-                  <p className="text--bold">Proxima Nova Bold</p>
-                  <p className="text--heavy">Proxima Nova Heavy</p>
-                `}
-              >
+              <Example>
                 <p className="text--large text--light">Proxima Nova Light</p>
                 <p className="text--large text--regular">Proxima Nova Regular</p>
                 <p className="text--large text--semi-bold">Proxima Nova Semibold</p>


### PR DESCRIPTION
Removes the `code` prop from `<Example>` components where possible now that it can be filled in automatically (see https://github.com/Clever/components/pull/161).