### PR TITLE
Adds a RichText component

### DIFF
--- a/docs/components/RichTextView.jsx
+++ b/docs/components/RichTextView.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+
+import Example from "./Example";
+import PropDocumentation from "./PropDocumentation";
+import View from "./View";
+import {RichText} from "src";
+
+export default function DateInputView() {
+  return (
+    <View title="RichText" sourcePath="src/RichText/RichText.jsx">
+      <p>
+        RichText is a view that improves rendering of raw text - Specifically by linkifying urls and not discarding linebreaks.
+      </p>
+      <i>Note - Rendering large blobs of text with urls isn't the best from an accessibility perspective, when possible links should have readable titles, instead of just a url.</i>
+      <h2>Without using RichText</h2>
+      <Example>
+        <p>{`
+          Do not go gentle into that good night,
+          Old age should burn and rave at close of day;
+          Rage, rage against the dying of the light.
+          
+          - https://www.poets.org/poetsorg/poem/do-not-go-gentle-good-night
+          - dylan.thomas@poems.com
+        `}</p>
+      </Example>
+      <h2>Using RichText</h2>
+      <Example>
+        <RichText
+          text={`
+            Do not go gentle into that good night,
+            Old age should burn and rave at close of day;
+            Rage, rage against the dying of the light.
+            
+            - https://www.poets.org/poetsorg/poem/do-not-go-gentle-good-night
+            - dylan.thomas@poems.com
+          `}
+        />
+      </Example>
+
+      <PropDocumentation
+        availableProps={[
+          {
+            name: "text",
+            type: "String",
+            description: "The text to render",
+            optional: false,
+          },
+        ]}
+      />
+    </View>
+  );
+}

--- a/docs/components/SideBar/SideBar.jsx
+++ b/docs/components/SideBar/SideBar.jsx
@@ -84,6 +84,7 @@ export default class SideBar extends React.Component {
           {this._renderLink("/components/modal-button", "ModalButton")}
           {this._renderLink("/components/number", "Number")}
           {this._renderLink("/components/progress-bar", "ProgressBar")}
+          {this._renderLink("/components/rich-text", "RichText")}
           {this._renderLink("/components/segmented-control", "SegmentedControl")}
           {this._renderLink("/components/select", "Select")}
           {this._renderLink("/components/tab-bar", "TabBar")}

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -30,6 +30,7 @@ import NumberView from "./components/NumberView";
 import PageLayoutView from "./components/PageLayoutView";
 import ProgressBarView from "./components/ProgressBarView";
 import SegmentedControlView from "./components/SegmentedControlView";
+import RichTextView from "./components/RichTextView";
 import SelectView from "./components/SelectView";
 import SizingView from "./components/SizingView";
 import SpacingView from "./components/SpacingView";
@@ -78,6 +79,7 @@ render((
         <Route path="modal-button(/*)" component={ModalButtonView} />
         <Route path="number(/*)" component={NumberView} />
         <Route path="progress-bar(/*)" component={ProgressBarView} />
+        <Route path="rich-text(/*)" component={RichTextView} />
         <Route path="segmented-control(/*)" component={SegmentedControlView} />
         <Route path="select(/*)" component={SelectView} />
         <Route path="tab-bar(/*)" component={TabBarView} />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.11",
+  "version": "0.25.12",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",
@@ -25,6 +25,7 @@
     "react-bootstrap": "^0.30.0",
     "react-copy-to-clipboard": "^4.2.1",
     "react-dropzone": "^3.11.0",
+    "react-linkify": "^0.2.1",
     "react-onclickoutside": "^5.11.1",
     "react-overlays": "^0.7.0",
     "react-select": "^1.0.0-beta14",

--- a/src/RichText/RichText.jsx
+++ b/src/RichText/RichText.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import Linkify from "react-linkify";
+
+export default function RichText(props) {
+  return (<Linkify properties={{target: "_blank"}}>
+    {props.text.split("\n").map((item, key) => <span key={key}>{item}<br /></span>)}
+  </Linkify>);
+}
+
+RichText.propTypes = {
+  text: React.PropTypes.string.isRequired,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,9 @@ export {Count};
 import DateInput from "./DateInput/DateInput";
 export {DateInput};
 
+import RichText from "./RichText/RichText";
+export {RichText};
+
 import DatePicker from "./DatePicker";
 export {DatePicker};
 


### PR DESCRIPTION
Adds a component that renders text while preserving newlines and linkifying links and emails

![](https://cl.ly/2g2D0Q1p2Q2s/Screen%20Shot%202017-06-09%20at%2011.04.55%20AM.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
