### PR TITLE
update selector-no-id

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -16,7 +16,7 @@
     "no-descending-specificity": true,
     "no-duplicate-selectors": true,
     "rule-nested-empty-line-before": ["always", {except: ["first-nested"]}],
-    "selector-no-id": true,
+    "selector-max-id": 0,
     "value-list-comma-space-after": "always-single-line",
     "value-list-comma-newline-after": "always-multi-line",
     "unit-whitelist": ["em", "rem", "%", "s", "vh", "ms"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.23",
+  "version": "0.25.24",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-router": "^3.0.0",
     "sinon": "^1.17.3",
     "style-loader": "^0.13.0",
-    "stylelint": "^7.9.0",
+    "stylelint": "^7.12.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.16.1"


### PR DESCRIPTION
Deprecation Warning: 'selector-no-id' has been deprecated and in 8.0 will be removed. Instead use 'selector-max-id' with '0' as its primary option. See: https://stylelint.io/user-guide/rules/selector-no-id/
