### PR TITLE
Modal Accessibility

### DIFF
--- a/docs/components/ModalView.jsx
+++ b/docs/components/ModalView.jsx
@@ -82,6 +82,13 @@ export default class ModalView extends Component {
               defaultValue: "400px",
               optional: true,
             },
+            {
+              name: "focusLocked",
+              type: "Boolean",
+              description: "Whether or not focus stays within the modal when tabbing",
+              defaultValue: "true",
+              optional: true,
+            },
           ]}
           className={cssClass.PROPS}
           title="Modal"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.37",
+  "version": "0.26.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.25.36",
+  "version": "0.25.37",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -46,7 +46,7 @@ export class Modal extends React.Component {
     let contentStyle = {maxHeight: (this.state.windowHeight * 0.9) - 60};
     const modalContent = (
       <div className={classnames("Modal", this.props.className)}>
-        <div className="Modal--background" onClick={this.props.closeModal} />
+        <div className="Modal--background" onClick={this.props.closeModal} aria-hidden="true" />
         <div className="Modal--window" style={windowStyle}>
           <header className="Modal--header">
             <button className="Modal--close" onClick={this.props.closeModal}>{closeIcon}</button>

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -79,5 +79,5 @@ Modal.propTypes = {
 
 Modal.defaultProps = {
   width: DEFAULT_WIDTH,
-  focusLocked: false,
+  focusLocked: true,
 };

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -5,8 +5,8 @@ import FocusTrap from "focus-trap-react";
 require("./Modal.less");
 
 const DEFAULT_WIDTH = 400;
-const closeIcon = <svg viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1490 1322q0 40-28 68l-136 136q-28 28-68 28t-68-28l-294-294-294 294q-28 28-68 28t-68-28l-136-136q-28-28-28-68t28-68l294-294-294-294q-28-28-28-68t28-68l136-136q28-28 68-28t68 28l294 294 294-294q28-28 68-28t68 28l136 136q28 28 28 68t-28 68l-294 294 294 294q28 28 28 68z" /></svg>;
 const ESC = 27;
+const closeIcon = <svg viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1490 1322q0 40-28 68l-136 136q-28 28-68 28t-68-28l-294-294-294 294q-28 28-68 28t-68-28l-136-136q-28-28-28-68t28-68l294-294-294-294q-28-28-28-68t28-68l136-136q28-28 68-28t68 28l294 294 294-294q28-28 68-28t68 28l136 136q28 28 28 68t-28 68l-294 294 294 294q28 28 28 68z" /></svg>;
 
 export class Modal extends React.Component {
   constructor(props) {

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -49,7 +49,7 @@ export class Modal extends React.Component {
         <div className="Modal--background" onClick={this.props.closeModal} aria-hidden="true" />
         <div className="Modal--window" style={windowStyle}>
           <header className="Modal--header">
-            <button className="Modal--close" onClick={this.props.closeModal}>{closeIcon}</button>
+            <button className="Modal--close" onClick={this.props.closeModal} type="button" aria-label="close modal window">{closeIcon}</button>
             <h1>{this.props.title}</h1>
           </header>
           <div style={contentStyle} className="Modal--window--content">


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FEE-95

**Overview:**
The focus locking feature in the modal window is now the default behavior in order to help promote accessibility standards. Accessibility labels have been added to the modal to improve the experience for users with screen readers. 

**Screenshots/GIFs:**
<img width="1831" alt="screen shot 2017-10-18 at 2 19 45 pm" src="https://user-images.githubusercontent.com/32328921/31743300-7adc969c-b40f-11e7-975c-e58dd1017f1f.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
