### PR TITLE
TextInput: support arbitrary input type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -68,7 +68,13 @@ export class TextInput extends React.Component {
       inputNote = <span className="TextInput--error">{this.props.error}</span>;
     }
 
-    let type = (this.props.type === "password" && this.state.hidden) ? "password" : "text";
+    let type;
+    if (this.props.type === "password") {
+      type = this.state.hidden ? "password" : "text";
+    } else {
+      type = this.props.type || "text";
+    }
+
     const additionalProps = _.omit(this.props, Object.keys(TextInput.propTypes));
 
     return (


### PR DESCRIPTION
**Jira:** n/a

**Overview:** the docs say we support "number" type for TextInputs but we don't actually. This allows setting the `type` prop on the TextInput to be passed down to the underlying `input` element.