### PR TITLE
Sticky wizard sidebar

### DIFF
--- a/docs/WizardExample.jsx
+++ b/docs/WizardExample.jsx
@@ -143,6 +143,7 @@ export default class WizardExample extends React.Component {
     this.state = {
       seekable: false,
       showHelp: false,
+      sticky: false,
       prevButtonValue: "Back",
       hideProgressBar: false,
       recipient: "Kristen Stark",
@@ -211,6 +212,15 @@ export default class WizardExample extends React.Component {
             </label>
           </li>
           <li>
+            <label>
+              <input
+                type="checkbox"
+                onChange={(e) => this.setState({sticky: e.target.checked})}
+              />
+              Sticky sidebar?
+            </label>
+          </li>
+          <li>
             <TextInput
               value={this.state.recipient}
               onChange={(e) => this.setState({recipient: e.target.value})}
@@ -232,6 +242,7 @@ export default class WizardExample extends React.Component {
       <Wizard
         title="Delivery setup"
         description="Ensure that your delivery will come on time"
+        stickySidebar={this.state.sticky}
         steps={steps}
         prevButtonValue={this.state.prevButtonValue}
         onComplete={(state) =>
@@ -257,6 +268,7 @@ export default class WizardExample extends React.Component {
         )}
         seekable={this.state.seekable}
         hideProgressBar={this.state.hideProgressBar}
+        style={{height: 700}}
       />
     </div>);
   }

--- a/docs/components/WizardView.jsx
+++ b/docs/components/WizardView.jsx
@@ -121,6 +121,13 @@ export default class WizardView extends PureComponent {
               defaultValue: "[]",
               optional: true,
             },
+            {
+              name: "stickySidebar",
+              type: "boolean",
+              description: "Whether the sidebar should be fixed vertically",
+              defaultValue: "false",
+              optional: true,
+            },
           ]}
           className={cssClass.PROPS}
           title="Wizard"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-dropzone": "^3.11.0",
     "react-onclickoutside": "^5.11.1",
     "react-select": "^1.0.0-beta14",
+    "react-sticky": "^6.0.1",
     "short-number": "^1.0.6",
     "tether": "^1.4.0"
   },

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
 import React, {PropTypes} from "react";
+import {Sticky, StickyContainer} from "react-sticky";
 import _ from "lodash";
 
 import WizardStep from "./WizardStep";
@@ -82,10 +83,72 @@ export class Wizard extends React.Component {
     return validSteps.length / this.props.steps.length;
   }
 
