### PR TITLE
Update react-select, make div transparent

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-linkify": "^0.2.1",
     "react-onclickoutside": "^5.11.1",
     "react-overlays": "^0.7.0",
-    "react-select": "^1.0.0-beta14",
+    "react-select": "^1.2.1",
     "react-sticky": "^6.0.1",
     "short-number": "^1.0.6",
     "tether": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select/Select.less
+++ b/src/Select/Select.less
@@ -122,6 +122,7 @@
 
     .Select-input {
       position: absolute;
+      background-color: transparent;
     }
   }
 


### PR DESCRIPTION
**Overview:**
There's a styling bug that occurs when repos like `sd2` use `react-select@1.2.1`, where a white div appears over text. This PR upgrades the `react-select` dependency to `1.2.1` and then makes that div transparent.  It appears the div does not display anything in our usages of the component, so this is a safe change.

**Screenshots/GIFs:**
Previously:
![screen shot 2018-02-26 at 6 00 29 pm](https://user-images.githubusercontent.com/12655228/36706548-1b0e380c-1b1f-11e8-9e94-e4a1dfc47e57.png)

Now:
![screen shot 2018-02-26 at 6 05 18 pm](https://user-images.githubusercontent.com/12655228/36706638-a17272fa-1b1f-11e8-80c6-0d2610d792d1.png)

**Testing:**
- [x] Local testing

**Roll Out:**
- Before merging:
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
