### PR TITLE
remove redundant Table.Cell styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.29",
+  "version": "0.25.30",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table/Cell.less
+++ b/src/Table/Cell.less
@@ -3,14 +3,6 @@
 .Table--cell {
   .padding--x--m;
   .padding--y--s;
-
-  &:first-child {
-	.padding--left--m;
-  }
-
-  &:last-child {
-    .padding--right--m;
-  }
 }
 
 .Table--cell--no_wrap {


### PR DESCRIPTION
**Jira:** n/a

**Overview:** removes redundant `Table.Cell` padding styles that spilled over to the `List` component

**Roll Out:**
- Before merging:
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.

