### PR TITLE
Fix List Item width styling.

### DIFF
--- a/docs/components/Layout.less
+++ b/docs/components/Layout.less
@@ -2,10 +2,6 @@
 @import (reference) "~less/index";
 @import "~less/type-size";
 
-* {
-  box-sizing: border-box;
-}
-
 body {
   .flexbox;
   .text--medium;

--- a/docs/components/TopBar/TopBar.less
+++ b/docs/components/TopBar/TopBar.less
@@ -3,6 +3,7 @@
 
 .TopBar {
   background-color: @primary_blue;
+  box-sizing: border-box;
   color: @neutral_white;
   height: @size_5xl;
   padding: 0 @size_m 0 0;
@@ -10,6 +11,7 @@
 
 .TopBar--homeLink {
   background-color: @primary_blue;
+  box-sizing: border-box;
   height: 100%;
   padding: 0 @size_m @size_3xs;
   transition: background-color .25s ease-out;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.28.7",
+  "version": "0.28.8",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/List/Item.less
+++ b/src/List/Item.less
@@ -10,6 +10,7 @@
 .List--Item--ContentWrapper {
   // Match the Table component's cell styling.
   .Table--cell();
+  box-sizing: border-box;
   width: 100%;
 }
 


### PR DESCRIPTION
**Jira:** N/A

**Overview:**
Recent change added 100% width to the list item contents, which extends it past its parent bounds.

Issue wasn't visible in Dewey because there was a top-level `box-sizing: border-box` applied to all elements in Dewey. Took that out so that components build in Dewey don't make assumptions about the base styling clients are using.


**Screenshots/GIFs:**

**Before:**
<img width="334" alt="screen shot 2018-03-01 at 9 06 15 am" src="https://user-images.githubusercontent.com/16216084/36858398-ecd21e0a-1d2f-11e8-8a1b-eb8e9dacdfe2.png">

**After:**
<img width="330" alt="screen shot 2018-03-01 at 9 06 40 am" src="https://user-images.githubusercontent.com/16216084/36858411-f28de752-1d2f-11e8-8cba-f0935c231e7c.png">

**Testing:**
- [n/a] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
