### PR TITLE
Table: Handle empty lazy-table case.

### DIFF
--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -216,7 +216,7 @@ export class Table extends Component {
 
     let numPages;
     if (numRows != null) {
-      numPages = Math.ceil(numRows / pageSize);
+      numPages = Math.max(Math.ceil(numRows / pageSize), 1);
     } else {
       if (lazyPages.length === 0) {
         numPages = 1;


### PR DESCRIPTION
Previously, we weren't handling the empty lazy-table case (`numRows === 0`). Now we are.

**Screenshot:**
![image](https://cloud.githubusercontent.com/assets/184140/26019251/dde72298-3728-11e7-9330-5551e614dc1f.png)

**Roll Out:**
- Before merging:
  - [n/a] Updated docs
  - [ ] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
