### PR TITLE
Date input demo

### DIFF
--- a/docs/components/DateInputView.jsx
+++ b/docs/components/DateInputView.jsx
@@ -1,30 +1,82 @@
 import React, {Component} from "react";
 
-import Example from "./Example";
+import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import {DateInput} from "src";
 
+import "./DateInputView.less";
+
 export default class DateInputView extends Component {
   constructor(props) {
     super(props);
-    this.state = {value: null};
+
+    this.state = {
+      disabled: false,
+      readOnly: false,
+      hasError: false,
+      required: false,
+      value: null,
+    };
   }
 
   render() {
+    const {cssClass} = DateInputView;
+
     return (
       <View title="DateInput" sourcePath="src/DateInput/DateInput.jsx">
         <p>
           DateInput is an input that allows the user to select dates from a DatePicker.
         </p>
         <Example>
-          <DateInput
-            label="label"
-            placeholder="Placeholder"
-            required
-            value={this.state.value}
-            onChange={(value) => this.setState({value})}
-          />
+          <ExampleCode>
+            <DateInput
+              disabled={this.state.disabled}
+              error={this.state.hasError ? "Invalid date" : null}
+              label="label"
+              onChange={(value) => this.setState({value})}
+              placeholder="Placeholder"
+              readOnly={this.state.readOnly}
+              required={this.state.required}
+              value={this.state.value}
+            />
+          </ExampleCode>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={this.state.disabled}
+              onChange={({target}) => this.setState({disabled: target.checked})}
+            />
+            {" "}
+            Disabled
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={this.state.readOnly}
+              onChange={({target}) => this.setState({readOnly: target.checked})}
+            />
+            {" "}
+            Read Only
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={this.state.required}
+              onChange={({target}) => this.setState({required: target.checked})}
+            />
+            {" "}
+            Required
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={this.state.hasError}
+              onChange={({target}) => this.setState({hasError: target.checked})}
+            />
+            {" "}
+            Error
+          </label>
         </Example>
 
         <PropDocumentation
@@ -78,6 +130,12 @@ export default class DateInputView extends Component {
               optional: true,
             },
             {
+              name: "readOnly",
+              type: "Bool",
+              description: "Enable read-only styling and disable date input interaction",
+              optional: true,
+            },
+            {
               name: "required",
               type: "Bool",
               description: "Marks input as required and adds indicator",
@@ -107,3 +165,9 @@ export default class DateInputView extends Component {
     );
   }
 }
+
+DateInputView.cssClass = {
+  CONFIG: "DateInputView--config",
+  CONTAINER: "DateInputView",
+  INPUT_CONTAINER: "DateInputView--inputContainer",
+};

--- a/docs/components/DateInputView.less
+++ b/docs/components/DateInputView.less
@@ -1,0 +1,16 @@
+@import (reference) "~less/index";
+
+
+.DateInputView--inputContainer {
+  max-width: 25rem;
+  min-width: 15rem;
+}
+
+.DateInputView--config {
+  .text--small;
+  cursor: pointer;
+  display: inline-block;
+  margin: @size_xs;
+  margin-left: 0;
+  text-transform: uppercase;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -17,21 +17,25 @@ export default class DateInput extends React.Component {
   }
 
   render() {
-    let wrapperClass = "DateInput";
+    const classes = ["DateInput"];
 
     // add additional wrapper classes
-    if (this.props.error) wrapperClass += " DateInput--hasError";
+    if (this.props.error) {
+      classes.push("DateInput--hasError");
+    }
 
     // TODO:  throw error for mutually exclusive states
-    if (this.props.disabled) {
-      wrapperClass += " DateInput--disabled";
+    if (this.props.readOnly) {
+      classes.push("DateInput--readonly");
+    } else if (this.props.disabled) {
+      classes.push("DateInput--disabled");
     } else if (this.state.inFocus) {
-      wrapperClass += " DateInput--inFocus";
+      classes.push("DateInput--inFocus");
     }
 
     // placeholder shown
     if (!this.props.value && this.props.placeholder) {
-      wrapperClass += " DateInput--placeholder-shown";
+      classes.push("DateInput--placeholder-shown");
     }
 
     // note on the upper right corner
@@ -45,25 +49,26 @@ export default class DateInput extends React.Component {
 
 
     return (
-      <div className={classnames(wrapperClass, this.props.className)}>
+      <div className={classnames(classes, this.props.className)}>
         <div className="DateInput--infoRow">
           <label className="DateInput--label" htmlFor={this.props.name}>{this.props.label}</label>
           {inputNote}
         </div>
         <ReactDatePicker
-          ref="input"
-          className="DateInput--input"
           calendarClassName="DatePicker"
-          disabled={this.props.disabled}
-          name={this.props.name}
-          onFocus={() => this.setState({inFocus: true})}
-          onBlur={() => this.setState({inFocus: false})}
-          placeholderText={this.props.placeholder}
-          required={this.props.required}
-          onSelect={this.props.onChange}
-          selected={this.props.value}
-          minDate={this.props.min}
+          className="DateInput--input"
+          disabled={this.props.disabled || this.props.readOnly}
           maxDate={this.props.max}
+          minDate={this.props.min}
+          name={this.props.name}
+          onBlur={() => this.setState({inFocus: false})}
+          onFocus={() => this.setState({inFocus: true})}
+          onSelect={this.props.onChange}
+          placeholderText={this.props.placeholder}
+          readOnly={this.props.readOnly}
+          ref="input"
+          required={this.props.required}
+          selected={this.props.value}
         />
       </div>
     );
@@ -84,6 +89,7 @@ DateInput.propTypes = {
   onFocus: React.PropTypes.func,
   onBlur: React.PropTypes.func,
   placeholder: React.PropTypes.node,
+  readOnly: React.PropTypes.bool,
   required: React.PropTypes.bool,
   type: React.PropTypes.string,
   value: dateType,

--- a/src/DateInput/DateInput.less
+++ b/src/DateInput/DateInput.less
@@ -80,4 +80,20 @@
     box-shadow: inset @size_2xs 0 @primary_blue;
     transition: box-shadow .25s ease-out;
   }
+
+  &.DateInput--disabled {
+    .border--s(@neutral_silver);
+    color: @neutral_dark_gray;
+    background: @neutral_silver;
+
+    .DateInput--input {
+      background: transparent;
+    }
+  }
+
+  &.DateInput--readonly {
+    .border--s(transparent);
+    color: @neutral_black;
+    background: transparent;
+  }
 }


### PR DESCRIPTION
**Overview:**
- Fix disabled state styling for DateInput.
- Include input states in DateInput demo.

**Screenshots/GIFs:**
![https://gyazo.com/0e6086899144cc96bfc2cf72c7106e4b](https://i.gyazo.com/0e6086899144cc96bfc2cf72c7106e4b.gif)

**Testing:**
- [N/A] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
