### PR TITLE
Add lint-compliant spacing between auto-generated CSS rulesets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BABEL := node_modules/babel-cli/bin/babel.js
 WEBPACK := node_modules/webpack/bin/webpack.js
 
 .PHONY: dev-server test lint clean es5 docs build new $(TESTS) styles sizing-styles border-styles
-.PHONY: border-radius-styles deploy-docs
+.PHONY: border-radius-styles deploy-docs generate
 
 clean:
 	@echo '✓ Clean out dist directory'
@@ -35,6 +35,8 @@ styles:
 	@echo "Building stylesheet"
 	@$(WEBPACK) --config webpack_styles.config.js
 
+generate: sizing-styles border-styles border-radius-styles
+
 sizing-styles:
 	@echo "Generating sizing style definitions..."
 	@node genSizing.js
@@ -47,7 +49,7 @@ border-radius-styles:
 	@echo "Generating border-radius style definitions..."
 	@node genBorderRadius.js
 
-LINT_MAX_LESS_PROBLEMS := 322
+LINT_MAX_LESS_PROBLEMS := 122
 lint:
 	@echo "Linting files..."
 	@$(LINT) $(JS_FILES) $(JSX_FILES)

--- a/genBorder.js
+++ b/genBorder.js
@@ -26,17 +26,17 @@ _.forEach(borderWidths, (width, name) => {
 
     `/** ${widthVar} */`,
 
-    `.border--${name}(@color) { border: ${widthVar} solid @color; }`,
+    `.border--${name}(@color) { border: ${widthVar} solid @color; }\n`,
 
-    `.border--top--${name}(@color) { border-top: ${widthVar} solid @color; }`,
+    `.border--top--${name}(@color) { border-top: ${widthVar} solid @color; }\n`,
 
-    `.border--right--${name}(@color) { border-right: ${widthVar} solid @color; }`,
+    `.border--right--${name}(@color) { border-right: ${widthVar} solid @color; }\n`,
 
-    `.border--bottom--${name}(@color) { border-bottom: ${widthVar} solid @color; }`,
+    `.border--bottom--${name}(@color) { border-bottom: ${widthVar} solid @color; }\n`,
 
-    `.border--left--${name}(@color) { border-left: ${widthVar} solid @color; }`,
+    `.border--left--${name}(@color) { border-left: ${widthVar} solid @color; }\n`,
 
-    `.border--x--${name}(@color) { .border--left--${name}(@color); .border--right--${name}(@color); }`,
+    `.border--x--${name}(@color) { .border--left--${name}(@color); .border--right--${name}(@color); }\n`,
 
     `.border--y--${name}(@color) { .border--top--${name}(@color); .border--bottom--${name}(@color); }`,
   ]);

--- a/genBorderRadius.js
+++ b/genBorderRadius.js
@@ -26,17 +26,17 @@ _.forEach(borderRadii, (radius, name) => {
 
     `/** ${radiusVar} */`,
 
-    `.borderRadius--${name} { border-radius: ${radiusVar}; }`,
+    `.borderRadius--${name} { border-radius: ${radiusVar}; }\n`,
 
-    `.borderRadius--topLeft--${name} { border-top-left-radius: ${radiusVar}; }`,
+    `.borderRadius--topLeft--${name} { border-top-left-radius: ${radiusVar}; }\n`,
 
-    `.borderRadius--topRight--${name} { border-top-right-radius: ${radiusVar}; }`,
+    `.borderRadius--topRight--${name} { border-top-right-radius: ${radiusVar}; }\n`,
 
-    `.borderRadius--bottomLeft--${name} { border-bottom-left-radius: ${radiusVar}; }`,
+    `.borderRadius--bottomLeft--${name} { border-bottom-left-radius: ${radiusVar}; }\n`,
 
-    `.borderRadius--bottomRight--${name} { border-bottom-right-radius: ${radiusVar}; }`,
+    `.borderRadius--bottomRight--${name} { border-bottom-right-radius: ${radiusVar}; }\n`,
 
-    `.borderRadius--top--${name} { .borderRadius--topLeft--${name}; .borderRadius--topRight--${name}; }`,
+    `.borderRadius--top--${name} { .borderRadius--topLeft--${name}; .borderRadius--topRight--${name}; }\n`,
 
     `.borderRadius--bottom--${name} { .borderRadius--bottomLeft--${name}; .borderRadius--bottomRight--${name}; }`,
   ]);

