### PR TITLE
Adds required option to Select component

### DIFF
--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -22,6 +22,7 @@ export default class SelectView extends Component {
       creatable: false,
       lazy: false,
       selectValue: null,
+      required: false,
     };
   }
 
@@ -53,6 +54,7 @@ export default class SelectView extends Component {
                 creatablePromptFn={label => `Add new option: ${label}`}
                 multi={this.state.multi}
                 readOnly={this.state.readOnly}
+                required={this.state.required}
                 name="select"
                 onChange={value => this.setState({selectValue: value})}
                 options={!this.state.lazy && _.range(100).map(i => ({label: `Option ${i + 1}`, value: `${i + 1}`}))}
@@ -138,6 +140,15 @@ export default class SelectView extends Component {
             />
             {" "}
             Read Only
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={this.state.required}
+              onChange={({target}) => this.setState({required: target.checked})}
+            />
+            {" "}
+            Required
           </label>
         </Example>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.20",
+  "version": "0.25.21",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -36,6 +36,7 @@ export function Select({
   loadOptions,
   placeholder = "",
   readOnly,
+  required,
   searchable,
   creatable,
   creatablePromptFn,
@@ -60,9 +61,14 @@ export function Select({
     }
   }
 
-  let labelContainerClasses = cssClass.LABEL_CONTAINER;
+  let labelClasses = cssClass.LABEL;
   if (isLabelHidden(placeholder, value)) {
-    labelContainerClasses += ` ${cssClass.LABEL_HIDDEN}`;
+    labelClasses += ` ${cssClass.LABEL_HIDDEN}`;
+  }
+
+  let inputNote;
+  if (required) {
+    inputNote = <span className="Select--required">required</span>;
   }
 
   let reactSelectClasses = cssClass.REACT_SELECT;
@@ -100,8 +106,9 @@ export function Select({
           value={value}
         />
       </div>
-      <div className={labelContainerClasses}>
-        <label className={cssClass.LABEL} htmlFor={id}>{label}</label>
+      <div className={cssClass.LABEL_CONTAINER}>
+        <label className={labelClasses} htmlFor={id}>{label}</label>
+        {inputNote}
       </div>
     </div>
   );
@@ -138,6 +145,7 @@ Select.propTypes = {
   searchable: React.PropTypes.bool,
   creatable: React.PropTypes.bool,
   creatablePromptFn: React.PropTypes.func,
+  required: React.PropTypes.bool,
   value: React.PropTypes.oneOfType([
     React.PropTypes.string,
     selectValuePropType,

--- a/src/Select/Select.less
+++ b/src/Select/Select.less
@@ -14,14 +14,19 @@
   top: @size_xs;
   width: 100%;
 
-  &.Select--labelHidden {
-    opacity: 0 !important;
+  .Select--required {
+    position: absolute;
+    right: @size_l;
   }
 }
 
 .Select--label {
   left: @size_s;
   position: absolute;
+
+  &.Select--labelHidden {
+    opacity: 0 !important;
+  }
 }
 
 .Select--ReactSelect {

--- a/test/Select_test.jsx
+++ b/test/Select_test.jsx
@@ -35,9 +35,8 @@ describe("Select", () => {
         label="test label"
       />
     );
-    const labelContainer = select.find(`.${Select.cssClass.LABEL_CONTAINER}`);
-    assert.equal(labelContainer.hasClass(Select.cssClass.LABEL_HIDDEN), false);
-    const label = labelContainer.find(`label.${Select.cssClass.LABEL}`);
+    const label = select.find(`label.${Select.cssClass.LABEL}`);
+    assert.equal(label.hasClass(Select.cssClass.LABEL_HIDDEN), false);
     assert.equal(label.prop("htmlFor"), "testid");
   });
 
@@ -49,8 +48,8 @@ describe("Select", () => {
         label="test label"
       />
     );
-    const labelContainer = select.find(`.${Select.cssClass.LABEL_CONTAINER}`);
-    assert.equal(labelContainer.hasClass(Select.cssClass.LABEL_HIDDEN), false);
+    const label = select.find(`.${Select.cssClass.LABEL}`);
+    assert.equal(label.hasClass(Select.cssClass.LABEL_HIDDEN), false);
   });
 
   it("renders the label when a value is selected", () => {
@@ -64,8 +63,8 @@ describe("Select", () => {
         value={testOptions[2]}
       />
     );
-    const labelContainer = select.find(`.${Select.cssClass.LABEL_CONTAINER}`);
-    assert.equal(labelContainer.hasClass(Select.cssClass.LABEL_HIDDEN), false);
+    const label = select.find(`.${Select.cssClass.LABEL}`);
+    assert.equal(label.hasClass(Select.cssClass.LABEL_HIDDEN), false);
   });
 
   it("hides the label when a placeholder is provided but no value is selected", () => {
@@ -77,8 +76,8 @@ describe("Select", () => {
         placeholder="test placeholder"
       />
     );
-    const labelContainer = select.find(`.${Select.cssClass.LABEL_CONTAINER}`);
-    assert(labelContainer.hasClass(Select.cssClass.LABEL_HIDDEN));
+    const label = select.find(`.${Select.cssClass.LABEL}`);
+    assert(label.hasClass(Select.cssClass.LABEL_HIDDEN));
   });
 
   it("renders the label when multiple values are selected", () => {
@@ -92,8 +91,8 @@ describe("Select", () => {
         value={[testOptions[2], testOptions[0]]}
       />
     );
-    const labelContainer = select.find(`.${Select.cssClass.LABEL_CONTAINER}`);
-    assert.equal(labelContainer.hasClass(Select.cssClass.LABEL_HIDDEN), false);
+    const label = select.find(`.${Select.cssClass.LABEL}`);
+    assert.equal(label.hasClass(Select.cssClass.LABEL_HIDDEN), false);
   });
 
   it("hides the label when a placeholder is provided and value is an empty array", () => {
@@ -106,8 +105,8 @@ describe("Select", () => {
         value={[]}
       />
     );
-    const labelContainer = select.find(`.${Select.cssClass.LABEL_CONTAINER}`);
-    assert(labelContainer.hasClass(Select.cssClass.LABEL_HIDDEN));
+    const label = select.find(`.${Select.cssClass.LABEL}`);
+    assert(label.hasClass(Select.cssClass.LABEL_HIDDEN));
   });
 
   it("correctly sets the appropriate props on ReactSelect", () => {

--- a/test/Select_test.jsx
+++ b/test/Select_test.jsx
@@ -208,6 +208,17 @@ describe("Select", () => {
     assert.equal(reactSelect.prop("placeholder"), "");
   });
 
+  it("renders the required label if specified", () => {
+    const select = shallow(
+      <Select
+        id="testid"
+        name="testname"
+        required
+      />
+    );
+    assert(select.find("Select--required"));
+  });
+
   it("uses the ReactSelect Creatable component to allow creating custom options if creatable prop is true", () => {
     const select = shallow(
       <Select


### PR DESCRIPTION
[DEV-598](https://clever.atlassian.net/browse/DEV-598)

**Overview:**
Adds the option for Select components to be required. Unsure about the
positioning of the "REQUIRED" label, but it currently mimics the
TextInput positioning.

**Screenshots/GIFs:**
![screen recording 2017-07-12 at 08 06 pm](https://user-images.githubusercontent.com/3298966/28147427-9e72e742-673d-11e7-81b1-b56d7382bc84.gif)

**Testing:**
- [x] Unit tests (Updated existing tests, still need to add new tests)
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
