### PR TITLE
Classrooms 1601 aria label match button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.35",
+  "version": "0.25.36",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -59,6 +59,7 @@ export class Button extends React.PureComponent {
           ref={ref => { this._buttonRef = ref; }}
           style={style}
           type={submit ? "submit" : "button"}
+          aria-label={(typeof value === "string") ? value : null}
         >
           {value}
         </button>
@@ -72,6 +73,7 @@ export class Button extends React.PureComponent {
         ref={ref => { this._buttonRef = ref; }}
         style={style}
         target={target}
+        aria-label={(typeof value === "string") ? value : null}
       >
         {value}
       </a>

--- a/test/Button_test.jsx
+++ b/test/Button_test.jsx
@@ -36,18 +36,21 @@ describe("Button", () => {
     const button = shallow(<Button value="A button" />);
     assert.equal(button.find("button[type='button']").length, 1);
     assert.equal(button.text(), "A button");
+    assert.equal(button.props()["aria-label"], "A button");
   });
 
   it("renders a <button> element with [type=submit] if submit is true", () => {
     const button = shallow(<Button value="A submit button" submit />);
     assert.equal(button.find("button[type='submit']").length, 1);
     assert.equal(button.text(), "A submit button");
+    assert.equal(button.props()["aria-label"], "A submit button");
   });
 
   it("renders a <a> element if href is provided", () => {
     const button = shallow(<Button value="A link" href="http://clever.com" />);
     assert.equal(button.find("a[target='_blank']").length, 1);
     assert.equal(button.text(), "A link");
+    assert.equal(button.props()["aria-label"], "A link");
   });
 
   it("throws an error if href and submit are both set", () => {


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/CLASSROOMS-1601

**Overview:**
Make the `aria-label` value of Buttons equal to its text value. No documentation change.

**Screenshots/GIFs:**
![screen shot 2017-09-20 at 6 47 02 pm](https://user-images.githubusercontent.com/3036591/30675462-93e53440-9e35-11e7-92d7-14799624c98d.png)
![screen shot 2017-09-20 at 6 44 01 pm](https://user-images.githubusercontent.com/3036591/30675461-93e3eae0-9e35-11e7-9769-d978fd9bb6ce.png)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10
  - [x] FF

**Roll Out:**
- Before merging:
  - [ ] Bumped version in `package.json`
    - Backward compatible change? Run `npm version patch`
