### PR TITLE
Add provided className to children of Wizard

### DIFF
--- a/docs/WizardExample.jsx
+++ b/docs/WizardExample.jsx
@@ -240,6 +240,7 @@ export default class WizardExample extends React.Component {
       </fieldset>
 
       <Wizard
+        className="ExampleWizard"
         title="Delivery setup"
         description="Ensure that your delivery will come on time"
         stickySidebar={this.state.sticky}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.14",
+  "version": "0.25.15",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -5,6 +5,7 @@ import _ from "lodash";
 
 import WizardStep from "./WizardStep";
 import {Button, ProgressBar} from "../";
+import {classNameFor} from "../utils";
 
 import "./Wizard.less";
 
@@ -62,7 +63,7 @@ export class Wizard extends React.Component {
     // If an onStepComplete handler is provided for the current step, we will only proceed to the
     // next step if the promise returned by the handler resolves to a truthy value.
     if (steps[currentStep].onStepComplete) {
-      steps[currentStep].onStepComplete(data).then((success) => success && this.goToNextStep());
+      steps[currentStep].onStepComplete(data).then(success => success && this.goToNextStep());
       return;
     }
     this.goToNextStep();
@@ -87,62 +88,78 @@ export class Wizard extends React.Component {
 
   _renderSidebar(style) {
     const {
-      title, description, wizardButtons, steps, seekable, hideProgressBar,
+      title, description, wizardButtons, steps, seekable, hideProgressBar, className,
     } = this.props;
-
+    const baseClasses = ["Wizard", className];
     return (
-      <div style={style} className="Wizard--sidebarContent">
+      <div style={style} className={classNameFor(baseClasses, "sidebarContent")}>
         <h2>{title}</h2>
-        {_.isString(description) ?
-          <p className="Wizard--description">{description}</p>
-        :
-          <div className="Wizard--description">{description}</div>
-        }
-        { !hideProgressBar &&
-          <ProgressBar percentage={this.state.percentComplete} />
-        }
-        <ul className="Wizard--stepsDisplay">
+        {_.isString(description)
+          ? <p className={classNameFor(baseClasses, "description")}>
+            {description}
+          </p>
+          : <div className={classNameFor(baseClasses, "description")}>
+            {description}
+          </div>}
+        {!hideProgressBar &&
+          <ProgressBar percentage={this.state.percentComplete} />}
+        <ul className={classNameFor(baseClasses, "stepsDisplay")}>
           {steps.map((step, idx) => {
             const stepValid = step.validate(this.state.data);
             const stepVisited = _.includes(this.state.stepsVisited, idx);
             const stepClassName = classnames(
-              "Wizard--stepsDisplay--step",
-              idx === this.state.currentStep && "Wizard--stepsDisplay--currentStep",
-              stepValid && "Wizard--stepsDisplay--valid",
-              stepVisited && "Wizard--stepsDisplay--visited",
-              seekable && "Wizard--stepsDisplay--stepLink"
+              classNameFor(baseClasses, ["stepsDisplay", "step"]),
+              idx === this.state.currentStep &&
+              classNameFor(baseClasses, ["stepsDisplay", "currentStep"]),
+              stepValid && classNameFor(baseClasses, ["stepsDisplay", "valid"]),
+              stepVisited &&
+              classNameFor(baseClasses, ["stepsDisplay", "visited"]),
+              seekable && classNameFor(baseClasses, ["stepsDisplay", "stepLink"])
             );
-            const listValue = (<span className={stepClassName}>
-              <span className="Wizard--stepsDisplay--icon" />
-              <span className="Wizard--stepsDisplay--stepTitle">{step.title}</span>
-            </span>);
+            const listValue = (
+              <span className={stepClassName}>
+                <span
+                  className={classNameFor(baseClasses, ["stepsDisplay", "icon"])}
+                />
+                <span
+                  className={classNameFor(
+                    baseClasses,
+                    ["stepsDisplay", "stepTitle"]
+                  )}
+                >
+                  {step.title}
+                </span>
+              </span>
+            );
             return (
               <li key={idx}>
-                { seekable ?
-                  <Button
-                    className="Wizard--stepsDisplay--stepButton"
-                    type="link" onClick={() => this.jumpToStep(idx)}
+                {seekable
+                  ? <Button
+                    className={classNameFor(
+                      baseClasses,
+                      ["stepsDisplay", "stepButton"],
+                    )}
+                    type="link"
+                    onClick={() => this.jumpToStep(idx)}
                     value={listValue}
                   />
-                :
-                  listValue
-                }
+                  : listValue}
               </li>
             );
           })}
         </ul>
         {wizardButtons &&
-          <div className="Wizard--controls">
-            {wizardButtons.map((btnSpec, idx) => (
+          <div className={classNameFor(baseClasses, "controls")}>
+            {wizardButtons.map((btnSpec, idx) =>
               <Button
                 key={idx}
-                onClick={() => btnSpec.handler(this.state.data, {resetWizard: this.reset})}
+                onClick={() =>
+                  btnSpec.handler(this.state.data, {resetWizard: this.reset})}
                 value={btnSpec.buttonValue}
-                className={classnames("Wizard--controls--control", btnSpec.buttonClassName)}
+                className={classNameFor(baseClasses, ["controls", "control"])}
               />
-            ))}
-          </div>
-        }
+            )}
+          </div>}
       </div>
     );
   }
@@ -153,7 +170,7 @@ export class Wizard extends React.Component {
       prevButtonValue, stickySidebar,
     } = this.props;
 
-    const classes = classnames("Wizard", className);
+    const baseClasses = ["Wizard", className].filter(c => !!c);
     const curStep = steps[this.state.currentStep];
     const validSteps = steps.filter(step => step.validate(this.state.data));
 
@@ -163,29 +180,30 @@ export class Wizard extends React.Component {
       validSteps.length !== steps.length : !curStep.validate(this.state.data);
 
     return (
-      <StickyContainer className={classes} style={style}>
-        <div className="Wizard--sidebar">
-          {!stickySidebar ? this._renderSidebar() : (
+      <StickyContainer className={classnames(baseClasses)} style={style}>
+        <div className={classNameFor(baseClasses, "sidebar")}>
+          {!stickySidebar ? this._renderSidebar() :
             <Sticky topOffset={24}>
               {({style: sidebarStyle}) => this._renderSidebar(sidebarStyle)}
-            </Sticky>
-          )}
+            </Sticky>}
         </div>
 
-        <div className="Wizard--step">
+        <div className={classNameFor(baseClasses, "step")}>
           <WizardStep
+            className={className}
             Component={steps[this.state.currentStep].component}
             componentProps={steps[this.state.currentStep].props}
             stepNumber={this.state.currentStep}
-            setWizardState={(changes) => {
+            setWizardState={changes => {
               const newState = Object.assign(this.state.data, changes);
               this.setState({data: newState});
               return newState;
             }}
             wizardState={this.state.data}
-            updatePercentComplete={(wizardState) => this.setState({
-              percentComplete: this.calculatePercentComplete(wizardState)})
-            }
+            updatePercentComplete={wizardState =>
+              this.setState({
+                percentComplete: this.calculatePercentComplete(wizardState),
+              })}
             calculatePercentComplete={this.calculatePercentComplete}
             percentComplete={this.state.percentComplete}
             totalSteps={steps.length}
@@ -198,17 +216,22 @@ export class Wizard extends React.Component {
             nextButtonValue={curStep.nextButtonValue}
           />
 
-          <div className="Wizard--contentGroup Wizard--navButtons">
-            { this.state.currentStep !== 0 &&
+          <div
+            className={classnames(
+              classNameFor(baseClasses, "contentGroup"),
+              classNameFor(baseClasses, "navButtons")
+            )}
+          >
+            {this.state.currentStep !== 0 &&
               <Button
-                className="Wizard--prevButton" type="link"
+                className={classNameFor(baseClasses, "prevButton")}
+                type="link"
                 onClick={this.prevStepHandler}
                 value={curStep.prevButtonValue || prevButtonValue || "Back"}
-              />
-            }
+              />}
 
             <Button
-              className="Wizard--nextButton"
+              className={classNameFor(baseClasses, "nextButton")}
               onClick={this.nextStepHandler}
               disabled={nextDisabled} type="primary"
               value={curStep.nextButtonValue || nextButtonValue || "Next"}
@@ -236,7 +259,10 @@ Wizard.propTypes = {
   steps: PropTypes.arrayOf(PropTypes.shape({
     title: PropTypes.string.isRequired,
     description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-    component: PropTypes.oneOfType([PropTypes.func, PropTypes.instanceOf(React.Component)]).isRequired,
+    component: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.instanceOf(React.Component),
+    ]).isRequired,
     validate: PropTypes.func.isRequired,
     help: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     props: PropTypes.object,

--- a/src/Wizard/WizardStep.jsx
+++ b/src/Wizard/WizardStep.jsx
@@ -1,6 +1,7 @@
 import React, {PropTypes} from "react";
 import _ from "lodash";
 import classnames from "classnames";
+import {classNameFor} from "../utils";
 
 // 58.25 rem = width of sidebar + width of left column
 const COLLAPSE_BREAKPOINT_WIDTH_REM = 63.25;
@@ -41,37 +42,51 @@ export default class WizardStep extends React.Component {
     const {
       title, description, Component, setWizardState, currentStep, wizardState, help,
       percentComplete, calculatePercentComplete, updatePercentComplete, totalSteps,
-      componentProps,
+      componentProps, className,
     } = this.props;
     const props = _.omit(componentProps || {}, ["wizardState", "setWizardState"]);
+    const baseClasses = ["Wizard", className].filter(c => !!c).map(c =>
+      classNameFor(c, "WizardStep")
+    );
+    const contentGroupClass = classNameFor(["Wizard", className], "contentGroup");
     return (
-      <div className="Wizard--WizardStep" ref={(e) => { this.component = e; }}>
-        <div className="Wizard--WizardStep--title">
+      <div className={classnames(baseClasses)} ref={e => { this.component = e; }}>
+        <div className={classNameFor(baseClasses, "title")}>
           <h1>Step {currentStep + 1}: {title}</h1>
         </div>
 
-        <div className="Wizard--WizardStep--topInfo">
-          { description && (
-            <div className="Wizard--contentGroup Wizard--WizardStep--description">
-              { _.isString(description) ? <p>{description}</p> : description }
-            </div>
-          )}
-          { help && (
+        <div className={classNameFor(baseClasses, "topInfo")}>
+          {description &&
             <div
               className={classnames(
-                "Wizard--contentGroup", "Wizard--WizardStep--help",
-                this.state.helpTextCollapsed && "Wizard--WizardStep--helpCollapsed"
+                contentGroupClass,
+                classNameFor(baseClasses, "description")
+              )}
+            >
+              {_.isString(description) ? <p>{description}</p> : description}
+            </div>}
+          {help &&
+            <div
+              className={classnames(
+                contentGroupClass,
+                classNameFor(baseClasses, "help"),
+                this.state.helpTextCollapsed &&
+                classNameFor(baseClasses, "helpCollapsed")
               )}
             >
               {_.isString(help) ? <p>{help}</p> : help}
-            </div>
-          )}
+            </div>}
         </div>
 
-        <div className="Wizard--contentGroup Wizard--WizardStep--component">
+        <div
+          className={classnames(
+            contentGroupClass,
+            classNameFor(baseClasses, "component")
+          )}
+        >
           <Component
             {...props}
-            setWizardState={(modifications) => {
+            setWizardState={modifications => {
               const newState = setWizardState(modifications);
 
               // this conditional updates the progress bar in 2 scenarios:
@@ -105,6 +120,7 @@ WizardStep.propTypes = {
   prevButtonValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   // internal facing
+  className: PropTypes.string,
   currentStep: PropTypes.number.isRequired,
   totalSteps: PropTypes.number.isRequired,
   updatePercentComplete: PropTypes.func.isRequired,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,10 +1,14 @@
+import classnames from "classnames";
+
 /**
  * Extracts properties from props that klass's propTypes field specifies, as an object.
  * Useful for inheriting properties from other components; see ModalButton for examples.
  */
 export function propsFor(klass, props) {
   return Object.keys(props).reduce((prev, propKey) => {
-    if (Object.keys(klass.propTypes).indexOf(propKey) >= 0) prev[propKey] = props[propKey];
+    if (Object.keys(klass.propTypes).indexOf(propKey) >= 0) {
+      prev[propKey] = props[propKey];
+    }
     return prev;
   }, {});
 }
@@ -21,14 +25,15 @@ export function omitKeys(obj, ...toOmit) {
   }, {});
 }
 
-
 /**
  * Returns a copy of obj (Object) with prefix (String) prepended to each key. Capitalizes the first
  * letter of the old key if capitalizeFirst (bool) is true.
  */
 export function prefixKeys(obj, prefix, capitalizeFirst = true) {
   return Object.keys(obj).reduce((prev, key) => {
-    const suffix = capitalizeFirst ? key.charAt(0).toUpperCase() + key.slice(1) : key;
+    const suffix = capitalizeFirst
+      ? key.charAt(0).toUpperCase() + key.slice(1)
+      : key;
     prev[prefix + suffix] = obj[key];
     return prev;
   }, {});
@@ -43,10 +48,40 @@ export function unprefixKeys(obj, prefixToRemove, lowercaseFirst = true) {
   return Object.keys(obj).reduce((prev, key) => {
     if (key.indexOf(prefixToRemove) === 0) {
       const sansPrefix = key.slice(prefixToRemove.length);
-      const newKey = lowercaseFirst ? sansPrefix.charAt(0).toLowerCase() +
-        sansPrefix.slice(1) : sansPrefix;
+      const newKey = lowercaseFirst
+        ? sansPrefix.charAt(0).toLowerCase() + sansPrefix.slice(1)
+        : sansPrefix;
       prev[newKey] = obj[key];
     }
     return prev;
   }, {});
+}
+
+/**
+ * Combine classname strings with long kabobs (--), and prepend each
+ * prefix to the result.
+ * For example:
+ * ```
+ * // returns "Component--a--b MyCustomClassName--a--b"
+ * classNamesFor(["Component", "MyCustomClassName"], "a", "b")
+ * ```
+ * If no prefixes are provided (i.e. prefixes === null or prefixes only contains null/empty values)
+ * it just doesn't append a prefix—i.e. it kabobs the rest of the arguments together.
+ * @param {string | Array<string>} prefixes Prefixes to prepend to resulting classname
+ * @param {string | Array<string>} classSegments Class names to kabob together
+ */
+export function classNameFor(prefixes, classSegments) {
+  const prefixList = (prefixes instanceof Array ? prefixes : [prefixes]).filter(p => !!p);
+  let classSegmentList;
+  if (!classSegments) {
+    classSegmentList = [];
+  } else {
+    classSegmentList = (classSegments instanceof Array ? classSegments : [classSegments]);
+  }
+
+  if (prefixList.length === 0) {
+    return classSegmentList.join("--");
+  }
+
+  return classnames(prefixList.map(p => [p].concat(classSegmentList).join("--")));
 }

--- a/test/utils/index_test.js
+++ b/test/utils/index_test.js
@@ -1,0 +1,36 @@
+import assert from "assert";
+import {classNameFor} from "../../src/utils";
+
+describe("utils", () => {
+  describe("classNameFor", () => {
+    it("prepends classnaems properly", () => {
+      assert.equal(classNameFor("A"), "A");
+      assert.equal(classNameFor("A", "x"), "A--x");
+      assert.equal(classNameFor("A", ["x"]), "A--x");
+      assert.equal(classNameFor("A", ["x", "y"]), "A--x--y");
+      assert.equal(classNameFor(["A"]), "A");
+      assert.equal(classNameFor(["A"], ["x"]), "A--x");
+      assert.equal(classNameFor(["A"], ["x", "y"]), "A--x--y");
+      assert.equal(classNameFor(["A", "B"]), "A B");
+      assert.equal(classNameFor(["A", "B"], "x"), "A--x B--x");
+      assert.equal(classNameFor(["A", "B"], ["x"]), "A--x B--x");
+      assert.equal(classNameFor(["A", "B"], ["x", "y"]), "A--x--y B--x--y");
+    });
+
+    it("handles empty prefix input gracefully", () => {
+      const testCases = [
+        [],
+        [undefined],
+        [""],
+        [null],
+        [undefined, null, ""],
+      ];
+      testCases.forEach(testCase => {
+        assert.equal(classNameFor(testCase), "");
+        assert.equal(classNameFor(testCase, "a"), "a");
+        assert.equal(classNameFor(testCase, ["a"]), "a");
+        assert.equal(classNameFor(testCase, ["a", "b"]), "a--b");
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Jira:**
none, but this will help solve https://clever.atlassian.net/browse/CROC-902.

Discussion on Slack regarding why this is useful here: https://clever.slack.com/archives/C0ERS5ABB/p1497294991024954

**Overview:**
Use both the custom class name provided to the wizard as well as the `Wizard` classname for all classes internal to the wizard, so they can be styled without compound selectors

**Screenshots/GIFs:**
<img width="442" alt="screen shot 2017-06-13 at 2 45 08 pm" src="https://user-images.githubusercontent.com/1890926/27098842-f33d471c-5046-11e7-8fbb-148b1318a480.png">


**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
