### PR TITLE
Fix select again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ border-radius-styles:
 	@echo "Generating border-radius style definitions..."
 	@node genBorderRadius.js
 
-LINT_MAX_LESS_PROBLEMS := 130
+LINT_MAX_LESS_PROBLEMS := 126
 lint:
 	@echo "Linting files..."
 	@$(LINT) $(JS_FILES) $(JSX_FILES)

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ border-radius-styles:
 	@echo "Generating border-radius style definitions..."
 	@node genBorderRadius.js
 
-LINT_MAX_LESS_PROBLEMS := 126
+LINT_MAX_LESS_PROBLEMS := 125
 lint:
 	@echo "Linting files..."
 	@$(LINT) $(JS_FILES) $(JSX_FILES)

--- a/src/Select/Select.less
+++ b/src/Select/Select.less
@@ -50,24 +50,19 @@
 
   &.Select--multi {
     .Select-multi-value-wrapper {
-      .padding--y--xs;
-      .padding--left--2xs;
+      padding-top: @size_m;
+      padding-bottom: @size_2xs;
 
       .Select-placeholder {
         padding-top: @size_xs;
       }
 
       .Select-value {
-        .margin--left--2xs;
-        padding: @size_none;
+        padding: 0;
         border-color: @neutral_silver;
         color: @neutral_black;
         line-height: @size_m;
-
-        margin-top: @size_2xs;
-        &:first-child {
-          margin-top: @size_s;
-        }
+        margin-top: @size_2xs 0 0 @size_2xs;
 
         .Select-value-icon {
           background-color: @neutral_silver;


### PR DESCRIPTION
groan

**Before:**
![image](https://user-images.githubusercontent.com/184140/27714580-b2b60e70-5cff-11e7-8b17-f461c060451b.png)

**After:**
![image](https://user-images.githubusercontent.com/184140/27714550-99084cb8-5cff-11e7-8a9d-70ad83b9f4f1.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
