### PR TITLE
Select: Customizable noResultsText.

### DIFF
--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -264,6 +264,13 @@ export default class SelectView extends Component {
               optional: true,
             },
             {
+              name: "noResultsText",
+              type: "node",
+              description: "Text to display when there are no results found in search",
+              defaultValue: "'No results found'",
+              optional: true,
+            },
+            {
               name: "value",
               type: "String",
               description: "Selected value. Must be updated by caller in the onChange",

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -38,6 +38,7 @@ export function Select({
   readOnly,
   required,
   searchable,
+  noResultsText,
   creatable,
   creatablePromptFn,
   value,
@@ -103,6 +104,7 @@ export function Select({
           loadOptions={loadOptions}
           placeholder={placeholder}
           searchable={searchable}
+          noResultsText={noResultsText}
           value={value}
         />
       </div>
@@ -145,6 +147,7 @@ Select.propTypes = {
   searchable: React.PropTypes.bool,
   creatable: React.PropTypes.bool,
   creatablePromptFn: React.PropTypes.func,
+  noResultsText: React.PropTypes.node,
   required: React.PropTypes.bool,
   value: React.PropTypes.oneOfType([
     React.PropTypes.string,


### PR DESCRIPTION
Make the "No results" text customizable - just passes through to the already existing react-select prop.