### PR TITLE
Select: add creatable option

### DIFF
--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -19,6 +19,7 @@ export default class SelectView extends Component {
       multi: false,
       readOnly: false,
       searchable: false,
+      creatable: false,
       selectValue: null,
     };
   }
@@ -46,6 +47,8 @@ export default class SelectView extends Component {
                 disabled={this.state.disabled}
                 clearable={this.state.clearable}
                 searchable={this.state.searchable}
+                creatable={this.state.creatable}
+                creatableProps={{promptTextCreator: (label) => `Add new option: ${label}`}}
                 multi={this.state.multi}
                 readOnly={this.state.readOnly}
                 name="select"
@@ -82,6 +85,15 @@ export default class SelectView extends Component {
             />
             {" "}
             Searchable
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={this.state.creatable}
+              onChange={({target}) => this.setState({creatable: target.checked})}
+            />
+            {" "}
+            Creatable
           </label>
           <label className={cssClass.CONFIG}>
             <input
@@ -135,6 +147,19 @@ export default class SelectView extends Component {
               type: "Boolean",
               description: "Whether the selected value can be cleared",
               defaultValue: "False",
+              optional: true,
+            },
+            {
+              name: "creatable",
+              type: "Boolean",
+              description: "Whether to allow users to create custom new options. Only works when searchable enabled.",
+              defaultValue: "False",
+              optional: true,
+            },
+            {
+              name: "creatableProps",
+              type: "Object",
+              description: "If creatable is true, creatableProps can be passed in to customize the behavior of new option creation. See the ReactSelect docs for the Creatable component to learn about these options.",
               optional: true,
             },
             {

--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -48,7 +48,7 @@ export default class SelectView extends Component {
                 clearable={this.state.clearable}
                 searchable={this.state.searchable}
                 creatable={this.state.creatable}
-                creatableProps={{promptTextCreator: (label) => `Add new option: ${label}`}}
+                creatablePromptFn={label => `Add new option: ${label}`}
                 multi={this.state.multi}
                 readOnly={this.state.readOnly}
                 name="select"
@@ -157,9 +157,10 @@ export default class SelectView extends Component {
               optional: true,
             },
             {
-              name: "creatableProps",
-              type: "Object",
-              description: "If creatable is true, creatableProps can be passed in to customize the behavior of new option creation. See the ReactSelect docs for the Creatable component to learn about these options.",
+              name: "creatablePromptFn",
+              type: "Function",
+              description: "If creatable is true, creatablePromptFn can be passed in to customize the prompt shown for creating a new option. The function should take the string entered by the user and returns a string to use as the prompt.",
+              defaultValue: "(label) => `Create option \"${label}\"`",
               optional: true,
             },
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.24.5",
+  "version": "0.25.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -37,6 +37,8 @@ export function Select({
   placeholder = "",
   readOnly,
   searchable,
+  creatable,
+  creatableProps,
   value,
   className,
 }) {
@@ -52,12 +54,15 @@ export function Select({
     reactSelectClasses += ` ${cssClass.READ_ONLY}`;
   }
 
+  const SelectComponent = creatable ? ReactSelect.Creatable : ReactSelect;
+  const extraProps = creatable && creatableProps;
+
   // The label container must be returned after the ReactSelect otherwise it does not get displayed
   // in the browser.
   return (
     <div className={classnames(cssClass.CONTAINER, className)}>
       <div id={id}>
-        <ReactSelect
+        <SelectComponent
           className={reactSelectClasses}
           clearable={clearable}
           disabled={disabled || readOnly}
@@ -69,6 +74,7 @@ export function Select({
           placeholder={placeholder}
           searchable={searchable}
           value={value}
+          {...extraProps}
         />
       </div>
       <div className={labelContainerClasses}>
@@ -105,6 +111,8 @@ Select.propTypes = {
   placeholder: React.PropTypes.string,
   readOnly: React.PropTypes.bool,
   searchable: React.PropTypes.bool,
+  creatable: React.PropTypes.bool,
+  creatableProps: React.PropTypes.object,
   value: React.PropTypes.oneOfType([
     React.PropTypes.string,
     selectValuePropType,
@@ -118,4 +126,5 @@ Select.defaultProps = {
   clearable: false,
   placeholder: "",
   searchable: false,
+  creatable: false,
 };

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -38,7 +38,7 @@ export function Select({
   readOnly,
   searchable,
   creatable,
-  creatableProps,
+  creatablePromptFn,
   value,
   className,
 }) {
@@ -55,7 +55,6 @@ export function Select({
   }
 
   const SelectComponent = creatable ? ReactSelect.Creatable : ReactSelect;
-  const extraProps = creatable && creatableProps;
 
   // The label container must be returned after the ReactSelect otherwise it does not get displayed
   // in the browser.
@@ -65,6 +64,7 @@ export function Select({
         <SelectComponent
           className={reactSelectClasses}
           clearable={clearable}
+          promptTextCreator={creatablePromptFn}
           disabled={disabled || readOnly}
           multi={multi}
           name={name}
@@ -74,7 +74,6 @@ export function Select({
           placeholder={placeholder}
           searchable={searchable}
           value={value}
-          {...extraProps}
         />
       </div>
       <div className={labelContainerClasses}>
@@ -112,7 +111,7 @@ Select.propTypes = {
   readOnly: React.PropTypes.bool,
   searchable: React.PropTypes.bool,
   creatable: React.PropTypes.bool,
-  creatableProps: React.PropTypes.object,
+  creatablePromptFn: React.PropTypes.func,
   value: React.PropTypes.oneOfType([
     React.PropTypes.string,
     selectValuePropType,

--- a/test/Select_test.jsx
+++ b/test/Select_test.jsx
@@ -222,31 +222,18 @@ describe("Select", () => {
     assert.equal(creatable.prop("name"), "testname");
   });
 
-  it("passes through creatableProps to the ReactSelect Creatable component to allow customizing", () => {
-    const creatableProps = {promptTextCreator: (label) => `Add ${label}`};
+  it("passes through creatablePromptFn to the ReactSelect Creatable component to allow customizing prompt text for new options", () => {
+    const promptFn = label => `Add ${label}`;
     const select = shallow(
       <Select
         id="testid"
         name="testname"
         creatable
-        creatableProps={creatableProps}
+        creatablePromptFn={promptFn}
       />
     );
     const creatable = select.find(ReactSelect.Creatable);
     assert(!creatable.isEmpty());
-    assert.equal(creatable.prop("promptTextCreator"), creatableProps.promptTextCreator);
-  });
-
-  it("doesn't pass through creatableProps if creatable false", () => {
-    const creatableProps = {promptTextCreator: (label) => `Add ${label}`};
-    const select = shallow(
-      <Select
-        id="testid"
-        name="testname"
-        creatableProps={creatableProps}
-      />
-    );
-    const reactSelect = select.find(ReactSelect);
-    assert(!reactSelect.prop("promptTextCreator"));
+    assert.equal(creatable.prop("promptTextCreator"), promptFn);
   });
 });

--- a/test/Select_test.jsx
+++ b/test/Select_test.jsx
@@ -208,4 +208,45 @@ describe("Select", () => {
     const reactSelect = select.find(ReactSelect);
     assert.equal(reactSelect.prop("placeholder"), "");
   });
+
+  it("uses the ReactSelect Creatable component to allow creating custom options if creatable prop is true", () => {
+    const select = shallow(
+      <Select
+        id="testid"
+        name="testname"
+        creatable
+      />
+    );
+    const creatable = select.find(ReactSelect.Creatable);
+    assert(!creatable.isEmpty());
+    assert.equal(creatable.prop("name"), "testname");
+  });
+
+  it("passes through creatableProps to the ReactSelect Creatable component to allow customizing", () => {
+    const creatableProps = {promptTextCreator: (label) => `Add ${label}`};
+    const select = shallow(
+      <Select
+        id="testid"
+        name="testname"
+        creatable
+        creatableProps={creatableProps}
+      />
+    );
+    const creatable = select.find(ReactSelect.Creatable);
+    assert(!creatable.isEmpty());
+    assert.equal(creatable.prop("promptTextCreator"), creatableProps.promptTextCreator);
+  });
+
+  it("doesn't pass through creatableProps if creatable false", () => {
+    const creatableProps = {promptTextCreator: (label) => `Add ${label}`};
+    const select = shallow(
+      <Select
+        id="testid"
+        name="testname"
+        creatableProps={creatableProps}
+      />
+    );
+    const reactSelect = select.find(ReactSelect);
+    assert(!reactSelect.prop("promptTextCreator"));
+  });
 });


### PR DESCRIPTION
**Jira:** none

**Overview:** Adds a `creatable` prop to allow users to create new options. Implemented using the ReactSelect Creatable component as recommended in the docs: https://github.com/JedWatson/react-select#user-created-tags. Also adds a `creatableProps` prop to allow configuration of new option creation. I chose this because I didn't want to have an opinion about what kinds of customization is worthwhile - I figure ReactSelect got the way it did for a reason so we should just use their behavior.

**Screenshots/GIFs:**
![screenshot 2017-05-05 15 40 59](https://cloud.githubusercontent.com/assets/530106/25766745/45127bfa-31a9-11e7-9027-65f630d702ed.png)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
