### PR TITLE
Force tooltip to use Proxima Nova

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.25",
+  "version": "0.25.26",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Tooltip/Tooltip.less
+++ b/src/Tooltip/Tooltip.less
@@ -10,6 +10,8 @@
   word-break: break-all;
   // Better breaking for webkit browsers (non-IE, basically):
   word-break: break-word;
+  font-family: "Proxima Nova";
+  .text--medium;
 }
 
 .Tooltip--content--center {


### PR DESCRIPTION
ReactBootstrapTooltip forces the font family to Helvetica. This overrides that and forces the tooltip to Proxima Nova. The font size increases a little bit too...I had a choice of medium or small text and the small looked too small. We can change that if others think a smaller text size makes more sense.

Before:
![image](https://user-images.githubusercontent.com/1924917/28747290-3c2df002-7450-11e7-84a0-a8a26a4aab54.png)

After:
![image](https://user-images.githubusercontent.com/1924917/28747294-4975a688-7450-11e7-8e85-5bd8801f51f8.png)

(Ignore the dark background, that's just Chrome's debugger in the paused state).