### PR TITLE
Added function type to Wizard Step

### DIFF
--- a/docs/components/WizardView.jsx
+++ b/docs/components/WizardView.jsx
@@ -198,6 +198,14 @@ export default class WizardView extends PureComponent {
               + "backwards/fowards through the wizard.",
               optional: true,
             },
+            {
+              name: "nextButtonValue",
+              type: "String, React Node, or Function",
+              description: "Text to display on next buttons in form. Function can be used to dynamically change "
+              + "the button text based on wizardstate",
+              defaultValue: "Next",
+              optional: true,
+            },
           ]}
           className={cssClass.PROPS}
           title="step"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.28.6",
+  "version": "0.28.7",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -226,7 +226,6 @@ export class Wizard extends React.Component {
             help={curStep.help ? curStep.help : help}
             validate={curStep.validate}
             prevButtonValue={curStep.prevButtonValue}
-            nextButtonValue={curStep.nextButtonValue}
           />
 
           <div
@@ -247,7 +246,12 @@ export class Wizard extends React.Component {
               className={classNameFor(baseClasses, "nextButton")}
               onClick={this.nextStepHandler}
               disabled={nextDisabled} type="primary"
-              value={curStep.nextButtonValue || nextButtonValue || "Next"}
+              value={
+                typeof curStep.nextButtonValue === "function" ?
+                curStep.nextButtonValue(this.state.data) : curStep.nextButtonValue ||
+                nextButtonValue ||
+                "Next"
+              }
             />
           </div>
         </div>
@@ -276,6 +280,7 @@ Wizard.propTypes = {
       PropTypes.func,
       PropTypes.instanceOf(React.Component),
     ]).isRequired,
+    nextButtonValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.func]),
     validate: PropTypes.func.isRequired,
     canContinue: PropTypes.func,
     help: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -225,7 +225,6 @@ export class Wizard extends React.Component {
             currentStep={this.state.currentStep}
             help={curStep.help ? curStep.help : help}
             validate={curStep.validate}
-            prevButtonValue={curStep.prevButtonValue}
           />
 
           <div

--- a/src/Wizard/WizardStep.jsx
+++ b/src/Wizard/WizardStep.jsx
@@ -116,7 +116,6 @@ WizardStep.propTypes = {
   help: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   Component: PropTypes.oneOfType([PropTypes.func, PropTypes.instanceOf(React.Component)]).isRequired,
   componentProps: PropTypes.object,
-  nextButtonValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   prevButtonValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   // internal facing

--- a/src/Wizard/WizardStep.jsx
+++ b/src/Wizard/WizardStep.jsx
@@ -116,7 +116,6 @@ WizardStep.propTypes = {
   help: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   Component: PropTypes.oneOfType([PropTypes.func, PropTypes.instanceOf(React.Component)]).isRequired,
   componentProps: PropTypes.object,
-  prevButtonValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   // internal facing
   className: PropTypes.string,


### PR DESCRIPTION
**Overview:**
This PR changes the `nextButtonValue` of the `WizardStep` to be able to accept a function as well as the already accepted node and string. The reasoning behind this is to allow for dynamically changing button values based on the `wizardState` which can only be accessed from within the wizard.

I also removed `nextButtonValue` from the `WizardStep` file because we're generating the buttons in the actual wizard instead.

**Screenshots/GIFs:**
Note how in Step 3 the `Next` button changes to `Save and exit`
![badgewizard](https://user-images.githubusercontent.com/3518597/37367669-52c6641a-26c1-11e8-95e0-b45abb8fc42c.gif)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
