### PR TITLE
Fix Select alignment

### DIFF
--- a/src/Select/Select.less
+++ b/src/Select/Select.less
@@ -14,9 +14,10 @@
   top: @size_xs;
   width: 100%;
 
+  // aligns REQUIRED text with text in other forms
   .Select--required {
     position: absolute;
-    right: @size_l;
+    right: 0.8rem;
   }
 }
 
@@ -51,6 +52,11 @@
     .Select-arrow {
       display: none;
     }
+  }
+
+  // aligns the arrow with REQUIRED text (so both align with other forms)
+  .Select-arrow-zone {
+    padding-right: 0.6rem;
   }
 
   &.Select--multi {


### PR DESCRIPTION
**Overview:**
The "REQUIRED" text and the dropdown arrow are both misaligned with
required text in other form components (e.g. the TextInput component).
I still don't fully understand the required alignment, but have
visually confirmed that they are now aligned.

Also, I'm aware these are not standard sizes, but these elements would 
not align correctly using them.

**Screenshots/GIFs:**
Required alignment:
<img width="1222" alt="screenshot 2017-11-21 08 30 41" src="https://user-images.githubusercontent.com/3298966/33075503-b45ec348-ce97-11e7-85dc-092e0d44465a.png">

Arrow alignment:
<img width="1242" alt="screenshot 2017-11-21 08 30 55" src="https://user-images.githubusercontent.com/3298966/33075507-b984d6dc-ce97-11e7-9e78-80d2b0f771d4.png">

Firefox:
<img width="722" alt="screenshot 2017-11-21 08 52 29" src="https://user-images.githubusercontent.com/3298966/33075997-5581b360-ce99-11e7-9b45-9ba41c9239ce.png">

Safari:
<img width="730" alt="screenshot 2017-11-21 08 57 48" src="https://user-images.githubusercontent.com/3298966/33076208-1716ab02-ce9a-11e7-80e1-59ab75cf164e.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [X] Chrome
  - [X] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
