### PR TITLE
README: use absolute links for documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Clever Design System
 
-Check out [documentation and live examples](clever.github.io/components/#/intro) for Dewey, as well as our [getting starting guide](clever.github.io/components/#/getting-started).
+Check out [documentation and live examples](https://clever.github.io/components/#/intro) for Dewey, as well as our [getting starting guide](https://clever.github.io/components/#/getting-started).


### PR DESCRIPTION
Currently they're treated as relative links to https://github.com/Clever/components/blob/master/clever.github.io/components/#/intro and https://github.com/Clever/components/blob/master/clever.github.io/components/#/getting-started, which do not exist.