### PR TITLE
Footer: Always show if loading.

### DIFF
--- a/src/Table/Footer.jsx
+++ b/src/Table/Footer.jsx
@@ -25,7 +25,7 @@ export default function Footer({currentPage, numColumns, numPages, onPageChange,
     onPageChange(page);
   };
 
-  if (numPages < 2 && !lengthUnknown) {
+  if (numPages < 2 && !lengthUnknown && !isLoading) {
     return null;
   }
 


### PR DESCRIPTION
Sometimes we know the number of pages even with lazy tables and it could turn out there's only one page, but we still want to show the loading indicator while that one page is loading. As such, we need to show the footer while `isLoading === true`.

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