--- a/genSizing.js
+++ b/genSizing.js
@@ -7,6 +7,7 @@ const SIZING_FILENAME = "sizing.less";
 const SPACING_FILENAME = "spacing.less";
 const sizes = {
   none: 0,
+  "4xs": 0.0625,
   "3xs": 0.125,
   "2xs": 0.25,
   xs: 0.5,
@@ -37,19 +38,19 @@ _.forEach(sizes, (size, sizeName) => {
   ["margin", "padding"].forEach(type => {
     const classPrefix = `${type}`;
     spacingContents = spacingContents.concat([
-      `.${classPrefix}--${sizeName} { ${type}: ${sizeVar} };`,
+      `.${classPrefix}--${sizeName} { ${type}: ${sizeVar} }\n`,
 
-      `.${classPrefix}--top--${sizeName} { ${type}-top: ${sizeVar} };`,
+      `.${classPrefix}--top--${sizeName} { ${type}-top: ${sizeVar} }\n`,
 
-      `.${classPrefix}--right--${sizeName} { ${type}-right: ${sizeVar} };`,
+      `.${classPrefix}--right--${sizeName} { ${type}-right: ${sizeVar} }\n`,
 
-      `.${classPrefix}--bottom--${sizeName} { ${type}-bottom: ${sizeVar} };`,
+      `.${classPrefix}--bottom--${sizeName} { ${type}-bottom: ${sizeVar} }\n`,
 
-      `.${classPrefix}--left--${sizeName} { ${type}-left: ${sizeVar} };`,
+      `.${classPrefix}--left--${sizeName} { ${type}-left: ${sizeVar} }\n`,
 
-      `.${classPrefix}--x--${sizeName} { ${type}-left: ${sizeVar}; ${type}-right: ${sizeVar} };`,
+      `.${classPrefix}--x--${sizeName} { ${type}-left: ${sizeVar}; ${type}-right: ${sizeVar} }\n`,
 
-      `.${classPrefix}--y--${sizeName} { ${type}-top: ${sizeVar}; ${type}-bottom: ${sizeVar} };`,
+      `.${classPrefix}--y--${sizeName} { ${type}-top: ${sizeVar}; ${type}-bottom: ${sizeVar} }`,
     ]);
 
     spacingContents.push("");

--- a/src/less/border.less
+++ b/src/less/border.less
@@ -19,27 +19,45 @@
 
 /** @borderWidthS */
 .border--s(@color) { border: @borderWidthS solid @color; }
+
 .border--top--s(@color) { border-top: @borderWidthS solid @color; }
+
 .border--right--s(@color) { border-right: @borderWidthS solid @color; }
+
 .border--bottom--s(@color) { border-bottom: @borderWidthS solid @color; }
+
 .border--left--s(@color) { border-left: @borderWidthS solid @color; }
+
 .border--x--s(@color) { .border--left--s(@color); .border--right--s(@color); }
+
 .border--y--s(@color) { .border--top--s(@color); .border--bottom--s(@color); }
 
 /** @borderWidthM */
 .border--m(@color) { border: @borderWidthM solid @color; }
+
 .border--top--m(@color) { border-top: @borderWidthM solid @color; }
+
 .border--right--m(@color) { border-right: @borderWidthM solid @color; }
+
 .border--bottom--m(@color) { border-bottom: @borderWidthM solid @color; }
+
 .border--left--m(@color) { border-left: @borderWidthM solid @color; }
+
 .border--x--m(@color) { .border--left--m(@color); .border--right--m(@color); }
+
 .border--y--m(@color) { .border--top--m(@color); .border--bottom--m(@color); }
 
 /** @borderWidthL */
 .border--l(@color) { border: @borderWidthL solid @color; }
+
 .border--top--l(@color) { border-top: @borderWidthL solid @color; }
+
 .border--right--l(@color) { border-right: @borderWidthL solid @color; }
+
 .border--bottom--l(@color) { border-bottom: @borderWidthL solid @color; }
+
 .border--left--l(@color) { border-left: @borderWidthL solid @color; }
+
 .border--x--l(@color) { .border--left--l(@color); .border--right--l(@color); }
+
 .border--y--l(@color) { .border--top--l(@color); .border--bottom--l(@color); }

--- a/src/less/border_radius.less
+++ b/src/less/border_radius.less
@@ -21,45 +21,75 @@
 
 /** @borderRadius0 */
 .borderRadius--0 { border-radius: @borderRadius0; }
+
 .borderRadius--topLeft--0 { border-top-left-radius: @borderRadius0; }
+
 .borderRadius--topRight--0 { border-top-right-radius: @borderRadius0; }
+
 .borderRadius--bottomLeft--0 { border-bottom-left-radius: @borderRadius0; }
+
 .borderRadius--bottomRight--0 { border-bottom-right-radius: @borderRadius0; }
+
 .borderRadius--top--0 { .borderRadius--topLeft--0; .borderRadius--topRight--0; }
+
 .borderRadius--bottom--0 { .borderRadius--bottomLeft--0; .borderRadius--bottomRight--0; }
 
 /** @borderRadiusS */
 .borderRadius--s { border-radius: @borderRadiusS; }
+
 .borderRadius--topLeft--s { border-top-left-radius: @borderRadiusS; }
+
 .borderRadius--topRight--s { border-top-right-radius: @borderRadiusS; }
+
 .borderRadius--bottomLeft--s { border-bottom-left-radius: @borderRadiusS; }
+
 .borderRadius--bottomRight--s { border-bottom-right-radius: @borderRadiusS; }
+
 .borderRadius--top--s { .borderRadius--topLeft--s; .borderRadius--topRight--s; }
+
 .borderRadius--bottom--s { .borderRadius--bottomLeft--s; .borderRadius--bottomRight--s; }
 
 /** @borderRadiusM */
 .borderRadius--m { border-radius: @borderRadiusM; }
+
 .borderRadius--topLeft--m { border-top-left-radius: @borderRadiusM; }
+
 .borderRadius--topRight--m { border-top-right-radius: @borderRadiusM; }
+
 .borderRadius--bottomLeft--m { border-bottom-left-radius: @borderRadiusM; }
+
 .borderRadius--bottomRight--m { border-bottom-right-radius: @borderRadiusM; }
+
 .borderRadius--top--m { .borderRadius--topLeft--m; .borderRadius--topRight--m; }
+
 .borderRadius--bottom--m { .borderRadius--bottomLeft--m; .borderRadius--bottomRight--m; }
 
 /** @borderRadiusL */
 .borderRadius--l { border-radius: @borderRadiusL; }
+
 .borderRadius--topLeft--l { border-top-left-radius: @borderRadiusL; }
+
 .borderRadius--topRight--l { border-top-right-radius: @borderRadiusL; }
+
 .borderRadius--bottomLeft--l { border-bottom-left-radius: @borderRadiusL; }
+
 .borderRadius--bottomRight--l { border-bottom-right-radius: @borderRadiusL; }
+
 .borderRadius--top--l { .borderRadius--topLeft--l; .borderRadius--topRight--l; }
+
 .borderRadius--bottom--l { .borderRadius--bottomLeft--l; .borderRadius--bottomRight--l; }
 
 /** @borderRadiusXL */
 .borderRadius--xl { border-radius: @borderRadiusXL; }
+
 .borderRadius--topLeft--xl { border-top-left-radius: @borderRadiusXL; }
+
 .borderRadius--topRight--xl { border-top-right-radius: @borderRadiusXL; }
+
 .borderRadius--bottomLeft--xl { border-bottom-left-radius: @borderRadiusXL; }
+
 .borderRadius--bottomRight--xl { border-bottom-right-radius: @borderRadiusXL; }
+
 .borderRadius--top--xl { .borderRadius--topLeft--xl; .borderRadius--topRight--xl; }
+
 .borderRadius--bottom--xl { .borderRadius--bottomLeft--xl; .borderRadius--bottomRight--xl; }

--- a/src/less/flex.less
+++ b/src/less/flex.less
@@ -253,43 +253,68 @@
  */
 
 .flexbox { .flexbox() }
+
 /* Enable flex for specific layout breakpoints. */
 .breakpointS({ .flexbox--s { .flexbox } });
+
 .breakpointM({ .flexbox--m { .flexbox } });
+
 .breakpointL({ .flexbox--l { .flexbox } });
 
 .flexbox--inline { .inlineFlexbox() }
+
 .flex--direction--column { .flexDirection(column) }
+
 .flex--wrap { .flexWrap(wrap) }
+
 .flex--nowrap { .flexWrap(nowrap) }
 
 .flex--grow { .flexGrow(1) }
+
 .flex--none { .flexNone() }
+
 .flex--shrink { .flexShrink(1) }
 
 .items--baseline { .alignItems(baseline) }
+
 .items--center { .alignItems(center) }
+
 .items--end { .alignItems(flex-end) }
+
 .items--start { .alignItems(flex-start) }
+
 .items--stretch { .alignItems(stretch) }
 
 .self--baseline { .alignSelf(baseline) }
+
 .self--center { .alignSelf(center) }
+
 .self--end { .alignSelf(flex-end) }
+
 .self--start { .alignSelf(flex-start) }
+
 .self--stretch { .alignSelf(stretch) }
 
 .justify--around { .justifyContent(space-around) }
+
 .justify--between { .justifyContent(space-between) }
+
 .justify--center { .justifyContent(center) }
+
 .justify--end { .justifyContent(flex-end) }
+
 .justify--start { .justifyContent(flex-start) }
 
 .content--around { .alignContent(space-around) }
+
 .content--between { .alignContent(space-between) }
+
 .content--center { .alignContent(center) }
+
 .content--end { .alignContent(flex-end) }
+
 .content--start { .alignContent(flex-start) }
+
 .content--stretch { .alignContent(stretch) }
 
 /* 1. Fix for Chrome 44 bug. https://code.google.com/p/chromium/issues/detail?id=506893 */
@@ -300,7 +325,11 @@
 }
 
 .order--0 { .order(0) }
+
 .order--1 { .order(1) }
+
 .order--2 { .order(2) }
+
 .order--3 { .order(3) }
+
 .order--last { .order(99999) }

--- a/src/less/sizing.less
+++ b/src/less/sizing.less
@@ -6,7 +6,7 @@
  */
 
 @size_none: 0rem;  /* 0px */
-@size_4xs: .0625rem; /* 1px */
+@size_4xs: .0625rem;  /* 1px */
 @size_3xs: .125rem;  /* 2px */
 @size_2xs: .25rem;  /* 4px */
 @size_xs: .5rem;  /* 8px */

--- a/src/less/spacing.less
+++ b/src/less/spacing.less
@@ -9,227 +9,402 @@
 /**
  * @size_none
  */
-.margin--none { margin: @size_none };
-.margin--top--none { margin-top: @size_none };
-.margin--right--none { margin-right: @size_none };
-.margin--bottom--none { margin-bottom: @size_none };
-.margin--left--none { margin-left: @size_none };
-.margin--x--none { margin-left: @size_none; margin-right: @size_none };
-.margin--y--none { margin-top: @size_none; margin-bottom: @size_none };
+.margin--none { margin: @size_none }
 
-.padding--none { padding: @size_none };
-.padding--top--none { padding-top: @size_none };
-.padding--right--none { padding-right: @size_none };
-.padding--bottom--none { padding-bottom: @size_none };
-.padding--left--none { padding-left: @size_none };
-.padding--x--none { padding-left: @size_none; padding-right: @size_none };
-.padding--y--none { padding-top: @size_none; padding-bottom: @size_none };
+.margin--top--none { margin-top: @size_none }
+
+.margin--right--none { margin-right: @size_none }
+
+.margin--bottom--none { margin-bottom: @size_none }
+
+.margin--left--none { margin-left: @size_none }
+
+.margin--x--none { margin-left: @size_none; margin-right: @size_none }
+
+.margin--y--none { margin-top: @size_none; margin-bottom: @size_none }
+
+.padding--none { padding: @size_none }
+
+.padding--top--none { padding-top: @size_none }
+
+.padding--right--none { padding-right: @size_none }
+
+.padding--bottom--none { padding-bottom: @size_none }
+
+.padding--left--none { padding-left: @size_none }
+
+.padding--x--none { padding-left: @size_none; padding-right: @size_none }
+
+.padding--y--none { padding-top: @size_none; padding-bottom: @size_none }
+
+/**
+ * @size_4xs
+ */
+.margin--4xs { margin: @size_4xs }
+
+.margin--top--4xs { margin-top: @size_4xs }
+
+.margin--right--4xs { margin-right: @size_4xs }
+
+.margin--bottom--4xs { margin-bottom: @size_4xs }
+
+.margin--left--4xs { margin-left: @size_4xs }
+
+.margin--x--4xs { margin-left: @size_4xs; margin-right: @size_4xs }
+
+.margin--y--4xs { margin-top: @size_4xs; margin-bottom: @size_4xs }
+
+.padding--4xs { padding: @size_4xs }
+
+.padding--top--4xs { padding-top: @size_4xs }
+
+.padding--right--4xs { padding-right: @size_4xs }
+
+.padding--bottom--4xs { padding-bottom: @size_4xs }
+
+.padding--left--4xs { padding-left: @size_4xs }
+
+.padding--x--4xs { padding-left: @size_4xs; padding-right: @size_4xs }
+
+.padding--y--4xs { padding-top: @size_4xs; padding-bottom: @size_4xs }
 
 /**
  * @size_3xs
  */
-.margin--3xs { margin: @size_3xs };
-.margin--top--3xs { margin-top: @size_3xs };
-.margin--right--3xs { margin-right: @size_3xs };
-.margin--bottom--3xs { margin-bottom: @size_3xs };
-.margin--left--3xs { margin-left: @size_3xs };
-.margin--x--3xs { margin-left: @size_3xs; margin-right: @size_3xs };
-.margin--y--3xs { margin-top: @size_3xs; margin-bottom: @size_3xs };
+.margin--3xs { margin: @size_3xs }
 
-.padding--3xs { padding: @size_3xs };
-.padding--top--3xs { padding-top: @size_3xs };
-.padding--right--3xs { padding-right: @size_3xs };
-.padding--bottom--3xs { padding-bottom: @size_3xs };
-.padding--left--3xs { padding-left: @size_3xs };
-.padding--x--3xs { padding-left: @size_3xs; padding-right: @size_3xs };
-.padding--y--3xs { padding-top: @size_3xs; padding-bottom: @size_3xs };
+.margin--top--3xs { margin-top: @size_3xs }
+
+.margin--right--3xs { margin-right: @size_3xs }
+
+.margin--bottom--3xs { margin-bottom: @size_3xs }
+
+.margin--left--3xs { margin-left: @size_3xs }
+
+.margin--x--3xs { margin-left: @size_3xs; margin-right: @size_3xs }
+
+.margin--y--3xs { margin-top: @size_3xs; margin-bottom: @size_3xs }
+
+.padding--3xs { padding: @size_3xs }
+
+.padding--top--3xs { padding-top: @size_3xs }
+
+.padding--right--3xs { padding-right: @size_3xs }
+
+.padding--bottom--3xs { padding-bottom: @size_3xs }
+
+.padding--left--3xs { padding-left: @size_3xs }
+
+.padding--x--3xs { padding-left: @size_3xs; padding-right: @size_3xs }
+
+.padding--y--3xs { padding-top: @size_3xs; padding-bottom: @size_3xs }
 
 /**
  * @size_2xs
  */
-.margin--2xs { margin: @size_2xs };
-.margin--top--2xs { margin-top: @size_2xs };
-.margin--right--2xs { margin-right: @size_2xs };
-.margin--bottom--2xs { margin-bottom: @size_2xs };
-.margin--left--2xs { margin-left: @size_2xs };
-.margin--x--2xs { margin-left: @size_2xs; margin-right: @size_2xs };
-.margin--y--2xs { margin-top: @size_2xs; margin-bottom: @size_2xs };
+.margin--2xs { margin: @size_2xs }
 
-.padding--2xs { padding: @size_2xs };
-.padding--top--2xs { padding-top: @size_2xs };
-.padding--right--2xs { padding-right: @size_2xs };
-.padding--bottom--2xs { padding-bottom: @size_2xs };
-.padding--left--2xs { padding-left: @size_2xs };
-.padding--x--2xs { padding-left: @size_2xs; padding-right: @size_2xs };
-.padding--y--2xs { padding-top: @size_2xs; padding-bottom: @size_2xs };
+.margin--top--2xs { margin-top: @size_2xs }
+
+.margin--right--2xs { margin-right: @size_2xs }
+
+.margin--bottom--2xs { margin-bottom: @size_2xs }
+
+.margin--left--2xs { margin-left: @size_2xs }
+
+.margin--x--2xs { margin-left: @size_2xs; margin-right: @size_2xs }
+
+.margin--y--2xs { margin-top: @size_2xs; margin-bottom: @size_2xs }
+
+.padding--2xs { padding: @size_2xs }
+
+.padding--top--2xs { padding-top: @size_2xs }
+
+.padding--right--2xs { padding-right: @size_2xs }
+
+.padding--bottom--2xs { padding-bottom: @size_2xs }
+
+.padding--left--2xs { padding-left: @size_2xs }
+
+.padding--x--2xs { padding-left: @size_2xs; padding-right: @size_2xs }
+
+.padding--y--2xs { padding-top: @size_2xs; padding-bottom: @size_2xs }
 
 /**
  * @size_xs
  */
-.margin--xs { margin: @size_xs };
-.margin--top--xs { margin-top: @size_xs };
-.margin--right--xs { margin-right: @size_xs };
-.margin--bottom--xs { margin-bottom: @size_xs };
-.margin--left--xs { margin-left: @size_xs };
-.margin--x--xs { margin-left: @size_xs; margin-right: @size_xs };
-.margin--y--xs { margin-top: @size_xs; margin-bottom: @size_xs };
+.margin--xs { margin: @size_xs }
 
-.padding--xs { padding: @size_xs };
-.padding--top--xs { padding-top: @size_xs };
-.padding--right--xs { padding-right: @size_xs };
-.padding--bottom--xs { padding-bottom: @size_xs };
-.padding--left--xs { padding-left: @size_xs };
-.padding--x--xs { padding-left: @size_xs; padding-right: @size_xs };
-.padding--y--xs { padding-top: @size_xs; padding-bottom: @size_xs };
+.margin--top--xs { margin-top: @size_xs }
+
+.margin--right--xs { margin-right: @size_xs }
+
+.margin--bottom--xs { margin-bottom: @size_xs }
+
+.margin--left--xs { margin-left: @size_xs }
+
+.margin--x--xs { margin-left: @size_xs; margin-right: @size_xs }
+
+.margin--y--xs { margin-top: @size_xs; margin-bottom: @size_xs }
+
+.padding--xs { padding: @size_xs }
+
+.padding--top--xs { padding-top: @size_xs }
+
+.padding--right--xs { padding-right: @size_xs }
+
+.padding--bottom--xs { padding-bottom: @size_xs }
+
+.padding--left--xs { padding-left: @size_xs }
+
+.padding--x--xs { padding-left: @size_xs; padding-right: @size_xs }
+
+.padding--y--xs { padding-top: @size_xs; padding-bottom: @size_xs }
 
 /**
  * @size_s
  */
-.margin--s { margin: @size_s };
-.margin--top--s { margin-top: @size_s };
-.margin--right--s { margin-right: @size_s };
-.margin--bottom--s { margin-bottom: @size_s };
-.margin--left--s { margin-left: @size_s };
-.margin--x--s { margin-left: @size_s; margin-right: @size_s };
-.margin--y--s { margin-top: @size_s; margin-bottom: @size_s };
+.margin--s { margin: @size_s }
 
-.padding--s { padding: @size_s };
-.padding--top--s { padding-top: @size_s };
-.padding--right--s { padding-right: @size_s };
-.padding--bottom--s { padding-bottom: @size_s };
-.padding--left--s { padding-left: @size_s };
-.padding--x--s { padding-left: @size_s; padding-right: @size_s };
-.padding--y--s { padding-top: @size_s; padding-bottom: @size_s };
+.margin--top--s { margin-top: @size_s }
+
+.margin--right--s { margin-right: @size_s }
+
+.margin--bottom--s { margin-bottom: @size_s }
+
+.margin--left--s { margin-left: @size_s }
+
+.margin--x--s { margin-left: @size_s; margin-right: @size_s }
+
+.margin--y--s { margin-top: @size_s; margin-bottom: @size_s }
+
+.padding--s { padding: @size_s }
+
+.padding--top--s { padding-top: @size_s }
+
+.padding--right--s { padding-right: @size_s }
+
+.padding--bottom--s { padding-bottom: @size_s }
+
+.padding--left--s { padding-left: @size_s }
+
+.padding--x--s { padding-left: @size_s; padding-right: @size_s }
+
+.padding--y--s { padding-top: @size_s; padding-bottom: @size_s }
 
 /**
  * @size_m
  */
-.margin--m { margin: @size_m };
-.margin--top--m { margin-top: @size_m };
-.margin--right--m { margin-right: @size_m };
-.margin--bottom--m { margin-bottom: @size_m };
-.margin--left--m { margin-left: @size_m };
-.margin--x--m { margin-left: @size_m; margin-right: @size_m };
-.margin--y--m { margin-top: @size_m; margin-bottom: @size_m };
+.margin--m { margin: @size_m }
 
-.padding--m { padding: @size_m };
-.padding--top--m { padding-top: @size_m };
-.padding--right--m { padding-right: @size_m };
-.padding--bottom--m { padding-bottom: @size_m };
-.padding--left--m { padding-left: @size_m };
-.padding--x--m { padding-left: @size_m; padding-right: @size_m };
-.padding--y--m { padding-top: @size_m; padding-bottom: @size_m };
+.margin--top--m { margin-top: @size_m }
+
+.margin--right--m { margin-right: @size_m }
+
+.margin--bottom--m { margin-bottom: @size_m }
+
+.margin--left--m { margin-left: @size_m }
+
+.margin--x--m { margin-left: @size_m; margin-right: @size_m }
+
+.margin--y--m { margin-top: @size_m; margin-bottom: @size_m }
+
+.padding--m { padding: @size_m }
+
+.padding--top--m { padding-top: @size_m }
+
+.padding--right--m { padding-right: @size_m }
+
+.padding--bottom--m { padding-bottom: @size_m }
+
+.padding--left--m { padding-left: @size_m }
+
+.padding--x--m { padding-left: @size_m; padding-right: @size_m }
+
+.padding--y--m { padding-top: @size_m; padding-bottom: @size_m }
 
 /**
  * @size_l
  */
-.margin--l { margin: @size_l };
-.margin--top--l { margin-top: @size_l };
-.margin--right--l { margin-right: @size_l };
-.margin--bottom--l { margin-bottom: @size_l };
-.margin--left--l { margin-left: @size_l };
-.margin--x--l { margin-left: @size_l; margin-right: @size_l };
-.margin--y--l { margin-top: @size_l; margin-bottom: @size_l };
+.margin--l { margin: @size_l }
 
-.padding--l { padding: @size_l };
-.padding--top--l { padding-top: @size_l };
-.padding--right--l { padding-right: @size_l };
-.padding--bottom--l { padding-bottom: @size_l };
-.padding--left--l { padding-left: @size_l };
-.padding--x--l { padding-left: @size_l; padding-right: @size_l };
-.padding--y--l { padding-top: @size_l; padding-bottom: @size_l };
+.margin--top--l { margin-top: @size_l }
+
+.margin--right--l { margin-right: @size_l }
+
+.margin--bottom--l { margin-bottom: @size_l }
+
+.margin--left--l { margin-left: @size_l }
+
+.margin--x--l { margin-left: @size_l; margin-right: @size_l }
+
+.margin--y--l { margin-top: @size_l; margin-bottom: @size_l }
+
+.padding--l { padding: @size_l }
+
+.padding--top--l { padding-top: @size_l }
+
+.padding--right--l { padding-right: @size_l }
+
+.padding--bottom--l { padding-bottom: @size_l }
+
+.padding--left--l { padding-left: @size_l }
+
+.padding--x--l { padding-left: @size_l; padding-right: @size_l }
+
+.padding--y--l { padding-top: @size_l; padding-bottom: @size_l }
 
 /**
  * @size_xl
  */
-.margin--xl { margin: @size_xl };
-.margin--top--xl { margin-top: @size_xl };
-.margin--right--xl { margin-right: @size_xl };
-.margin--bottom--xl { margin-bottom: @size_xl };
-.margin--left--xl { margin-left: @size_xl };
-.margin--x--xl { margin-left: @size_xl; margin-right: @size_xl };
-.margin--y--xl { margin-top: @size_xl; margin-bottom: @size_xl };
+.margin--xl { margin: @size_xl }
 
-.padding--xl { padding: @size_xl };
-.padding--top--xl { padding-top: @size_xl };
-.padding--right--xl { padding-right: @size_xl };
-.padding--bottom--xl { padding-bottom: @size_xl };
-.padding--left--xl { padding-left: @size_xl };
-.padding--x--xl { padding-left: @size_xl; padding-right: @size_xl };
-.padding--y--xl { padding-top: @size_xl; padding-bottom: @size_xl };
+.margin--top--xl { margin-top: @size_xl }
+
+.margin--right--xl { margin-right: @size_xl }
+
+.margin--bottom--xl { margin-bottom: @size_xl }
+
+.margin--left--xl { margin-left: @size_xl }
+
+.margin--x--xl { margin-left: @size_xl; margin-right: @size_xl }
+
+.margin--y--xl { margin-top: @size_xl; margin-bottom: @size_xl }
+
+.padding--xl { padding: @size_xl }
+
+.padding--top--xl { padding-top: @size_xl }
+
+.padding--right--xl { padding-right: @size_xl }
+
+.padding--bottom--xl { padding-bottom: @size_xl }
+
+.padding--left--xl { padding-left: @size_xl }
+
+.padding--x--xl { padding-left: @size_xl; padding-right: @size_xl }
+
+.padding--y--xl { padding-top: @size_xl; padding-bottom: @size_xl }
 
 /**
  * @size_2xl
  */
-.margin--2xl { margin: @size_2xl };
-.margin--top--2xl { margin-top: @size_2xl };
-.margin--right--2xl { margin-right: @size_2xl };
-.margin--bottom--2xl { margin-bottom: @size_2xl };
-.margin--left--2xl { margin-left: @size_2xl };
-.margin--x--2xl { margin-left: @size_2xl; margin-right: @size_2xl };
-.margin--y--2xl { margin-top: @size_2xl; margin-bottom: @size_2xl };
+.margin--2xl { margin: @size_2xl }
 
-.padding--2xl { padding: @size_2xl };
-.padding--top--2xl { padding-top: @size_2xl };
-.padding--right--2xl { padding-right: @size_2xl };
-.padding--bottom--2xl { padding-bottom: @size_2xl };
-.padding--left--2xl { padding-left: @size_2xl };
-.padding--x--2xl { padding-left: @size_2xl; padding-right: @size_2xl };
-.padding--y--2xl { padding-top: @size_2xl; padding-bottom: @size_2xl };
+.margin--top--2xl { margin-top: @size_2xl }
+
+.margin--right--2xl { margin-right: @size_2xl }
+
+.margin--bottom--2xl { margin-bottom: @size_2xl }
+
+.margin--left--2xl { margin-left: @size_2xl }
+
+.margin--x--2xl { margin-left: @size_2xl; margin-right: @size_2xl }
+
+.margin--y--2xl { margin-top: @size_2xl; margin-bottom: @size_2xl }
+
+.padding--2xl { padding: @size_2xl }
+
+.padding--top--2xl { padding-top: @size_2xl }
+
+.padding--right--2xl { padding-right: @size_2xl }
+
+.padding--bottom--2xl { padding-bottom: @size_2xl }
+
+.padding--left--2xl { padding-left: @size_2xl }
+
+.padding--x--2xl { padding-left: @size_2xl; padding-right: @size_2xl }
+
+.padding--y--2xl { padding-top: @size_2xl; padding-bottom: @size_2xl }
 
 /**
  * @size_3xl
  */
-.margin--3xl { margin: @size_3xl };
-.margin--top--3xl { margin-top: @size_3xl };
-.margin--right--3xl { margin-right: @size_3xl };
-.margin--bottom--3xl { margin-bottom: @size_3xl };
-.margin--left--3xl { margin-left: @size_3xl };
-.margin--x--3xl { margin-left: @size_3xl; margin-right: @size_3xl };
-.margin--y--3xl { margin-top: @size_3xl; margin-bottom: @size_3xl };
+.margin--3xl { margin: @size_3xl }
 
-.padding--3xl { padding: @size_3xl };
-.padding--top--3xl { padding-top: @size_3xl };
-.padding--right--3xl { padding-right: @size_3xl };
-.padding--bottom--3xl { padding-bottom: @size_3xl };
-.padding--left--3xl { padding-left: @size_3xl };
-.padding--x--3xl { padding-left: @size_3xl; padding-right: @size_3xl };
-.padding--y--3xl { padding-top: @size_3xl; padding-bottom: @size_3xl };
+.margin--top--3xl { margin-top: @size_3xl }
+
+.margin--right--3xl { margin-right: @size_3xl }
+
+.margin--bottom--3xl { margin-bottom: @size_3xl }
+
+.margin--left--3xl { margin-left: @size_3xl }
+
+.margin--x--3xl { margin-left: @size_3xl; margin-right: @size_3xl }
+
+.margin--y--3xl { margin-top: @size_3xl; margin-bottom: @size_3xl }
+
+.padding--3xl { padding: @size_3xl }
+
+.padding--top--3xl { padding-top: @size_3xl }
+
+.padding--right--3xl { padding-right: @size_3xl }
+
+.padding--bottom--3xl { padding-bottom: @size_3xl }
+
+.padding--left--3xl { padding-left: @size_3xl }
+
+.padding--x--3xl { padding-left: @size_3xl; padding-right: @size_3xl }
+
+.padding--y--3xl { padding-top: @size_3xl; padding-bottom: @size_3xl }
 
 /**
  * @size_4xl
  */
-.margin--4xl { margin: @size_4xl };
-.margin--top--4xl { margin-top: @size_4xl };
-.margin--right--4xl { margin-right: @size_4xl };
-.margin--bottom--4xl { margin-bottom: @size_4xl };
-.margin--left--4xl { margin-left: @size_4xl };
-.margin--x--4xl { margin-left: @size_4xl; margin-right: @size_4xl };
-.margin--y--4xl { margin-top: @size_4xl; margin-bottom: @size_4xl };
+.margin--4xl { margin: @size_4xl }
 
-.padding--4xl { padding: @size_4xl };
-.padding--top--4xl { padding-top: @size_4xl };
-.padding--right--4xl { padding-right: @size_4xl };
-.padding--bottom--4xl { padding-bottom: @size_4xl };
-.padding--left--4xl { padding-left: @size_4xl };
-.padding--x--4xl { padding-left: @size_4xl; padding-right: @size_4xl };
-.padding--y--4xl { padding-top: @size_4xl; padding-bottom: @size_4xl };
+.margin--top--4xl { margin-top: @size_4xl }
+
+.margin--right--4xl { margin-right: @size_4xl }
+
+.margin--bottom--4xl { margin-bottom: @size_4xl }
+
+.margin--left--4xl { margin-left: @size_4xl }
+
+.margin--x--4xl { margin-left: @size_4xl; margin-right: @size_4xl }
+
+.margin--y--4xl { margin-top: @size_4xl; margin-bottom: @size_4xl }
+
+.padding--4xl { padding: @size_4xl }
+
+.padding--top--4xl { padding-top: @size_4xl }
+
+.padding--right--4xl { padding-right: @size_4xl }
+
+.padding--bottom--4xl { padding-bottom: @size_4xl }
+
+.padding--left--4xl { padding-left: @size_4xl }
+
+.padding--x--4xl { padding-left: @size_4xl; padding-right: @size_4xl }
+
+.padding--y--4xl { padding-top: @size_4xl; padding-bottom: @size_4xl }
 
 /**
  * @size_5xl
  */
-.margin--5xl { margin: @size_5xl };
-.margin--top--5xl { margin-top: @size_5xl };
-.margin--right--5xl { margin-right: @size_5xl };
-.margin--bottom--5xl { margin-bottom: @size_5xl };
-.margin--left--5xl { margin-left: @size_5xl };
-.margin--x--5xl { margin-left: @size_5xl; margin-right: @size_5xl };
-.margin--y--5xl { margin-top: @size_5xl; margin-bottom: @size_5xl };
+.margin--5xl { margin: @size_5xl }
 
-.padding--5xl { padding: @size_5xl };
-.padding--top--5xl { padding-top: @size_5xl };
-.padding--right--5xl { padding-right: @size_5xl };
-.padding--bottom--5xl { padding-bottom: @size_5xl };
-.padding--left--5xl { padding-left: @size_5xl };
-.padding--x--5xl { padding-left: @size_5xl; padding-right: @size_5xl };
-.padding--y--5xl { padding-top: @size_5xl; padding-bottom: @size_5xl };
+.margin--top--5xl { margin-top: @size_5xl }
+
+.margin--right--5xl { margin-right: @size_5xl }
+
+.margin--bottom--5xl { margin-bottom: @size_5xl }
+
+.margin--left--5xl { margin-left: @size_5xl }
+
+.margin--x--5xl { margin-left: @size_5xl; margin-right: @size_5xl }
+
+.margin--y--5xl { margin-top: @size_5xl; margin-bottom: @size_5xl }
+
+.padding--5xl { padding: @size_5xl }
+
+.padding--top--5xl { padding-top: @size_5xl }
+
+.padding--right--5xl { padding-right: @size_5xl }
+
+.padding--bottom--5xl { padding-bottom: @size_5xl }
+
+.padding--left--5xl { padding-left: @size_5xl }
+
+.padding--x--5xl { padding-left: @size_5xl; padding-right: @size_5xl }
+
+.padding--y--5xl { padding-top: @size_5xl; padding-bottom: @size_5xl }


### PR DESCRIPTION
**Overview:**
Fixed a broken stylelint rule in https://github.com/Clever/components/pull/213 and had to temporarily raise the expected lint count.
Updating the autogen scripts to output newlines between rulesets to pass the lint checks.

**Roll Out:**
- Before merging:
  - [N/A] Updated docs
  - [N/A] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
