### PR TITLE
Add support for a date time picker in DateInput component

### DIFF
--- a/docs/components/DateInputView.jsx
+++ b/docs/components/DateInputView.jsx
@@ -16,6 +16,7 @@ export default class DateInputView extends Component {
       readOnly: false,
       hasError: false,
       required: false,
+      useTime: false,
       value: null,
     };
   }
@@ -39,6 +40,7 @@ export default class DateInputView extends Component {
               readOnly={this.state.readOnly}
               required={this.state.required}
               value={this.state.value}
+              useTime={this.state.useTime}
             />
           </ExampleCode>
           <label className={cssClass.CONFIG}>
@@ -76,6 +78,15 @@ export default class DateInputView extends Component {
             />
             {" "}
             Error
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={this.state.useTime}
+              onChange={({target}) => this.setState({useTime: target.checked})}
+            />
+            {" "}
+            Use Time
           </label>
         </Example>
 
@@ -157,6 +168,12 @@ export default class DateInputView extends Component {
               name: "max",
               type: "Date",
               description: "Maximum date the user can select.",
+              optional: true,
+            },
+            {
+              name: "useTime",
+              type: "Bool",
+              description: "Flag to switch to date time picker input",
               optional: true,
             },
           ]}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-autosize-textarea": "^3.0.1",
     "react-bootstrap": "^0.30.0",
     "react-copy-to-clipboard": "^4.2.1",
+    "react-datetime": "^2.12.0",
     "react-dropzone": "^3.11.0",
     "react-fontawesome": "^1.6.1",
     "react-linkify": "^0.2.1",

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -2,6 +2,7 @@ import moment from "moment";
 import React from "react";
 import classnames from "classnames";
 import ReactDatePicker from "../../vendor/react-datepicker/dist/react-datepicker.min.js";
+import ReactDateTime from "react-datetime";
 
 import "./DateInput.less";
 
