### PR TITLE
Add lamp and map icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.26.11",
+  "version": "0.26.12",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Icon/Icon.jsx
+++ b/src/Icon/Icon.jsx
@@ -47,6 +47,7 @@ Icon.names = {
   LEADER:             "leader",
   LIGHTNING_JAR:      "lightning-jar",
   LOCK:               "lock",
+  MAP:                "map",
   MAGIC_LAMP:         "magic-lamp",
   MAGNIFY_C:          "magnify-c",
   MAGNIFY_USER:       "magnify-user",

--- a/src/Icon/Icon.jsx
+++ b/src/Icon/Icon.jsx
@@ -47,6 +47,7 @@ Icon.names = {
   LEADER:             "leader",
   LIGHTNING_JAR:      "lightning-jar",
   LOCK:               "lock",
+  MAGIC_LAMP:         "magic-lamp",
   MAGNIFY_C:          "magnify-c",
   MAGNIFY_USER:       "magnify-user",
   MAN:                "man",

--- a/src/Icon/icons/MagicLamp.jsx
+++ b/src/Icon/icons/MagicLamp.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+export default function MagicLamp(props) {
+  return (
+    <svg width="46px" height="46px" viewBox="0 0 46 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" {...props}>
+        {/* Generator: Sketch 47.1 (45422) - http://www.bohemiancoding.com/sketch */}
+        <title>Magic Lamp 44px</title>
+      <desc>Created with Sketch.</desc>
+      <defs />
+      <g id="Icons" stroke="none" strokeWidth={1} fill="none" fillRule="evenodd">
+        <g id="Magic-Lamp-44px">
+          <g id="Page-1" transform="translate(0.000000, 4.000000)">
+            <path d="M8.49257143,23.3058947 C8.49257143,25.3185263 6.83185714,26.9522105 4.78114286,26.9522105 C2.73257143,26.9522105 1.07185714,25.3185263 1.07185714,23.3058947 C1.07185714,21.2932632 2.73257143,19.6595789 4.78114286,19.6595789 C6.83185714,19.6595789 8.49257143,21.2932632 8.49257143,23.3058947 Z" id="Stroke-1" stroke="#A59F59" strokeWidth="2.12000012" strokeLinecap="round" strokeLinejoin="round" />
+            <polygon id="Fill-3" fill="#FDF49C" points="44.6933571 16.7915789 28.8233571 32.6231579 27.7605 22.2926316 40.3155 16.7915789" />
+            <polygon id="Stroke-5" stroke="#A59F59" strokeWidth="2.12000012" strokeLinecap="round" strokeLinejoin="round" points="44.6933571 16.7915789 28.8233571 32.6231579 27.7605 22.2926316 40.3155 16.7915789" />
+            <path d="M28.8023571,38.6526316 C28.6459286,34.8631579 25.4916429,31.8315789 21.5959286,31.8315789 C17.7002143,31.8315789 14.5459286,34.8631579 14.3895,38.6526316 L28.8023571,38.6526316 Z" id="Fill-7" fill="#FDF49C" />
+            <path d="M28.8023571,38.6526316 C28.6459286,34.8631579 25.4916429,31.8315789 21.5959286,31.8315789 C17.7002143,31.8315789 14.5459286,34.8631579 14.3895,38.6526316 L28.8023571,38.6526316 Z" id="Stroke-9" stroke="#A59F59" strokeWidth="2.12000012" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M34.7181429,25.0488421 C34.7181429,29.9204211 28.8424286,33.8698947 21.5952857,33.8698947 C14.3481429,33.8698947 8.47457143,29.9204211 8.47457143,25.0488421 C8.47457143,20.1772632 14.3481429,16.2277895 21.5952857,16.2277895 C28.8424286,16.2277895 34.7181429,20.1772632 34.7181429,25.0488421" id="Fill-11" fill="#FDF49C" />
+            <path d="M34.7181429,25.0488421 C34.7181429,29.9204211 28.8424286,33.8698947 21.5952857,33.8698947 C14.3481429,33.8698947 8.47457143,29.9204211 8.47457143,25.0488421 C8.47457143,20.1772632 14.3481429,16.2277895 21.5952857,16.2277895 C28.8424286,16.2277895 34.7181429,20.1772632 34.7181429,25.0488421 Z" id="Stroke-13" stroke="#A59F59" strokeWidth="2.12000012" strokeLinecap="round" strokeLinejoin="round" />
+            <g id="Group-18" transform="translate(8.571429, 20.757895)">
+              <path d="M1.34121429,0.288842105 L24.7090714,0.288842105" id="Fill-15" fill="#FDF49C" />
+              <path d="M1.34121429,0.288842105 L24.7090714,0.288842105" id="Stroke-17" stroke="#A59F59" strokeWidth="2.12000012" strokeLinecap="round" strokeLinejoin="round" />
+            </g>
+            <path d="M24.1977857,12.8717895 C24.1977857,14.2844211 23.0320714,15.4275789 21.5963571,15.4275789 C20.1585,15.4275789 18.9949286,14.2844211 18.9949286,12.8717895 C18.9949286,11.4591579 20.1585,10.316 21.5963571,10.316 C23.0320714,10.316 24.1977857,11.4591579 24.1977857,12.8717895 Z" id="Stroke-19" stroke="#A59F59" strokeWidth="2.12000012" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M34.7181429,1.05242105 L34.7181429,8.66715789" id="Stroke-21" stroke="#A59F59" strokeWidth="2.12000012" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M38.5930714,4.85957895 L30.8423571,4.85957895" id="Stroke-23" stroke="#A59F59" strokeWidth="2.12000012" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M8.47414286,5.45136842 L8.47414286,9.50821053" id="Stroke-25" stroke="#A59F59" strokeWidth="2.12000012" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M10.539,7.48 L6.40971429,7.48" id="Stroke-27" stroke="#A59F59" strokeWidth="2.12000012" strokeLinecap="round" strokeLinejoin="round" />
+          </g>
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/src/Icon/icons/Map.jsx
+++ b/src/Icon/icons/Map.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+export default function Map(props) {
+  return (
+    <svg width="46px" height="46px" viewBox="0 0 46 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" {...props}>
+        {/* Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch */}
+        <title>icon-map-46px</title>
+      <desc>Created with Sketch.</desc>
+      <defs />
+      <g id="Finalized-Icons" stroke="none" strokeWidth={1} fill="none" fillRule="evenodd" strokeLinecap="round" strokeLinejoin="round">
+        <g id="icon-map-46px" stroke="#566279" strokeWidth={2}>
+          <g id="Group" transform="translate(1.000000, 2.000000)">
+            <polyline id="Shape" fill="#D2DEFF" points="29 11.7 44 8 44 38 28 42 16 38 0 42 0 12 13.9 8.5" />
+            <path d="M16,38 L16,13.3" id="Shape" opacity="0.5" />
+            <path d="M28,42 L28,13.3" id="Shape" opacity="0.5" />
+            <circle id="Oval" fill="#F38B91" cx={22} cy={8} r={8} />
+            <path d="M22,16 L22,26" id="Shape" />
+          </g>
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/src/Icon/icons/index.jsx
+++ b/src/Icon/icons/index.jsx
@@ -21,6 +21,7 @@ import Juggler from "./Juggler";
 import Leader from "./Leader";
 import LightningJar from "./LightningJar";
 import Lock from "./Lock";
+import MagicLamp from "./MagicLamp";
 import MagnifyC from "./MagnifyC";
 import MagnifyUser from "./MagnifyUser";
 import Man from "./Man";
@@ -87,6 +88,7 @@ export default {
   leader: Leader,
   "lightning-jar": LightningJar,
   lock: Lock,
+  "magic-lamp": MagicLamp,
   "magnify-c": MagnifyC,
   "magnify-user": MagnifyUser,
   man: Man,

--- a/src/Icon/icons/index.jsx
+++ b/src/Icon/icons/index.jsx
@@ -25,6 +25,7 @@ import MagicLamp from "./MagicLamp";
 import MagnifyC from "./MagnifyC";
 import MagnifyUser from "./MagnifyUser";
 import Man from "./Man";
+import Map from "./Map";
 import Menu from "./Menu";
 import Microphone from "./Microphone";
 import Microscope from "./Microscope";
@@ -92,6 +93,7 @@ export default {
   "magnify-c": MagnifyC,
   "magnify-user": MagnifyUser,
   man: Man,
+  map: Map,
   menu: Menu,
   microphone: Microphone,
   microscope: Microscope,


### PR DESCRIPTION
**Jira:** n/a

**Overview:** adds Map and MagicLamp icons 

**Screenshots/GIFs:**
<img width="395" alt="screen shot 2018-01-10 at 5 40 58 pm" src="https://user-images.githubusercontent.com/1060688/34804468-92bc8f32-f62d-11e7-840f-b9bcef6eb99c.png">

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
