### PR TITLE
Select: Support lazy-loading options.

### DIFF
--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -229,8 +229,14 @@ export default class SelectView extends Component {
             },
             {
               name: "loadOptions",
-              type: "(input: string) => Promise<{options: {label: string; value: string}[]}>",
-              description: "Function to load options for a given search input. Required if `lazy`.",
+              type: "(input: string) => Promise<{options: {label: string; value: string}[], complete: boolean}>",
+              description: "Function to load options for a given search input. " +
+                "Required if `lazy`. When the component is mounted, this function " +
+                "will be called with the empty string as input to seed the default " +
+                "set of options. Results are cached. If you set `complete` to `true` " +
+                "in the return value to indicate that the set of options is the complete " +
+                "set for that query, then more specific queries will not incur new " +
+                "(unnecessary) calls to `loadOptions`.
               optional: true,
             },
             {

--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -236,7 +236,7 @@ export default class SelectView extends Component {
                 "set of options. Results are cached. If you set `complete` to `true` " +
                 "in the return value to indicate that the set of options is the complete " +
                 "set for that query, then more specific queries will not incur new " +
-                "(unnecessary) calls to `loadOptions`.
+                "(unnecessary) calls to `loadOptions`.",
               optional: true,
             },
             {

--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -20,6 +20,7 @@ export default class SelectView extends Component {
       readOnly: false,
       searchable: false,
       creatable: false,
+      lazy: false,
       selectValue: null,
     };
   }
@@ -48,12 +49,19 @@ export default class SelectView extends Component {
                 clearable={this.state.clearable}
                 searchable={this.state.searchable}
                 creatable={this.state.creatable}
+                lazy={this.state.lazy}
                 creatablePromptFn={label => `Add new option: ${label}`}
                 multi={this.state.multi}
                 readOnly={this.state.readOnly}
                 name="select"
                 onChange={value => this.setState({selectValue: value})}
-                options={_.range(100).map(i => ({label: `Option ${i + 1}`, value: `${i + 1}`}))}
+                options={!this.state.lazy && _.range(100).map(i => ({label: `Option ${i + 1}`, value: `${i + 1}`}))}
+                loadOptions={this.state.lazy && (async (input) => {
+                  await new Promise(resolve => setTimeout(resolve, 1000));
+                  const allOptions = _.range(100).map(i => ({label: `Option ${i + 1}`, value: `${i + 1}`}));
+                  const options = allOptions.filter(x => x.label.toLowerCase().startsWith(input.toLowerCase()));
+                  return {options};
+                })}
                 placeholder="Select Placeholder"
                 value={this.state.selectValue}
               />
@@ -94,6 +102,15 @@ export default class SelectView extends Component {
             />
             {" "}
             Creatable
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={this.state.lazy}
+              onChange={({target}) => this.setState({lazy: target.checked})}
+            />
+            {" "}
+            Lazy
           </label>
           <label className={cssClass.CONFIG}>
             <input

--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -216,8 +216,21 @@ export default class SelectView extends Component {
             },
             {
               name: "options",
-              type: "Array",
-              description: "Possible options, must contain objects with label and value attributes.",
+              type: "{label: string; value: string}[]",
+              description: "Possible options, must contain objects with label and value attributes. Must not be set if `lazy`.",
+              optional: true,
+            },
+            {
+              name: "lazy",
+              type: "boolean",
+              description: "Set to true to fetch options asynchronously using the `loadOptions` function.",
+              defaultValue: "false",
+              optional: true,
+            },
+            {
+              name: "loadOptions",
+              type: "(input: string) => Promise<{options: {label: string; value: string}[]}>",
+              description: "Function to load options for a given search input. Required if `lazy`.",
               optional: true,
             },
             {

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -70,11 +70,14 @@ export function Select({
     reactSelectClasses += ` ${cssClass.READ_ONLY}`;
   }
 
-  const SelectComponent =
-    creatable && lazy ? ReactSelect.AsyncCreatable :
-    creatable ? ReactSelect.Creatable :
-    lazy ? ReactSelect.Async :
-    ReactSelect;
+  let SelectComponent = ReactSelect;
+  if (creatable && lazy) {
+    SelectComponent = ReactSelect.AsyncCreatable;
+  } else if (creatable) {
+    SelectComponent = ReactSelect.Creatable;
+  } else if (lazy) {
+    SelectComponent = ReactSelect.Async;
+  }
 
   // The label container must be returned after the ReactSelect otherwise it does not get displayed
   // in the browser.
@@ -128,6 +131,8 @@ Select.propTypes = {
   onChange: React.PropTypes.func,
   optionRenderer: React.PropTypes.func,
   options: React.PropTypes.arrayOf(selectValuePropType),
+  lazy: React.PropTypes.bool,
+  loadOptions: React.PropTypes.func,
   placeholder: React.PropTypes.string,
   readOnly: React.PropTypes.bool,
   searchable: React.PropTypes.bool,

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -19,11 +19,9 @@ function isLabelHidden(placeholder, value) {
 }
 
 /*
-  Component to allow selecting options from a list. Right now this only supports a basic dropdown
-  with a fixed list of options. This component will be updated to allow searching for options that
-  may be fetched asynchronously.
-*/
-
+ * Component to allow selecting options from a list. It can fetch those options
+ * synchronously or asynchronously by specifying the `lazy` parameter.
+ */
 export function Select({
   id,
   name,
@@ -34,6 +32,8 @@ export function Select({
   onChange,
   optionRenderer,
   options,
+  lazy,
+  loadOptions,
   placeholder = "",
   readOnly,
   searchable,
@@ -43,6 +43,22 @@ export function Select({
   className,
 }) {
   const {cssClass} = Select;
+
+  if (!lazy) {
+    if (!options) {
+      console.error("Select: prop \"options\" must be set if not \"lazy\"");
+    }
+    if (loadOptions) {
+      console.error("Select: prop \"loadOptions\" may not be set if not \"lazy\"");
+    }
+  } else {
+    if (options) {
+      console.error("Select: prop \"options\" may not be set if not \"lazy\"");
+    }
+    if (!loadOptions) {
+      console.error("Select: prop \"loadOptions\" must be set if not \"lazy\"");
+    }
+  }
 
   let labelContainerClasses = cssClass.LABEL_CONTAINER;
   if (isLabelHidden(placeholder, value)) {
@@ -54,7 +70,11 @@ export function Select({
     reactSelectClasses += ` ${cssClass.READ_ONLY}`;
   }
 
-  const SelectComponent = creatable ? ReactSelect.Creatable : ReactSelect;
+  const SelectComponent =
+    creatable && lazy ? ReactSelect.AsyncCreatable :
+    creatable ? ReactSelect.Creatable :
+    lazy ? ReactSelect.Async :
+    ReactSelect;
 
   // The label container must be returned after the ReactSelect otherwise it does not get displayed
   // in the browser.
@@ -71,6 +91,7 @@ export function Select({
           onChange={onChange}
           optionRenderer={optionRenderer}
           options={options}
+          loadOptions={loadOptions}
           placeholder={placeholder}
           searchable={searchable}
           value={value}

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -46,17 +46,17 @@ export function Select({
 
   if (!lazy) {
     if (!options) {
-      console.error("Select: prop \"options\" must be set if not \"lazy\"");
+      console.warn("Select: prop \"options\" must be set if not \"lazy\"");
     }
     if (loadOptions) {
-      console.error("Select: prop \"loadOptions\" may not be set if not \"lazy\"");
+      console.warn("Select: prop \"loadOptions\" may not be set if not \"lazy\"");
     }
   } else {
     if (options) {
-      console.error("Select: prop \"options\" may not be set if not \"lazy\"");
+      console.warn("Select: prop \"options\" may not be set if not \"lazy\"");
     }
     if (!loadOptions) {
-      console.error("Select: prop \"loadOptions\" must be set if not \"lazy\"");
+      console.warn("Select: prop \"loadOptions\" must be set if not \"lazy\"");
     }
   }
 


### PR DESCRIPTION
**Overview:**
Lets table fetch options from a backend server. Useful if there are lots of options.

**Screenshots/GIFs:**
![select-async](https://cloud.githubusercontent.com/assets/184140/26747954/6b32b154-47ae-11e7-8e0e-19455d2c1217.gif)

**Testing:** N/A? Just passing options to a 3rd party lib.
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
