### PR TITLE
tooltip delay hide

### DIFF
--- a/docs/components/TooltipView.jsx
+++ b/docs/components/TooltipView.jsx
@@ -128,6 +128,18 @@ export default class TooltipView extends Component {
               description: "Alignment of the tooltip text content.",
               defaultValue: "Tooltip.Align.LEFT",
             },
+            {
+              name: "delayMs",
+              type: "number",
+              description: "Number of ms to wait before showing the tooltip",
+              defaultValue: 0,
+            },
+            {
+              name: "delayHideMs",
+              type: "number",
+              description: "Number of ms to wait before hiding the tooltip",
+              defaultValue: 0,
+            },
           ]}
           className={cssClass.PROPS}
         />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.27.2",
+  "version": "0.28.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Tooltip/Tooltip.jsx
+++ b/src/Tooltip/Tooltip.jsx
@@ -21,7 +21,7 @@ export default class Tooltip extends Component {
 
   render() {
     const {cssClass} = Tooltip;
-    const {children, className, content, delayMs, hide, placement, textAlign} = this.props;
+    const {children, className, content, delayMs, hide, placement, textAlign, delayHideMs} = this.props;
 
     const tooltip = (
       <BootstrapTooltip id={this.id}>
@@ -34,6 +34,7 @@ export default class Tooltip extends Component {
     return (
       <OverlayTrigger
         delayShow={delayMs}
+        delayHide={delayHideMs}
         overlay={tooltip}
         placement={placement}
         rootClose
@@ -65,6 +66,7 @@ Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
   content: PropTypes.node.isRequired,
   delayMs: PropTypes.number,
+  delayHideMs: PropTypes.number,
   hide: PropTypes.bool,
   placement: PropTypes.oneOf(_.values(Tooltip.Placement)),
   textAlign: PropTypes.oneOf(_.values(Tooltip.Align)),


### PR DESCRIPTION
Allows delay the hiding of tooltips. This is useful for when there is is content in the tooltip we want to allow users to click. 