### PR TITLE
add style to modalbutton's button to match height of container div

### DIFF
--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -34,6 +34,7 @@ a, button {
     font-weight: 600;
     text-decoration: none;
     transition: all 0.25s ease-out;
+    white-space: nowrap;
 
     &[disabled],
     &[disabled]:hover,

--- a/src/ModalButton/ModalButton.jsx
+++ b/src/ModalButton/ModalButton.jsx
@@ -6,6 +6,7 @@ import {omitKeys, prefixKeys, propsFor, unprefixKeys} from "../utils";
 
 const excludeModalProps = ["closeModal", "children"];
 
+import "./ModalButton.less";
 export class ModalButton extends React.Component {
   constructor(props) {
     super(props);

--- a/src/ModalButton/ModalButton.less
+++ b/src/ModalButton/ModalButton.less
@@ -1,0 +1,9 @@
+.ModalButton {
+  position: relative; // create positioning context
+}
+
+.ModalButton > .Button {
+  position: absolute; // ensure button is height of parent
+  height: 100%;
+}
+


### PR DESCRIPTION
**Jira:**
none

**Overview:**
Add 100% height styling to modal button's nested button, so that it matches height of parent. Also adds `nowrap` to `Button` after talking with @mischelle-m , confirming that we shouldn't be having multi-line buttons anyway.

**Screenshots/GIFs:**

NOTE: the real version of the example page used below doesn't actually use the primary type links in an infopanel footer; it's just to illustrate the true size of the buttons.

### Buggy behavior
In a flex parent, the modalbutton is smaller than the rest of them. its wrapping div matches the correct height, but not the child button.

![screen shot 2017-05-04 at 10 31 27](https://cloud.githubusercontent.com/assets/1890926/25716797/41aaa75c-30b5-11e7-88f7-f8275a33e7b2.png)

### With the fix
![screen shot 2017-05-04 at 10 31 41](https://cloud.githubusercontent.com/assets/1890926/25716811/4a8b69a6-30b5-11e7-8095-1cda625fbe54.png)


### With expanded parent height
![screen shot 2017-05-04 at 10 31 55](https://cloud.githubusercontent.com/assets/1890926/25716819/501c3e0e-30b5-11e7-927f-2dceb4a92c31.png)



### In its natural documentation habitat
![screen shot 2017-05-04 at 10 31 15](https://cloud.githubusercontent.com/assets/1890926/25716791/3d5323be-30b5-11e7-987d-9cdae68c92f0.png)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