+  _renderSidebar(style) {
+    const {
+      title, description, wizardButtons, steps, seekable, hideProgressBar,
+    } = this.props;
+
+    return (
+      <div style={style} className="Wizard--sidebarContent">
+        <h2>{title}</h2>
+        {_.isString(description) ?
+          <p className="Wizard--description">{description}</p>
+        :
+          <div className="Wizard--description">{description}</div>
+        }
+        { !hideProgressBar &&
+          <ProgressBar percentage={this.state.percentComplete} />
+        }
+        <ul className="Wizard--stepsDisplay">
+          {steps.map((step, idx) => {
+            const stepValid = step.validate(this.state.data);
+            const stepVisited = _.includes(this.state.stepsVisited, idx);
+            const stepClassName = classnames(
+              "Wizard--stepsDisplay--step",
+              idx === this.state.currentStep && "Wizard--stepsDisplay--currentStep",
+              stepValid && "Wizard--stepsDisplay--valid",
+              stepVisited && "Wizard--stepsDisplay--visited",
+              seekable && "Wizard--stepsDisplay--stepLink"
+            );
+            const listValue = (<span className={stepClassName}>
+              <span className="Wizard--stepsDisplay--icon" />
+              <span className="Wizard--stepsDisplay--stepTitle">{step.title}</span>
+            </span>);
+            return (
+              <li key={idx}>
+                { seekable ?
+                  <Button
+                    className="Wizard--stepsDisplay--stepButton"
+                    type="link" onClick={() => this.jumpToStep(idx)}
+                    value={listValue}
+                  />
+                :
+                  listValue
+                }
+              </li>
+            );
+          })}
+        </ul>
+        {wizardButtons &&
+          <div className="Wizard--controls">
+            {wizardButtons.map((btnSpec, idx) => (
+              <Button
+                key={idx}
+                onClick={() => btnSpec.handler(this.state.data, {resetWizard: this.reset})}
+                value={btnSpec.buttonValue}
+                className={classnames("Wizard--controls--control", btnSpec.buttonClassName)}
+              />
+            ))}
+          </div>
+        }
+      </div>
+    );
+  }
+
   render() {
     const {
-      className, style, title, description, help, wizardButtons, steps, nextButtonValue,
-      prevButtonValue, seekable, hideProgressBar,
+      className, style, help, steps, nextButtonValue,
+      prevButtonValue, stickySidebar,
     } = this.props;
 
     const classes = classnames("Wizard", className);
@@ -98,107 +161,61 @@ export class Wizard extends React.Component {
       validSteps.length !== steps.length : !curStep.validate(this.state.data);
 
     return (
-      <div className={classes} style={style}>
-        <div className="Wizard--sidebar">
-          <div className="Wizard--sidebarContent">
-            <h2>{title}</h2>
-            {_.isString(description) ?
-              <p className="Wizard--description">{description}</p>
-            :
-              <div className="Wizard--description">{description}</div>
-            }
-            { !hideProgressBar &&
-              <ProgressBar percentage={this.state.percentComplete} />
-            }
-            <ul className="Wizard--stepsDisplay">
-              {steps.map((step, idx) => {
-                const stepValid = step.validate(this.state.data);
-                const stepVisited = _.includes(this.state.stepsVisited, idx);
-                const stepClassName = classnames(
-                  "Wizard--stepsDisplay--step",
-                  idx === this.state.currentStep && "Wizard--stepsDisplay--currentStep",
-                  stepValid && "Wizard--stepsDisplay--valid",
-                  stepVisited && "Wizard--stepsDisplay--visited",
-                  seekable && "Wizard--stepsDisplay--stepLink"
-                );
-                const listValue = (<span className={stepClassName}>
-                  <span className="Wizard--stepsDisplay--icon" />
-                  <span className="Wizard--stepsDisplay--stepTitle">{step.title}</span>
-                </span>);
-                return (
-                  <li key={idx}>
-                    { seekable ?
-                      <Button
-                        className="Wizard--stepsDisplay--stepButton"
-                        type="link" onClick={() => this.jumpToStep(idx)}
-                        value={listValue}
-                      />
-                    :
-                      listValue
-                    }
-                  </li>
-                );
-              })}
-            </ul>
-            {wizardButtons &&
-              <div className="Wizard--controls">
-                {wizardButtons.map((btnSpec, idx) => (
-                  <Button
-                    key={idx}
-                    onClick={() => btnSpec.handler(this.state.data, {resetWizard: this.reset})}
-                    value={btnSpec.buttonValue}
-                    className={classnames("Wizard--controls--control", btnSpec.buttonClassName)}
-                  />
-                ))}
-              </div>
-            }
+      <StickyContainer>
+        <div className={classes} style={style}>
+          <div className="Wizard--sidebar">
+            {!stickySidebar ? this._renderSidebar() : (
+              <Sticky topOffset={24}>
+                {({style: sidebarStyle}) => this._renderSidebar(sidebarStyle)}
+              </Sticky>
+            )}
           </div>
-        </div>
 
-        <div className="Wizard--step">
-          <WizardStep
-            Component={steps[this.state.currentStep].component}
-            componentProps={steps[this.state.currentStep].props}
-            stepNumber={this.state.currentStep}
-            setWizardState={(changes) => {
-              const newState = Object.assign(this.state.data, changes);
-              this.setState({data: newState});
-              return newState;
-            }}
-            wizardState={this.state.data}
-            updatePercentComplete={(wizardState) => this.setState({
-              percentComplete: this.calculatePercentComplete(wizardState)})
-            }
-            calculatePercentComplete={this.calculatePercentComplete}
-            percentComplete={this.state.percentComplete}
-            totalSteps={steps.length}
-            title={curStep.title}
-            description={curStep.description}
-            currentStep={this.state.currentStep}
-            help={curStep.help ? curStep.help : help}
-            validate={curStep.validate}
-            prevButtonValue={curStep.prevButtonValue}
-            nextButtonValue={curStep.nextButtonValue}
-          />
-
-          <div className="Wizard--contentGroup Wizard--navButtons">
-            { this.state.currentStep !== 0 &&
-              <Button
-                className="Wizard--prevButton" type="link"
-                onClick={this.prevStepHandler}
-                value={curStep.prevButtonValue || prevButtonValue || "Back"}
-              />
-            }
-
-            <Button
-              className="Wizard--nextButton"
-              onClick={this.nextStepHandler}
-              disabled={nextDisabled} type="primary"
-              value={curStep.nextButtonValue || nextButtonValue || "Next"}
+          <div className="Wizard--step">
+            <WizardStep
+              Component={steps[this.state.currentStep].component}
+              componentProps={steps[this.state.currentStep].props}
+              stepNumber={this.state.currentStep}
+              setWizardState={(changes) => {
+                const newState = Object.assign(this.state.data, changes);
+                this.setState({data: newState});
+                return newState;
+              }}
+              wizardState={this.state.data}
+              updatePercentComplete={(wizardState) => this.setState({
+                percentComplete: this.calculatePercentComplete(wizardState)})
+              }
+              calculatePercentComplete={this.calculatePercentComplete}
+              percentComplete={this.state.percentComplete}
+              totalSteps={steps.length}
+              title={curStep.title}
+              description={curStep.description}
+              currentStep={this.state.currentStep}
+              help={curStep.help ? curStep.help : help}
+              validate={curStep.validate}
+              prevButtonValue={curStep.prevButtonValue}
+              nextButtonValue={curStep.nextButtonValue}
             />
+
+            <div className="Wizard--contentGroup Wizard--navButtons">
+              { this.state.currentStep !== 0 &&
+                <Button
+                  className="Wizard--prevButton" type="link"
+                  onClick={this.prevStepHandler}
+                  value={curStep.prevButtonValue || prevButtonValue || "Back"}
+                />
+              }
+
+              <Button
+                className="Wizard--nextButton"
+                onClick={this.nextStepHandler}
+                disabled={nextDisabled} type="primary"
+                value={curStep.nextButtonValue || nextButtonValue || "Next"}
+              />
+            </div>
           </div>
         </div>
-      </div>
+      </StickyContainer>
     );
   }
 }
