### PR TITLE
fix typo in AlertBox documentation

### DIFF
--- a/docs/components/AlertBoxView.jsx
+++ b/docs/components/AlertBoxView.jsx
@@ -83,7 +83,7 @@ export default class AlertBoxView extends PureComponent {
               optional: true,
             },
             {
-              name: "chrildren",
+              name: "children",
               type: "node",
               description: "Body",
               defaultValue: "",


### PR DESCRIPTION
**Jira:** --

**Overview:**  "chrildren" -> "children" (checked that spelling is correct in component)


**Testing:**

Skipped manual testing due to simplicity of change.

- [ ] Unit tests
- ~Manual tests:~
  -  ~Chrome~
  - ~Safari~
  - ~IE10~

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - ~Bumped version in `package.json`~
    - ~Breaking change? Run `npm version minor`~
    - ~Backward compatible change? Run `npm version patch`~
    - **Only changing documentation? All good. Skip this step.**
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
