### PR TITLE
Fix logic for next step skipping

### DIFF
--- a/docs/WizardExample.jsx
+++ b/docs/WizardExample.jsx
@@ -41,7 +41,7 @@ class ContactStep extends React.Component {
 
   static onStepComplete(wizardState) {
     alert(
-      "A custom action for the current step. We might, for example, want to save the phone " +
+      "Step.onStepComplete: A custom action for the current step. We might, for example, want to save the phone " +
       `number (${wizardState.phoneNumber}) entered on this page in a database right away.`
     );
 
@@ -171,12 +171,39 @@ export default class WizardExample extends React.Component {
         onStepComplete: ContactStep.onStepComplete,
       },
       {
+        title: "Skip Intermediate Step 1",
+        description: "Who should we contact when we have arrived to your delivery address?",
+        component: ContactStep,
+        validate: () => (false),
+        shouldSkipStep: () => (true),
+        nextButtonValue: "Save contact",
+        onStepComplete: undefined,
+      },
+      {
+        title: "Skip Intermediate Step 2",
+        description: "Who should we contact when we have arrived to your delivery address?",
+        component: ContactStep,
+        validate: () => (false),
+        shouldSkipStep: () => (true),
+        nextButtonValue: "Save contact",
+        onStepComplete: undefined,
+      },
+      {
         title: "Review",
         description: "Please review and double check the information below before finalizing the " +
           "delivery process.",
         component: ReviewStep,
         validate: ReviewStep.validate,
         nextButtonValue: "Set delivery",
+      },
+      {
+        title: "Skip Final Step",
+        description: "Who should we contact when we have arrived to your delivery address?",
+        component: ContactStep,
+        validate: () => (false),
+        shouldSkipStep: () => (true),
+        nextButtonValue: "Save contact",
+        onStepComplete: undefined,
       },
     ];
 
@@ -247,7 +274,7 @@ export default class WizardExample extends React.Component {
         steps={steps}
         prevButtonValue={this.state.prevButtonValue}
         onComplete={(state) =>
-          alert(`Delivering to ${state.fullName} at ${state.address}. ` +
+          alert(`Wizard.OnComplete: Delivering to ${state.fullName} at ${state.address}. ` +
                 `Please call ${state.phoneNumber} upon delivery`)
         }
         wizardButtons={[{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.26",
+  "version": "0.25.27",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.28",
+  "version": "0.25.27",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.27",
+  "version": "0.25.28",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -78,13 +78,13 @@ export class Wizard extends React.Component {
     const {onComplete, steps} = this.props;
     const {currentStep, data} = this.state;
 
-    if (currentStep === steps.length - 1) {
+    let nextStep = currentStep + 1;
+    while ((nextStep < steps.length) && steps[nextStep].shouldSkipStep && steps[nextStep].shouldSkipStep(this.state.data)) {
+      nextStep++;
+    }
+    if (nextStep === steps.length) {
       onComplete(data);
       return;
-    }
-    let nextStep = Math.min(steps.length - 1, currentStep + 1);
-    if (steps[nextStep].shouldSkipStep && steps[nextStep].shouldSkipStep(this.state.data)) {
-      nextStep = Math.min(steps.length - 1, nextStep + 1);
     }
     this.jumpToStep(nextStep);
   }


### PR DESCRIPTION
**Jira:**

**Overview:**
The wizard component did not correctly handle skipping the final step in the wizard and it also did not handle skipping multiple steps.

**Screenshots/GIFs:**
![image](https://user-images.githubusercontent.com/19561552/28948500-e5ca6a28-786a-11e7-907a-607ad0a7abe2.png)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [n/a] Safari
  - [n/a] IE10

**Roll Out:**
- Before merging:
  - [n/a] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
