### PR TITLE
DIS2-1039 - Make labels selectable

### DIFF
--- a/docs/components/CleverLogInButtonView.jsx
+++ b/docs/components/CleverLogInButtonView.jsx
@@ -1,0 +1,90 @@
+import React from "react";
+import {Link} from "react-router";
+
+import Example, {ExampleCode} from "./Example";
+import PropDocumentation from "./PropDocumentation";
+import View from "./View";
+import {CleverLogInButton} from "src";
+
+let _focusExampleRef;
+
+export default function CleverLogInButtonView() {
+  const {cssClass} = CleverLogInButtonView;
+
+  return (
+    <View className={cssClass.CONTAINER} title="Clever Log In Button" sourcePath="src/CleverLogInButton/CleverLogInButton.jsx">
+      <p>
+        This is a log in button for our partners to use in their own applciations.
+      </p>
+      <Example title="Log in with Clever">
+        <CleverLogInButton client_id={"clever"} redirect_uri={"https://clever.com"}/>
+      </Example>
+
+
+      <PropDocumentation
+        availableProps={[
+          {
+            name: "value",
+            type: "string",
+            description: "The text that appears on the button",
+          },
+          {
+            name: "type",
+            type: "String",
+            description: "One of primary, secondary, destructive, link, linkPlain, plain",
+            defaultValue: "secondary",
+          },
+          {
+            name: "size",
+            type: "String",
+            description: "One of large, regular, small",
+            defaultValue: "regular",
+          },
+          {
+            name: "onClick",
+            type: "Function",
+            description: "Called when the user clicks on the button",
+            optional: true,
+          },
+          {
+            name: "href",
+            type: "String",
+            description: "If provided, cause the button to behave as a link",
+            optional: true,
+          },
+          {
+            name: "target",
+            type: "String",
+            description: "For links, either _self or _blank",
+            defaultValue: "_blank",
+            optional: true,
+          },
+          {
+            name: "disabled",
+            type: "Bool",
+            description: "User interaction is disabled when true",
+            defaultValue: "false",
+            optional: true,
+          },
+          {
+            name: "style",
+            type: "Object",
+            description: "Add custom styles (e.g. margin) if you must",
+            optional: true,
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Optional additional classname to apply to the button",
+            optional: true,
+          },
+        ]}
+        className={cssClass.PROPS}
+      />
+    </View>
+  );
+}
+
+CleverLogInButtonView.cssClass = {
+  CONTAINER: "CleverLogInButtonView",
+};

