### PR TITLE
Button secondary background color when hovering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -85,6 +85,7 @@ a, button {
     &:active {
       .shade(border-color, @primary_blue, 2);
       .shade(color, @primary_blue, 2);
+      background-color: @neutral_off_white;
     }
   }
 


### PR DESCRIPTION
**Jira:**

**Overview:**
This change adds a background color to the secondary button to fix an issue where the background color was being overridden.

**Screenshots/GIFs:**
Before
![](https://cl.ly/1q0d1i0w1Z12/Screen%20Recording%202017-12-19%20at%2003.23%20PM.gif)

After
![](https://cl.ly/0S1s1x0A371A/Screen%20Recording%202017-12-19%20at%2003.46%20PM.gif)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
