### PR TITLE
Add rowData param to Table onRowClick

### DIFF
--- a/docs/components/TableView.jsx
+++ b/docs/components/TableView.jsx
@@ -89,7 +89,7 @@ export default class TableView extends PureComponent {
                 onPageChange={page => console.log("Table page changed:", page)}
                 onSortChange={sortState => console.log("Table sort changed:", sortState)}
                 onRowClick={enableRowClick
-                  ? (e, row) => console.log("Table row clicked:", row)
+                  ? (e, rowID, rowData) => console.log("Table row clicked:", {rowID, rowData})
                   : undefined
                 }
                 onViewChange={data => console.log("Table view changed:", data.map(d => d.id))}
@@ -209,6 +209,12 @@ export default class TableView extends PureComponent {
               name: "onPageChange",
               type: "Function",
               description: "Callback function for the 1-based index displayed page change event",
+              optional: true,
+            },
+            {
+              name: "onRowClick",
+              type: "Function",
+              description: "Callback function for when a table row is clicked",
               optional: true,
             },
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.13",
+  "version": "0.25.14",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -295,7 +295,7 @@ export class Table extends Component {
                 rowClassNameFn && rowClassNameFn(rowData)
               )}
               key={rowIDFn(rowData)}
-              onClick={e => onRowClick && onRowClick(e, rowIDFn(rowData))}
+              onClick={e => onRowClick && onRowClick(e, rowIDFn(rowData), rowData)}
             >
               {columns.map(({props: col}) => (
                 <Cell className={col.cell.className} key={col.id} noWrap={col.noWrap}>


### PR DESCRIPTION
**Overview:**

The Table component's `onRowClick` prop currently only has access to the ID of the clicked row. There are however scenarios where we want access to all row data, not just the ID. I've added accordingly added a `rowData` param. Since we're just adding a param to the signature and JS sets missing params to `undefined`, this change is backward compatible.

**Testing:**

Ran the docs locally and verified that the new param works.

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)