### PR TITLE
Increase right margin of Wizard sidebar steps icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.24",
+  "version": "0.25.25",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Wizard/Wizard.less
+++ b/src/Wizard/Wizard.less
@@ -122,7 +122,7 @@
   background-image: url("../../assets/images/progress_notStarted.svg");
   background-repeat: no-repeat;
   background-size: contain;
-  .margin--right--2xs;
+  .margin--right--s;
 }
 
 .Wizard--WizardStep--component {


### PR DESCRIPTION
**Jira:**
None

**Overview:**
Make the margin slightly wider.

**Screenshots/GIFs:**
(Before)
![screen shot 2017-07-28 at 2 49 53 pm](https://user-images.githubusercontent.com/28937347/28738100-6c8cbe36-73a6-11e7-912c-be6eec02b28b.png)
(After)
![screen shot 2017-07-28 at 2 51 18 pm](https://user-images.githubusercontent.com/28937347/28738101-6e0f6eb6-73a6-11e7-9341-f20904d1d9c0.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