@@ -230,4 +247,5 @@ Wizard.propTypes = {
   prevButtonValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   seekable: PropTypes.bool,
   hideProgressBar: PropTypes.bool,
+  stickySidebar: PropTypes.bool,
 };

--- a/src/Wizard/Wizard.less
+++ b/src/Wizard/Wizard.less
@@ -20,6 +20,10 @@
   }
 }
 
+.Wizard--stepsDisplay--stepTitle {
+  -ms-flex: 0 1 auto;
+}
+
 @content_width: 37.5rem;
 @help_min_width: 18.75rem;
 .Wizard--contentGroup {

--- a/src/Wizard/Wizard.less
+++ b/src/Wizard/Wizard.less
@@ -20,10 +20,6 @@
   }
 }
 
-.Wizard--stepsDisplay--stepTitle {
-  -ms-flex: 0 1 auto;
-}
-
 @content_width: 37.5rem;
 @help_min_width: 18.75rem;
 .Wizard--contentGroup {
@@ -115,6 +111,7 @@
 .Wizard--stepsDisplay--stepTitle {
   display: block;
   overflow: hidden;
+  -ms-flex: 0 1 auto;
 }
 
 .Wizard--stepsDisplay--icon {


### PR DESCRIPTION
**Overview:**
Adds an option to make the sidebar sticky on a wizard. Uses `react-sticky` since `position: fixed` messes up wildly when you can scroll horizontally.

**Screenshots/GIFs:**
![wizard-sticky](https://cloud.githubusercontent.com/assets/184140/25975221/f7fbf55e-3661-11e7-97ca-02fb46747409.gif)

**Testing:**
- [n/a] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
