### PR TITLE
Wizard: Don't overwrite globals.

### DIFF
--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -9,7 +9,7 @@ import {Button, ProgressBar} from "../";
 import "./Wizard.less";
 
 // this is a function so that we get a new array each time
-const INITIAL_STATE = () => ({
+const getInitialState = () => ({
   currentStep: 0,
   percentComplete: 0,
   stepsVisited: [0],
@@ -18,7 +18,7 @@ const INITIAL_STATE = () => ({
 export class Wizard extends React.Component {
   constructor(props) {
     super(props);
-    this.state = Object.assign({}, INITIAL_STATE(), {
+    this.state = Object.assign({}, getInitialState(), {
       data: props.initialWizardData || {},
     });
 
@@ -39,7 +39,7 @@ export class Wizard extends React.Component {
   }
 
   reset() {
-    this.setState(Object.assign({}, INITIAL_STATE(), {data: {}}));
+    this.setState(Object.assign({}, getInitialState(), {data: {}}));
   }
 
   jumpToStep(idx) {

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -8,15 +8,17 @@ import {Button, ProgressBar} from "../";
 
 import "./Wizard.less";
 
-const INITIAL_STATE = {
+// this is a function so that we get a new array each time
+const INITIAL_STATE = () => ({
   currentStep: 0,
   percentComplete: 0,
   stepsVisited: [0],
-};
+});
+
 export class Wizard extends React.Component {
   constructor(props) {
     super(props);
-    this.state = _.assign(INITIAL_STATE, {
+    this.state = Object.assign({}, INITIAL_STATE(), {
       data: props.initialWizardData || {},
     });
 
@@ -37,7 +39,7 @@ export class Wizard extends React.Component {
   }
 
   reset() {
-    this.setState(_.assign({}, INITIAL_STATE, {data: {}}));
+    this.setState(Object.assign({}, INITIAL_STATE(), {data: {}}));
   }
 
   jumpToStep(idx) {


### PR DESCRIPTION
Since the constructor was setting didn't use a new empty object to initialize the state, and instead used the `INITIAL_STATE` variable, updates to the current step with `props.initialStep` would overwrite the `currentStep` in `INITIAL_STATE`. This fixes that, and also guards against potential  modifications of the `stepsVisited` array by turning `INITIAL_STATE` into a function (so a new array gets generated each time).

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
