### PR TITLE
Wizard

### DIFF
--- a/docs/components/WizardView.jsx
+++ b/docs/components/WizardView.jsx
@@ -159,9 +159,9 @@ export default class WizardView extends PureComponent {
             },
             {
               name: "canContinue",
-              type: "(wizardData: any) => bool"
+              type: "(wizardData: any) => bool",
               description: "If defined, used to determine whether the 'Next' " +
-                "button is clickable. Otherwise, `validate` is used."
+                "button is clickable. Otherwise, `validate` is used.",
               optional: true,
             },
             {

--- a/docs/components/WizardView.jsx
+++ b/docs/components/WizardView.jsx
@@ -158,6 +158,13 @@ export default class WizardView extends PureComponent {
               + " function is expected to examine for validity",
             },
             {
+              name: "canContinue",
+              type: "(wizardData: any) => bool"
+              description: "If defined, used to determine whether the 'Next' " +
+                "button is clickable. Otherwise, `validate` is used."
+              optional: true,
+            },
+            {
               name: "className",
               type: "String",
               description: "Additional classname to apply to the step",

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -184,8 +184,13 @@ export class Wizard extends React.Component {
 
     // If on the last step, cannot click next (i.e. complete) unless the whole form is valid; for
     // all other steps, only the current step needs to be valid.
-    const nextDisabled = this.state.currentStep === steps.length - 1 ?
-      validSteps.length !== steps.length : !curStep.validate(this.state.data);
+    let nextDisabled;
+    if (curStep.canContinue != null) {
+      nextDisabled = !curStep.canContinue(this.state.data);
+    } else {
+      nextDisabled = this.state.currentStep === steps.length - 1 ?
+        validSteps.length !== steps.length : !curStep.validate(this.state.data);
+    }
 
     return (
       <StickyContainer className={classnames(baseClasses)} style={style}>
@@ -272,6 +277,7 @@ Wizard.propTypes = {
       PropTypes.instanceOf(React.Component),
     ]).isRequired,
     validate: PropTypes.func.isRequired,
+    canContinue: PropTypes.func,
     help: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     props: PropTypes.object,
     onStepComplete: PropTypes.func,


### PR DESCRIPTION
I’m making a wizard and it might take users a few days to collect all the info for it, so state is saved in a db and I want to save that state every time a step is completed. however, I also want the wizard to be seekable (be able to jump around steps). BUT I don’t want the step to be marked as complete until they actually click the “Next” button at the bottom of the step. I’m having trouble getting this to work because to make the step “incomplete”, I have to have `validate` evaluate to `false`, but in order to make the “Next” button clickable, `validate` needs to evaluate to `true`.

To fix this, I'm adding the ability to separate out the notion of a step being completed and a step being continuable.