### PR TITLE
FEE-72: update secondary border color

### DIFF
--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -75,8 +75,8 @@ a, button {
   }
 
   &.Button--secondary {
+    .tint(border-color, @primary_blue, 2);
     background-color: @neutral_off_white;
-    border-color: @primary_blue;
     color: @primary_blue;
 
     &:hover,

--- a/src/DropdownButton/DropdownButton.less
+++ b/src/DropdownButton/DropdownButton.less
@@ -58,35 +58,25 @@
  */
 
 .Button--primary.DropdownButton--toggle {
-  .DropdownButton--Caret--container {
-    .border--left--s(shade(@primary_blue, @shadeStepAmount * 2));
-  }
+  .border--left--s(shade(@primary_blue, @shadeStepAmount * 2));
 }
 
 .Button--secondary.DropdownButton--toggle {
-  .DropdownButton--Caret--container {
-    .border--left--s(@primary_blue);
-  }
+  .border--left--s(tint(@primary_blue, @shadeStepAmount * 2));
 }
 
 .Button--destructive.DropdownButton--toggle {
-  .DropdownButton--Caret--container {
-    .border--left--s(shade(@alert_red, @shadeStepAmount * 2));
-  }
+  .border--left--s(shade(@alert_red, @shadeStepAmount * 2));
 }
 
 .Button.DropdownButton--toggle[disabled] {
-  .DropdownButton--Caret--container {
-    .border--left--s(shade(@neutral_silver, @shadeStepAmount * 2));
-  }
+  .border--left--s(shade(@neutral_silver, @shadeStepAmount * 2));
 }
 
 // Hide the partition on hover to avoid clashing with the darkened background in the "primary" and
 // "destructive" button types.
 .DropdownButton--buttons:hover {
   .Button.DropdownButton--toggle:not(.Button--secondary):not([disabled]) {
-    .DropdownButton--Caret--container {
-      .border--left--s(transparent);
-    }
+    .border--left--s(transparent);
   }
 }

--- a/src/DropdownButton/DropdownButton.less
+++ b/src/DropdownButton/DropdownButton.less
@@ -21,7 +21,6 @@
   .flex(0, 0);
   // Padding will be re-applied on the child Caret--container element.
   .padding--x--none;
-  border-left: 0;
   box-sizing: content-box;
   border-top-left-radius: 0;
 }
@@ -61,22 +60,10 @@
   .border--left--s(shade(@primary_blue, @shadeStepAmount * 2));
 }
 
-.Button--secondary.DropdownButton--toggle {
-  .border--left--s(tint(@primary_blue, @shadeStepAmount * 2));
-}
-
 .Button--destructive.DropdownButton--toggle {
   .border--left--s(shade(@alert_red, @shadeStepAmount * 2));
 }
 
 .Button.DropdownButton--toggle[disabled] {
   .border--left--s(shade(@neutral_silver, @shadeStepAmount * 2));
-}
-
-// Hide the partition on hover to avoid clashing with the darkened background in the "primary" and
-// "destructive" button types.
-.DropdownButton--buttons:hover {
-  .Button.DropdownButton--toggle:not(.Button--secondary):not([disabled]) {
-    .border--left--s(transparent);
-  }
 }


### PR DESCRIPTION
**Jira:**
[FEE-72](https://clever.atlassian.net/browse/FEE-72)

**Overview:**
- Update secondary button border color so that hover / focus state is much more visible
- Update left border on dropdown button to be full height of button

**Screenshots/GIFs:**
Old secondary button hover
![1aeb2071959f2d9c342603f95aa89f3c](https://cloud.githubusercontent.com/assets/835698/25353766/4430b5f2-28e5-11e7-8a72-b20d373c4fdb.gif)

New secondary button hover
![f4bcc88b146e90f1902a10e8236794e4](https://cloud.githubusercontent.com/assets/835698/25353715/17081084-28e5-11e7-8d4a-fef2c8cd40f8.gif)

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
