### PR TITLE
add a prop to skip steps in wizard

### DIFF
--- a/docs/components/WizardView.jsx
+++ b/docs/components/WizardView.jsx
@@ -184,6 +184,13 @@ export default class WizardView extends PureComponent {
               defaultValue: "{}",
               optional: true,
             },
+            {
+              name: "shouldSkipStep",
+              type: "Function",
+              description: "A function to check if this step should be immediately skipped when navigating "
+              + "backwards/fowards through the wizard.",
+              optional: true,
+            },
           ]}
           className={cssClass.PROPS}
           title="step"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.20",
+  "version": "0.25.21",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -52,7 +52,12 @@ export class Wizard extends React.Component {
   }
 
   prevStepHandler() {
-    const prevStep = Math.max(0, this.state.currentStep - 1);
+    const {steps} = this.props;
+
+    let prevStep = Math.max(0, this.state.currentStep - 1);
+    if (steps[prevStep].shouldSkipStep && steps[prevStep].shouldSkipStep(this.state.data)) {
+      prevStep = Math.max(0, prevStep - 1);
+    }
     this.jumpToStep(prevStep);
   }
 
@@ -77,7 +82,10 @@ export class Wizard extends React.Component {
       onComplete(data);
       return;
     }
-    const nextStep = Math.min(currentStep + 1);
+    let nextStep = Math.min(steps.length - 1, currentStep + 1);
+    if (steps[nextStep].shouldSkipStep && steps[nextStep].shouldSkipStep(this.state.data)) {
+      nextStep = Math.min(steps.length - 1, nextStep + 1);
+    }
     this.jumpToStep(nextStep);
   }
 

--- a/test/Wizard_test.jsx
+++ b/test/Wizard_test.jsx
@@ -281,7 +281,7 @@ describe("Wizard", () => {
     it("updates the displayed step upon next button click", () => {
       const renderedWizard = shallow(<Wizard
         title="title"
-        description="descritpion"
+        description="description"
         onComplete={() => {}}
         steps={[
           {title: "step1", validate: () => true, component: TestComponent},
@@ -309,7 +309,7 @@ describe("Wizard", () => {
     it("updates the displayed step upon prev button click", () => {
       const renderedWizard = shallow(<Wizard
         title="title"
-        description="descritpion"
+        description="description"
         onComplete={() => {}}
         steps={[
           {title: "step1", validate: () => true, component: TestComponent},
@@ -332,11 +332,39 @@ describe("Wizard", () => {
       assert.equal(newPrevBtnMatch.length, 0);
     });
 
+    it("handles skipping steps", () => {
+      const renderedWizard = shallow(<Wizard
+        title="title"
+        description="description"
+        onComplete={() => {}}
+        steps={[
+          {title: "step1", validate: () => false, component: TestComponent},
+          {title: "step2", validate: () => false, shouldSkipStep: () => true, component: TestComponent},
+          {title: "step3", validate: () => false, component: TestComponent},
+        ]}
+      />);
+      const nextBtnMatch = renderedWizard.find(".Wizard--nextButton");
+      assert.equal(nextBtnMatch.length, 1);
+
+      nextBtnMatch.simulate("click");
+
+      assert.strictEqual(renderedWizard.state("currentStep"), 2);
+      const prevBtnMatch = renderedWizard.find(".Wizard--prevButton");
+      assert.equal(prevBtnMatch.length, 1);
+
+      prevBtnMatch.simulate("click");
+
+      assert.strictEqual(renderedWizard.state("currentStep"), 0);
+      const newPrevBtnMatch = renderedWizard.find(".Wizard--prevButton");
+      assert.equal(newPrevBtnMatch.length, 0);
+    });
+
+
     it("doesn't update the displayed step upon next button click if last step, calls onComplete", () => {
       const onCompleteSpy = sinon.spy();
       const renderedWizard = shallow(<Wizard
         title="title"
-        description="descritpion"
+        description="description"
         onComplete={onCompleteSpy}
         steps={[{title: "step", validate: () => true, component: TestComponent}]}
       />);
@@ -352,7 +380,7 @@ describe("Wizard", () => {
       let valid = false;
       const renderedWizard = shallow(<Wizard
         title="title"
-        description="descritpion"
+        description="description"
         onComplete={() => {}}
         steps={[
           {title: "step1", validate: () => valid, component: TestComponent},


### PR DESCRIPTION
In the BTS guide, some steps depend on previous steps or state. We want to be able to skip some steps if they don't have any action.

e.g. User didn't add any apps in step 1 so skip step 2 (configure apps step).

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
