### PR TITLE
updated props table in documentation for ConfirmButton

### DIFF
--- a/docs/components/ConfirmationButtonView.jsx
+++ b/docs/components/ConfirmationButtonView.jsx
@@ -40,6 +40,11 @@ export default class ConfirmationButtonView extends Component {
         <PropDocumentation
           availableProps={[
             {
+              name: "value",
+              type: "string",
+              description: "The text that appears on the modal activation button",
+            },
+            {
               name: "modalTitle",
               type: "string",
               description: "Header text for the modal",
@@ -48,18 +53,22 @@ export default class ConfirmationButtonView extends Component {
               name: "confirmButtonValue",
               type: "string",
               description: "The text that appears on the Confirm button",
+              defaultValue: "Confirm",
+              optional: true,
             },
             {
               name: "confirmButtonType",
               type: "String",
               description: "One of primary, secondary, destructive, link, linkPlain, plain",
-              defaultValue: "secondary",
+              defaultValue: "primary",
+              optional: true,
             },
             {
               name: "confirmButtonSize",
               type: "String",
               description: "One of large, regular, small",
               defaultValue: "regular",
+              optional: true,
             },
             {
               name: "modalWidth",


### PR DESCRIPTION
**Jira:**

**Overview:**
Added value prop to the table in the ConfirmButton documentation. This is the text that appears on the button that activates the modal, and it is required since it is passed to a Button component. Updated some other props to make the documentation match the implementation.

Note that the button size is optional and has a default value that is defined in the Button's implementation:
https://github.com/Clever/components/blob/c3d2729dac0886622ec5a9d6d82b3bf04fe9afe2/src/Button/Button.jsx#L99-L103

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
