### PR TITLE
Split DropdownButton sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/DropdownButton/DropdownButton.less
+++ b/src/DropdownButton/DropdownButton.less
@@ -17,8 +17,8 @@
 
 .Button.DropdownButton--toggle {
   .flex(0, 0);
-  // Padding will be re-applied on the child Caret--container element.
   .margin--left--xs;
+  // Padding will be re-applied on the child Caret--container element.
   .padding--x--none;
   box-sizing: content-box;
 }

--- a/src/DropdownButton/DropdownButton.less
+++ b/src/DropdownButton/DropdownButton.less
@@ -12,17 +12,15 @@
 
   &:not(:last-child) {
     .text--left;
-    border-top-right-radius: 0;
-    border-right: 0;
   }
 }
 
 .Button.DropdownButton--toggle {
   .flex(0, 0);
   // Padding will be re-applied on the child Caret--container element.
+  .margin--left--xs;
   .padding--x--none;
   box-sizing: content-box;
-  border-top-left-radius: 0;
 }
 
 .DropdownButton--Caret--container {
@@ -50,20 +48,4 @@
   .DropdownButton--Caret--container {
     .padding--x--l;
   }
-}
-
-/*
- * Similarly, the following adjust the partition border color based on the button color.
- */
-
-.Button--primary.DropdownButton--toggle {
-  .border--left--s(shade(@primary_blue, @shadeStepAmount * 2));
-}
-
-.Button--destructive.DropdownButton--toggle {
-  .border--left--s(shade(@alert_red, @shadeStepAmount * 2));
-}
-
-.Button.DropdownButton--toggle[disabled] {
-  .border--left--s(shade(@neutral_silver, @shadeStepAmount * 2));
 }

--- a/src/DropdownButton/Menu.less
+++ b/src/DropdownButton/Menu.less
@@ -3,6 +3,7 @@
 
 .DropdownButton--Menu {
   .margin--none;
+  .margin--top--xs;
   .padding--none;
   .zIndex--2;
   box-shadow: 0 0 @size_xs rgba(0, 0, 0, .15);
@@ -13,9 +14,14 @@
 .Button.DropdownButton--Option {
   .borderRadius--0;
   .text--left;
-  border-top: 0;
   border-bottom-width: @borderWidthS;
 
+  &not(:first-child) {
+    border-top: 0;
+  }
+  &:first-child {
+    .borderRadius--top--s;
+  }
   &:last-child {
     .borderRadius--bottom--s;
   }
@@ -24,14 +30,14 @@
 // Reset the disabled border styles for the secondary button's left and right borders, so it they
 // match those of the siblings in the menu.
 .Button--secondary.DropdownButton--Option[disabled] {
-  .border--x--s(@primary_blue);
-  .border--bottom--s(@primary_blue);
+  .border--x--s(@primary_blue_tint_2);
+  .border--bottom--s(@primary_blue_tint_2);
 
   &:active,
   &:focus,
   &:hover {
-    .border--x--s(@primary_blue);
-    .border--bottom--s(@primary_blue);
+    .border--x--s(@primary_blue_tint_2);
+    .border--bottom--s(@primary_blue_tint_2);
   }
 }
 

--- a/src/DropdownButton/Menu.less
+++ b/src/DropdownButton/Menu.less
@@ -16,12 +16,14 @@
   .text--left;
   border-bottom-width: @borderWidthS;
 
-  &not(:first-child) {
+  &:not(:first-child) {
     border-top: 0;
   }
+
   &:first-child {
     .borderRadius--top--s;
   }
+
   &:last-child {
     .borderRadius--bottom--s;
   }
@@ -30,14 +32,14 @@
 // Reset the disabled border styles for the secondary button's left and right borders, so it they
 // match those of the siblings in the menu.
 .Button--secondary.DropdownButton--Option[disabled] {
-  .border--x--s(@primary_blue_tint_2);
-  .border--bottom--s(@primary_blue_tint_2);
+  .border--x--s(@primary_blue);
+  .border--bottom--s(@primary_blue);
 
   &:active,
   &:focus,
   &:hover {
-    .border--x--s(@primary_blue_tint_2);
-    .border--bottom--s(@primary_blue_tint_2);
+    .border--x--s(@primary_blue);
+    .border--bottom--s(@primary_blue);
   }
 }
 


### PR DESCRIPTION
**Overview:**
Split up the DropdownButton main button and caret.

**Screenshots/GIFs:**
<img width="1023" alt="screen shot 2018-02-23 at 3 45 10 pm" src="https://user-images.githubusercontent.com/16216084/36622210-dd0f095c-18b0-11e8-9dfe-9a230a794d97.png">

**Testing:**
- [n/a] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [n/a] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
