### PR TITLE
Fix header alignment in AlertBox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.33",
+  "version": "0.25.34",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AlertBox/AlertBox.jsx
+++ b/src/AlertBox/AlertBox.jsx
@@ -42,8 +42,8 @@ export default class AlertBox extends PureComponent {
     return (
       <div className={classnames(`AlertBox--${type}`, CLASSNAMES.CONTAINER, className)}>
         <div className={CLASSNAMES.HEADER}>
-          <span><Icon /></span>
-          <strong className={CLASSNAMES.TITLE}> {title} </strong>
+          <Icon />
+          <strong className={CLASSNAMES.TITLE}>{title}</strong>
           {isClosable &&
             <button className={CLASSNAMES.CLOSE} onClick={() => this.closeBox()}><CloseIcon /></button>
           }

--- a/src/AlertBox/AlertBox.jsx
+++ b/src/AlertBox/AlertBox.jsx
@@ -3,7 +3,7 @@ import classnames from "classnames";
 import React, {PureComponent, PropTypes} from "react";
 
 import {CloseIcon, WarningIcon, SuccessIcon, ErrorIcon, InfoIcon} from "./icons";
-import {FlexBox, ItemAlign} from "../flex";
+import {FlexBox, FlexItem, ItemAlign} from "../flex";
 
 import "./AlertBox.less";
 
@@ -45,7 +45,7 @@ export default class AlertBox extends PureComponent {
       <div className={classnames(`AlertBox--${type}`, CLASSNAMES.CONTAINER, className)}>
         <FlexBox className={CLASSNAMES.HEADER} alignItems={ItemAlign.CENTER}>
           <Icon />
-          <FlexBox className={CLASSNAMES.TITLE} grow>{title}</FlexBox>
+          <FlexItem className={CLASSNAMES.TITLE} grow>{title}</FlexItem>
           {isClosable && (
             <button className={CLASSNAMES.CLOSE} onClick={() => this.closeBox()}>
               <CloseIcon />

--- a/src/AlertBox/AlertBox.jsx
+++ b/src/AlertBox/AlertBox.jsx
@@ -2,8 +2,10 @@ import _ from "lodash";
 import classnames from "classnames";
 import React, {PureComponent, PropTypes} from "react";
 
-import "./AlertBox.less";
 import {CloseIcon, WarningIcon, SuccessIcon, ErrorIcon, InfoIcon} from "./icons";
+import {FlexBox, ItemAlign} from "../flex";
+
+import "./AlertBox.less";
 
 const ICONS = {
   warning: WarningIcon,
@@ -41,13 +43,15 @@ export default class AlertBox extends PureComponent {
     }
     return (
       <div className={classnames(`AlertBox--${type}`, CLASSNAMES.CONTAINER, className)}>
-        <div className={CLASSNAMES.HEADER}>
+        <FlexBox className={CLASSNAMES.HEADER} alignItems={ItemAlign.CENTER}>
           <Icon />
-          <strong className={CLASSNAMES.TITLE}>{title}</strong>
-          {isClosable &&
-            <button className={CLASSNAMES.CLOSE} onClick={() => this.closeBox()}><CloseIcon /></button>
-          }
-        </div>
+          <FlexBox className={CLASSNAMES.TITLE} grow>{title}</FlexBox>
+          {isClosable && (
+            <button className={CLASSNAMES.CLOSE} onClick={() => this.closeBox()}>
+              <CloseIcon />
+            </button>
+          )}
+        </FlexBox>
         {children}
       </div>
     );

--- a/src/AlertBox/AlertBox.less
+++ b/src/AlertBox/AlertBox.less
@@ -10,13 +10,15 @@
 }
 
 .AlertBox--title {
-  display: inline;
-  .margin--left--2xs;
+  .margin--left--xs;
   .text--semi-bold;
+  flex-grow: 1;
 }
 
 .AlertBox--header {
   .padding--bottom--xs;
+  align-items: center;
+  display: flex;
 }
 
 .AlertBox--Icon {
@@ -61,7 +63,6 @@
 }
 
 .AlertBox--close {
-  display: inline;
   cursor: pointer;
   height: @size_m;
   width: @size_m;

--- a/src/AlertBox/AlertBox.less
+++ b/src/AlertBox/AlertBox.less
@@ -12,13 +12,10 @@
 .AlertBox--title {
   .margin--left--xs;
   .text--semi-bold;
-  flex-grow: 1;
 }
 
 .AlertBox--header {
   .padding--bottom--xs;
-  align-items: center;
-  display: flex;
 }
 
 .AlertBox--Icon {


### PR DESCRIPTION
**Overview:**

The icon in the `AlertBox` header sits slightly higher than the title. Verified that this was not an intentional decision. This PR fixes the alignment!

**Screenshots/GIFs:**

*Before:*

<img width="891" alt="before" src="https://user-images.githubusercontent.com/12616928/29949727-7e439994-8e6b-11e7-9d3e-c63920418942.png">

*After:*

<img width="892" alt="after-1" src="https://user-images.githubusercontent.com/12616928/29949709-63594958-8e6b-11e7-8879-9dfc4e9916f3.png">

<img width="904" alt="after-2" src="https://user-images.githubusercontent.com/12616928/29949710-65872b82-8e6b-11e7-8db6-1773c5ebed8c.png">

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**

- Before merging:
  - [ ] ~Updated docs~ *N/A*
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch` <--
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)