@@ -9,11 +10,25 @@ export default class DateInput extends React.Component {
   constructor(props) {
     super(props);
     this.state = {inFocus: false};
+
+    this.isValidDate = this.isValidDate.bind(this);
   }
 
   onChange(v) {
     this.input.blur();
     this.props.onChange(v);
+  }
+
+  isValidDate(current) {
+    let afterMin = true;
+    let beforeMax = true;
+    if (this.props.min) {
+      afterMin = current.isSameOrAfter(this.props.min);
+    }
+    if (this.props.max) {
+      beforeMax = current.isSameOrBefore(this.props.max);
+    }
+    return afterMin && beforeMax;
   }
 
   render() {
@@ -54,22 +69,39 @@ export default class DateInput extends React.Component {
           <label className="DateInput--label" htmlFor={this.props.name}>{this.props.label}</label>
           {inputNote}
         </div>
-        <ReactDatePicker
-          calendarClassName="DatePicker"
-          className="DateInput--input"
-          disabled={this.props.disabled || this.props.readOnly}
-          maxDate={this.props.max}
-          minDate={this.props.min}
-          name={this.props.name}
-          onBlur={() => this.setState({inFocus: false})}
-          onFocus={() => this.setState({inFocus: true})}
-          onSelect={this.props.onChange}
-          placeholderText={this.props.placeholder}
-          readOnly={this.props.readOnly}
-          ref="input"
-          required={this.props.required}
-          selected={this.props.value}
-        />
+        {this.props.useTime ?
+          <ReactDateTime
+            className="DateTimePicker"
+            onChange={this.props.onChange}
+            value={this.props.value}
+            onBlur={() => this.setState({inFocus: false})}
+            onFocus={() => this.setState({inFocus: true})}
+            isValidDate={this.isValidDate}
+            inputProps={{
+              className: "DateInput--input",
+              placeholder: this.props.placeholder,
+              name: this.props.name,
+              disabled: this.props.disabled || this.props.readOnly,
+              required: this.props.required,
+            }}
+          /> :
+          <ReactDatePicker
+            calendarClassName="DatePicker"
+            className="DateInput--input"
+            disabled={this.props.disabled || this.props.readOnly}
+            maxDate={this.props.max}
+            minDate={this.props.min}
+            name={this.props.name}
+            onBlur={() => this.setState({inFocus: false})}
+            onFocus={() => this.setState({inFocus: true})}
+            onSelect={this.props.onChange}
+            placeholderText={this.props.placeholder}
+            readOnly={this.props.readOnly}
+            ref="input"
+            required={this.props.required}
+            selected={this.props.value}
+          />
+        }
       </div>
     );
   }
@@ -96,4 +128,5 @@ DateInput.propTypes = {
   className: React.PropTypes.string,
   min: dateType,
   max: dateType,
+  useTime: React.PropTypes.bool,
 };

--- a/src/DateInput/DateInput.less
+++ b/src/DateInput/DateInput.less
@@ -4,6 +4,7 @@
 @import (reference) "../less/type-size";
 @import (reference) "../less/type-utilities";
 @import (reference) "../less/spacing";
+@import "../../vendor/react-datetime/react-datetime.css";
 
 .DateInput {
   .padding--x--s;

--- a/vendor/react-datetime/react-datetime.css
+++ b/vendor/react-datetime/react-datetime.css
@@ -1,0 +1,209 @@
+.rdt {
+  position: relative;
+}
+.rdtPicker {
+  display: none;
+  position: absolute;
+  width: 250px;
+  padding: 4px;
+  margin-top: 1px;
+  z-index: 99999 !important;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0,0,0,.1);
+  border: 1px solid #f9f9f9;
+}
+.rdtOpen .rdtPicker {
+  display: block;
+}
+.rdtStatic .rdtPicker {
+  box-shadow: none;
+  position: static;
+}
+
+.rdtPicker .rdtTimeToggle {
+  text-align: center;
+}
+
+.rdtPicker table {
+  width: 100%;
+  margin: 0;
+}
+.rdtPicker td,
+.rdtPicker th {
+  text-align: center;
+  height: 28px;
+}
+.rdtPicker td {
+  cursor: pointer;
+}
+.rdtPicker td.rdtDay:hover,
+.rdtPicker td.rdtHour:hover,
+.rdtPicker td.rdtMinute:hover,
+.rdtPicker td.rdtSecond:hover,
+.rdtPicker .rdtTimeToggle:hover {
+  background: #eeeeee;
+  cursor: pointer;
+}
+.rdtPicker td.rdtOld,
+.rdtPicker td.rdtNew {
+  color: #999999;
+}
+.rdtPicker td.rdtToday {
+  position: relative;
+}
+.rdtPicker td.rdtToday:before {
+  content: '';
+  display: inline-block;
+  border-left: 7px solid transparent;
+  border-bottom: 7px solid #428bca;
+  border-top-color: rgba(0, 0, 0, 0.2);
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+}
+.rdtPicker td.rdtActive,
+.rdtPicker td.rdtActive:hover {
+  background-color: #428bca;
+  color: #fff;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+}
+.rdtPicker td.rdtActive.rdtToday:before {
+  border-bottom-color: #fff;
+}
+.rdtPicker td.rdtDisabled,
+.rdtPicker td.rdtDisabled:hover {
+  background: none;
+  color: #999999;
+  cursor: not-allowed;
+}
+
+.rdtPicker td span.rdtOld {
+  color: #999999;
+}
+.rdtPicker td span.rdtDisabled,
+.rdtPicker td span.rdtDisabled:hover {
+  background: none;
+  color: #999999;
+  cursor: not-allowed;
+}
+.rdtPicker th {
+  border-bottom: 1px solid #f9f9f9;
+}
+.rdtPicker .dow {
+  width: 14.2857%;
+  border-bottom: none;
+}
+.rdtPicker th.rdtSwitch {
+  width: 100px;
+}
+.rdtPicker th.rdtNext,
+.rdtPicker th.rdtPrev {
+  font-size: 21px;
+  vertical-align: top;
+}
+
+.rdtPrev span,
+.rdtNext span {
+  display: block;
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none;   /* Chrome/Safari/Opera */
+  -khtml-user-select: none;    /* Konqueror */
+  -moz-user-select: none;      /* Firefox */
+  -ms-user-select: none;       /* Internet Explorer/Edge */
+  user-select: none;
+}
+
+.rdtPicker th.rdtDisabled,
+.rdtPicker th.rdtDisabled:hover {
+  background: none;
+  color: #999999;
+  cursor: not-allowed;
+}
+.rdtPicker thead tr:first-child th {
+  cursor: pointer;
+}
+.rdtPicker thead tr:first-child th:hover {
+  background: #eeeeee;
+}
+
+.rdtPicker tfoot {
+  border-top: 1px solid #f9f9f9;
+}
+
+.rdtPicker button {
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+.rdtPicker button:hover {
+  background-color: #eee;
+}
+
+.rdtPicker thead button {
+  width: 100%;
+  height: 100%;
+}
+
+td.rdtMonth,
+td.rdtYear {
+  height: 50px;
+  width: 25%;
+  cursor: pointer;
+}
+td.rdtMonth:hover,
+td.rdtYear:hover {
+  background: #eee;
+}
+
+.rdtCounters {
+  display: inline-block;
+}
+
+.rdtCounters > div {
+  float: left;
+}
+
+.rdtCounter {
+  height: 100px;
+}
+
+.rdtCounter {
+  width: 40px;
+}
+
+.rdtCounterSeparator {
+  line-height: 100px;
+}
+
+.rdtCounter .rdtBtn {
+  height: 40%;
+  line-height: 40px;
+  cursor: pointer;
+  display: block;
+
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none;   /* Chrome/Safari/Opera */
+  -khtml-user-select: none;    /* Konqueror */
+  -moz-user-select: none;      /* Firefox */
+  -ms-user-select: none;       /* Internet Explorer/Edge */
+  user-select: none;
+}
+.rdtCounter .rdtBtn:hover {
+  background: #eee;
+}
+.rdtCounter .rdtCount {
+  height: 20%;
+  font-size: 1.2em;
+}
+
+.rdtMilli {
+  vertical-align: middle;
+  padding-left: 8px;
+  width: 48px;
+}
+
+.rdtMilli input {
+  width: 100%;
+  font-size: 1.2em;
+  margin-top: 37px;
+}


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/IL-160

**Overview:**
As part of IL-160, we're allowing users to select DateTime for start and end. This change allows us to use DateTime in the DateInput component. The problem with the library we currently use is two-fold:
* We're working off a branched version so we can't use functionality introduced in newer versions that somewhat support DateTime input
* It doesn't work in Modals because it moves the calendar portion to the top of the DOM instead of being a child of the Modal

This change introduces the react-datetime npm library: https://github.com/YouCanBookMe/react-datetime which doesn't suffer the problems listed above.

**Screenshots/GIFs:**
http://g.recordit.co/KBVS1CNzvz.gif

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10
  - [x] Firefox

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
