### PR TITLE
Table: Handle column removal + sorting.

### DIFF
--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -190,18 +190,22 @@ export class Table extends Component {
     }
     if (sortState) {
       const sortedColumn = this._getColumn(sortState.columnID);
-      displayedData = displayedData.sortBy(row => {
-        let value = sortedColumn.props.sortValueFn(row);
+      // sortedColumn might not exist if a column is removed from the table
+      // dynamically. in this case, just ignore the sort state.
+      if (sortedColumn) {
+        displayedData = displayedData.sortBy(row => {
+          let value = sortedColumn.props.sortValueFn(row);
 
-        if (typeof value === "string") {
-          value = value.trim().toLowerCase();
+          if (typeof value === "string") {
+            value = value.trim().toLowerCase();
+          }
+
+          return value;
+        });
+
+        if (sortState.direction === sortDirection.DESCENDING) {
+          displayedData = displayedData.reverse();
         }
-
-        return value;
-      });
-
-      if (sortState.direction === sortDirection.DESCENDING) {
-        displayedData = displayedData.reverse();
       }
     }
 


### PR DESCRIPTION
If you remove a column (dynamically) that was being sorted on, `this._getColumn` returns undefined, breaking the table. This fixes that.

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
