### PR TITLE
make the content pane take up the max size

### DIFF
--- a/src/InfoPanel/InfoPanel.less
+++ b/src/InfoPanel/InfoPanel.less
@@ -5,6 +5,8 @@
   .borderRadius--m;
   .border--s(@neutral_silver);
   background-color: @neutral_white;
+  .flexbox();
+  .flexDirection(column);
 
   .InfoPanelColumn {
     display: inline-block;
@@ -37,6 +39,7 @@
 
 .InfoPanel--content {
   padding: @size_m;
+  .flex--auto;
 }
 
 .InfoPanel--footer {


### PR DESCRIPTION
I ran two boxes side by side and the content panel didn't stretch all the way down.

**Screenshots/GIFs:**
Problem:
![screenshot 2018-02-07 19 10 25](https://user-images.githubusercontent.com/13126257/35953683-a142f3de-0c3a-11e8-9e69-23e58ca987db.png)

With my change
![screenshot 2018-02-07 19 11 20](https://user-images.githubusercontent.com/13126257/35953704-c19c0efe-0c3a-11e8-9af3-23f6f728de71.png)

local run for docs:
![screenshot 2018-02-07 19 08 12](https://user-images.githubusercontent.com/13126257/35953685-a81da438-0c3a-11e8-8f38-c436d3fecfcf.png)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