--- a/docs/components/SideBar/SideBar.jsx
+++ b/docs/components/SideBar/SideBar.jsx
@@ -66,6 +66,7 @@ export default class SideBar extends React.Component {
         <NavGroup id="components" label="Components" icon={icon(Icon.names.WEBSITE_HTML)}>
           {this._renderLink("/components/alert-box", "AlertBox")}
           {this._renderLink("/components/button", "Button")}
+          {this._renderLink("/components/clever-log-in-button", "Clever Log In Button")}
           {this._renderLink("/components/confirmation-button", "ConfirmationButton")}
           {this._renderLink("/components/copyable-input", "CopyableInput")}
           {this._renderLink("/components/count", "Count")}

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -4,6 +4,7 @@ import {IndexRedirect, Route, Router, hashHistory} from "react-router";
 
 import AlertBoxView from "./components/AlertBoxView";
 import ButtonView from "./components/ButtonView";
+import CleverLogInButtonView from "./components/CleverLogInButtonView";
 import ColorsView from "./components/ColorsView";
 import ConfirmationButtonView from "./components/ConfirmationButtonView";
 import CopyableInputView from "./components/CopyableInputView";
@@ -61,6 +62,7 @@ render((
       <Route path="components">
         <Route path="alert-box(/*)" component={AlertBoxView} />
         <Route path="button(/*)" component={ButtonView} />
+        <Route path="clever-log-in-button(/*)" component={CleverLogInButtonView} />
         <Route path="confirmation-button(/*)" component={ConfirmationButtonView} />
         <Route path="copyable-input(/*)" component={CopyableInputView} />
         <Route path="count(/*)" component={CountView} />

--- a/src/CleverLogInButton/CleverLogInButton.jsx
+++ b/src/CleverLogInButton/CleverLogInButton.jsx
@@ -1,0 +1,75 @@
+import React from "react";
+import classnames from "classnames";
+
+import "./CleverLogInButton.less";
+import {Icon} from "../Icon/Icon";
+/*
+  Add a description of your component here.
+
+  If your component can be expressed without state,
+  use the stateless function syntax instead!
+*/
+
+export class CleverLogInButton extends React.Component {
+  constructor(props) {
+    super(props);
+    // Set state and bind methods here
+  }
+
+  /* Insert any additional lifecycle methods,
+     event handlers, and helper methods here */
+
+  render() {
+    const {cssClass} = CleverLogInButton;
+    const {
+      className,
+      disabled,
+      href,
+      client_id,
+      redirect_uri,
+      submit,
+      target,
+    } = this.props;
+
+    var url = href;
+
+    if (href == null) {
+      url = "https://clever.com/oauth/authorize?response_type=code&redirect_uri=" + redirect_uri + "&client_id=" + client_id;
+    }
+
+    return (
+      <a
+        className={classnames(cssClass.BUTTON, className)}
+        href={url}
+        target={target}
+      >
+        <div>
+          <span className={classnames(cssClass.ICON)}>
+            <Icon
+              size={Icon.sizes.SMALL}
+              name={Icon.names.CLEVER_C}
+            />
+            </span>
+          {" "}
+          Log in with Clever
+        </div>
+      </a>
+    );
+  }
+}
+
+CleverLogInButton.propTypes = {
+  className: React.PropTypes.string,
+  href: React.PropTypes.string,
+  redirect_uri: React.PropTypes.string,
+  client_id: React.PropTypes.string,
+  target: React.PropTypes.oneOf(["_self", "_blank"]),
+  disabled: React.PropTypes.bool,
+  submit: React.PropTypes.bool,
+}
+
+CleverLogInButton.cssClass = {
+  BUTTON: "CleverLogInButton",
+  ICON: "CleverLogInButton--Icon",
+  LABEL: "LogInWithClever--Label",
+};

--- a/src/CleverLogInButton/CleverLogInButton.less
+++ b/src/CleverLogInButton/CleverLogInButton.less
@@ -1,0 +1,45 @@
+@import "../less/fonts.less";
+@import (reference) "../less/index";
+
+.CleverLogInButton--Inverse {
+
+}
+
+.CleverLogInButton {
+    .border--s(transparent);
+    .buttonColor(@primary_blue);
+    .borderRadius--top--m;
+    .text--medium;
+    border-bottom-width: @borderWidthL;
+    box-sizing: border-box;
+    color: @neutral_white;
+    cursor: pointer;
+    display: inline-block;
+    font-family: "Proxima Nova";
+    font-weight: 600;
+    padding: @size_s @size_m @size_xs;
+    text-decoration: none;
+    transition: all @timingPromptly @motionSmooth;
+
+    &[disabled],
+    &[disabled]:hover,
+    &[disabled]:focus
+    &[disabled]:active {
+      .buttonColor(@neutral_silver);
+      cursor: not-allowed;
+      color: @neutral_dark_gray;
+    }
+
+    &:hover,
+    &:focus,
+    &:active{
+      outline: 0;
+      color: @neutral_white;
+    }
+  }
+
+  .CleverLogInButton--Icon {
+    .margin--right--xs;
+    .padding--right--xs;
+    border-right: 1px solid @neutral_white;
+  }

--- a/src/Icon/Icon.jsx
+++ b/src/Icon/Icon.jsx
@@ -33,6 +33,7 @@ Icon.names = {
   CHAT_HEART:         "chat-heart",
   CHECKMARK:          "checkmark",
   CIRCLE_C:           "circle-c",
+  CLEVER_C:           "clever-c",
   CLOCK:              "clock",
   DIPLOMA:            "diploma",
   FUNNEL:             "funnel",

--- a/src/Icon/icons/CleverC.jsx
+++ b/src/Icon/icons/CleverC.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+export default function CleverC(props) {
+  return (
+    <svg
+      width="46px"
+      height="46px"
+      viewBox="0 0 32 32"
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      {...props}
+    >
+      {/* Generator: Sketch 41 (35326) - http://www.bohemiancoding.com/sketch */}
+      <title>clever-c</title>
+      <desc>Created with Sketch.</desc>
+      <defs>
+        <rect id="path-1" x={0} y={0} width={46} height={46} rx={23} />
+        <mask
+          id="mask-2"
+          maskContentUnits="userSpaceOnUse"
+          maskUnits="objectBoundingBox"
+          x={0}
+          y={0}
+          width={46}
+          height={46}
+          fill="white"
+        >
+          <use xlinkHref="#path-1" />
+        </mask>
+      </defs>
+      <g
+        id="Artboards"
+        stroke="none"
+        strokeWidth={1}
+        fill="none"
+        fillRule="evenodd"
+      >
+        <g id="clever-c">
+          <path
+            d="M14.4489187,29 C6.15787809,29 0,22.6309274 0,14.5801511 L0,14.4997902 C0,6.52874528 6.0372842,0 14.6905281,0 C20.0031949,0 23.1826991,1.76248426 25.7986588,4.32584977 L21.8544797,8.85228703 C19.681049,6.88963491 17.4675608,5.68799832 14.6502599,5.68799832 C9.90092683,5.68799832 6.47981317,9.61330256 6.47981317,14.4196391 L6.47981317,14.4997902 C6.47981317,19.3063366 9.82039036,23.3120017 14.6502599,23.3120017 C17.8700324,23.3120017 19.8421219,22.0304238 22.0558209,20.0276962 L26,23.9928661 C23.1021626,27.0770038 19.8823901,29 14.4489187,29"
+            id="Path"
+            fill="#FFFFFF"
+          />
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/src/Icon/icons/index.jsx
+++ b/src/Icon/icons/index.jsx
@@ -7,6 +7,7 @@ import ChatHeart from "./ChatHeart";
 import Chat from "./Chat";
 import Checkmark from "./Checkmark";
 import CircleC from "./CircleC";
+import CleverC from "./CleverC";
 import Clock from "./Clock";
 import Diploma from "./Diploma";
 import Funnel from "./Funnel";
@@ -73,6 +74,7 @@ export default {
   chat: Chat,
   checkmark: Checkmark,
   "circle-c": CircleC,
+  "clever-c": CleverC,
   clock: Clock,
   diploma: Diploma,
   funnel: Funnel,

--- a/src/Label/Label.less
+++ b/src/Label/Label.less
@@ -1,6 +1,5 @@
 @import (reference) "../less/index";
 
-
 .Label {
   .text--caps;
   .text--center;
@@ -15,7 +14,6 @@
     color 0.25s ease-out,
     font-size 0.25s ease-out,
     padding 0.25s ease-out;
-  user-select: none;
   vertical-align: middle;
 
   &:active,

--- a/src/index.js
+++ b/src/index.js
@@ -48,3 +48,4 @@ export {Number};
 
 import Tooltip from "./Tooltip";
 export {Tooltip};
+export {CleverLogInButton} from "./CleverLogInButton/CleverLogInButton";

--- a/src/less/components.less
+++ b/src/less/components.less
@@ -15,3 +15,4 @@
 @import "../Icon/Icon";
 @import "../LeftNav/LeftNav";
 @import "../AlertBox/AlertBox";
+@import "../CleverLogInButton/CleverLogInButton";

--- a/test/LogInButton_test.jsx
+++ b/test/LogInButton_test.jsx
@@ -1,0 +1,21 @@
+import assert from "assert";
+import React from "react";
+import sinon from "sinon";
+import {shallow} from "enzyme";
+import {CleverLogInButton} from "../src";
+
+describe("CleverLogInButton", () => {
+  it("renders (something)", () => {
+    /*
+       Write tests here that assert qualities about
+       CleverLogInButton's type, classes, properties,
+       and event handling.
+
+       Refer to enzyme's API and examples for Mocha:
+       http://airbnb.io/enzyme/
+
+       Refer to sinon's API for mocking event functions:
+       http://sinonjs.org/docs/
+    */
+  });
+});


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/DIS2-1039

**Overview:**
Since we replaced sharing rules items with labels from the design system, users have been unable to copy/paste them.

This fixes that by removing `user-select: none;` from the component

**Screenshots/GIFs:**
Old sadness
![image](https://user-images.githubusercontent.com/835698/29639765-c23a230e-8810-11e7-81b4-b3ddbcbe40cb.png)

New hotness
![image](https://user-images.githubusercontent.com/835698/29639865-26214f64-8811-11e7-9fcb-48b60b1b582f.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
