### PR TITLE
Allow cell className to be specified as a function on row data.

### DIFF
--- a/docs/components/TableView.jsx
+++ b/docs/components/TableView.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import _ from "lodash";
+import classnames from "classnames";
 import loremIpsum from "lorem-ipsum";
 import React, {PureComponent} from "react";
 
@@ -15,6 +16,7 @@ export default class TableView extends PureComponent {
   constructor(props) {
     super(props);
     this.state = {
+      enableDynamicCellClass: false,
       enableRowClick: true,
       tableFilter: "",
     };
@@ -46,7 +48,7 @@ export default class TableView extends PureComponent {
 
   render() {
     const {cssClass} = TableView;
-    const {enableRowClick, tableData} = this.state;
+    const {enableDynamicCellClass, enableRowClick, tableData} = this.state;
 
     return (
       <View className={cssClass.CONTAINER} title="Table">
@@ -136,7 +138,13 @@ export default class TableView extends PureComponent {
                 <Table.Column
                   id="status"
                   header={{content: "Status"}}
-                  cell={{renderer: r => r.status}}
+                  cell={{
+                    className: r => classnames(
+                      "TableView--status",
+                      enableDynamicCellClass && r.status.includes("e") && "TableView--status--red"
+                    ),
+                    renderer: r => r.status,
+                  }}
                   sortable
                   sortValueFn={r => r.status}
                 />
@@ -158,6 +166,15 @@ export default class TableView extends PureComponent {
             />
             {" "}
             Clickable rows (see console)
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={enableDynamicCellClass}
+              onChange={({target}) => this.setState({enableDynamicCellClass: target.checked})}
+            />
+            {" "}
+            Dynamic cell class names
           </label>
         </Example>
 
@@ -281,9 +298,20 @@ export default class TableView extends PureComponent {
           availableProps={[
             {
               name: "cell",
-              type: "{className: String (optional), renderer: Function}",
-              description: "Configuration for the table body cell for this column. renderer will be called with data"
-              + " for a single row and should return content that can be rendered by the React DOM renderer",
+              type: "{className: String or Function (optional), renderer: Function}",
+              description: (
+                <div>
+                  <p>Configuration for the table body cell for this column.</p>
+                  <p>
+                    <code>renderer</code> will be called with data for a single row and should return content that can
+                    be rendered by the React DOM renderer.
+                  </p>
+                  <p>
+                    If <code>className</code> is a function, it will also be called with row data and should return a
+                    render-compatible value.
+                  </p>
+                </div>
+              ),
             },
             {
               name: "id",

--- a/docs/components/TableView.less
+++ b/docs/components/TableView.less
@@ -10,3 +10,12 @@
   display: inline-block;
   text-transform: uppercase;
 }
+
+.TableView--status {
+  transition: all @timingPromptly ease-out;
+}
+
+.TableView--status--red {
+  background-color: @alert_red;
+  color: @neutral_white;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.26.9",
+  "version": "0.26.10",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table/Column.jsx
+++ b/src/Table/Column.jsx
@@ -7,7 +7,10 @@ export default function Column() {
 
 Column.propTypes = {
   cell: PropTypes.shape({
-    className: PropTypes.string,
+    className: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func,
+    ]),
     renderer: PropTypes.func.isRequired,
   }),
   id: PropTypes.string.isRequired,

--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -308,7 +308,7 @@ export class Table extends Component {
               onClick={e => onRowClick && onRowClick(e, rowIDFn(rowData), rowData)}
             >
               {columns.map(({props: col}) => (
-                <Cell className={col.cell.className} key={col.id} noWrap={col.noWrap}>
+                <Cell className={getCellClassName(col, rowData)} key={col.id} noWrap={col.noWrap}>
                   {col.cell.renderer(rowData)}
                 </Cell>
               ))}
@@ -329,6 +329,16 @@ export class Table extends Component {
       </table>
     );
   }
+}
+
+function getCellClassName(columnProps, rowData) {
+  const {className} = columnProps.cell;
+
+  if (typeof className === "function") {
+    return className(rowData);
+  }
+
+  return className;
 }
 
 Table.propTypes = {

--- a/test/Table/Table_test.jsx
+++ b/test/Table/Table_test.jsx
@@ -49,7 +49,10 @@ describe("Table", () => {
     <Column
       id="description"
       header={{content: "Description"}}
-      cell={{renderer: r => r.description}}
+      cell={{
+        className: r => r.id,
+        renderer: r => r.description,
+      }}
     />
   );
 
@@ -108,6 +111,19 @@ describe("Table", () => {
       assert(
         lodash.includes(nameCell.props().className, nameColumn.props.cell.className),
         `Expected ${nameCell.props().className} to contain ${nameColumn.props.cell.className}`
+      );
+    });
+
+    it("assigns custom cell class name if specified as a function", () => {
+      const descriptionCell = newTable()
+        .find(`.${cssClass.ROW}`).first()
+        .find(Cell).at(1);
+
+      assert(
+        descriptionCell.props().className.includes(descriptionColumn.props.cell.className(DATA[0])),
+        `Expected ${
+          descriptionCell.props().className
+        } to contain ${descriptionColumn.props.cell.className(DATA[0])}`
       );
     });
 


### PR DESCRIPTION
**Jira:** N/A

**Overview:**
Allow cell className to be specified as a function on row data.

**Screenshots/GIFs:**
![Screenshot from Gyazo](https://gyazo.com/c96ca2a6a070cc0873115c6201fee343/raw)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [n/a] Safari
  - [n/a] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)

  