### PR TITLE
Wizard: support opening wizard at a specific step

### DIFF
--- a/docs/components/WizardView.jsx
+++ b/docs/components/WizardView.jsx
@@ -72,6 +72,13 @@ export default class WizardView extends PureComponent {
               optional: true,
             },
             {
+              name: "initialStep",
+              type: "Number",
+              description: "The index of the step to open the wizard at",
+              defaultValue: 0,
+              optional: true,
+            },
+            {
               name: "initialWizardData",
               type: "Object",
               description: "Initial data to seed wizardState. Useful for saving the state of a form for later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -18,10 +18,21 @@ export class Wizard extends React.Component {
     this.state = _.assign(INITIAL_STATE, {
       data: props.initialWizardData || {},
     });
+
     this.reset = this.reset.bind(this);
     this.prevStepHandler = this.prevStepHandler.bind(this);
     this.nextStepHandler = this.nextStepHandler.bind(this);
     this.calculatePercentComplete = this.calculatePercentComplete.bind(this);
+
+    // Launch the wizard at a specific step (e.g. to resume at furthest step)
+    if (this.props.initialStep) {
+      const idx = this.props.initialStep;
+      Object.assign(this.state, {
+        currentStep: idx,
+        stepsVisited: _.range(idx + 1), // include the step itself
+        percentComplete: this.calculatePercentComplete(),
+      });
+    }
   }
 
   reset() {
@@ -214,6 +225,7 @@ Wizard.propTypes = {
     props: PropTypes.object,
     onStepComplete: PropTypes.func,
   })).isRequired,
+  initialStep: PropTypes.number,
   nextButtonValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   prevButtonValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   seekable: PropTypes.bool,


### PR DESCRIPTION
**Overview:**

The wizard always opens at the first step by default, but sometimes we want to resume the wizard at a specific later step, e.g. the furthest step the user has reached so far.

**Screenshots/GIFs:**

https://cl.ly/321i0X294610

![](https://d3dr1ze7164817.cloudfront.net/items/3N3l1F1N1H3T0Z1v1135/Screen%20Recording%202017-05-09%20at%2005.15%20PM.gif)

**Testing:**
- [ ] Unit tests - I think the demo (see above) is more useful, since this essentially only calls an existing method when a prop value is set.
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10 - no, but I don't think this is necessary since it just conditionally updates state in an existing component to an already-possible value.

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
