### PR TITLE
add present gift for dark background

### DIFF
--- a/src/Icon/Icon.jsx
+++ b/src/Icon/Icon.jsx
@@ -67,6 +67,7 @@ Icon.names = {
   PLAY_BUTTON:        "play",
   PORTAL_OPEN:        "portal-open",
   PRESENT_GIFT:       "present-gift",
+  PRESENT_GIFT_DARK:  "present-gift-dark",
   PRESENTATION:       "presentation",
   PRINTER:            "printer",
   QR:                 "qr",

--- a/src/Icon/icons/PresentGiftDark.jsx
+++ b/src/Icon/icons/PresentGiftDark.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+export default function PresentGiftForDark(props) {
+  return (
+    <svg
+      width="46px"
+      height="46px"
+      viewBox="0 0 46 46"
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      {...props}
+    >
+    <g transform="translate(1 1)" stroke="#FFF" strokeWidth="2" fill="none"
+      fillRule="evenodd"
+    >
+        <path d="M40 16v26.009c0 1.1-.89 1.991-2 1.991H6a2 2 0 0 1-2-1.991V16"
+          fill="#2E51AC" fillRule="nonzero"
+        />
+        <rect fill="#355DC5" fillRule="nonzero" y="8" width="44" height="8" rx="2" />
+        <path fill="#284694" fillRule="nonzero" d="M26 8v36h-8V8" />
+        <path
+          d="M10 4a4 4 0 0 1 4-4c5.917 0 8 8 8 8h-8a4 4 0 0 1-4-4zM34 4a4 4 0 0 0-4-4c-5.917 0-8 8-8 8h8a4 4 0 0 0 4-4z"
+        />
+    </g>
+</svg>
+  );
+}

--- a/src/Icon/icons/index.jsx
+++ b/src/Icon/icons/index.jsx
@@ -41,6 +41,7 @@ import Pickax from "./Pickax";
 import Play from "./Play";
 import PortalOpen from "./PortalOpen";
 import PresentGift from "./PresentGift";
+import PresentGiftDark from "./PresentGiftDark";
 import Presentation from "./Presentation";
 import Printer from "./Printer";
 import QR from "./QR";
@@ -110,6 +111,7 @@ export default {
   play: Play,
   "portal-open": PortalOpen,
   "present-gift": PresentGift,
+  "present-gift-dark": PresentGiftDark,
   presentation: Presentation,
   printer: Printer,
   qr: QR,


### PR DESCRIPTION
**Overview:**
- Add present icon for dark backgrounds (see below for current and new)

**Screenshots/GIFs:**
![image](https://user-images.githubusercontent.com/926385/35458628-f11009e0-0291-11e8-9510-89b978da5f5b.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
