### PR TITLE
Add auto-generator for color variables and output both LESS and JS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ TESTS_JS := $(shell find . -regex ".*_test\.jsx*" -not -path "./node_modules/*")
 TESTS_TS := $(shell find . -regex ".*_test\.tsx*" -not -path "./node_modules/*" -not -path "./bin/*")
 WEBPACK := node_modules/webpack/bin/webpack.js
 
-.PHONY: dev-server test lint clean es5 docs build new $(TESTS) styles sizing-styles border-styles
-.PHONY: border-radius-styles deploy-docs generate
+.PHONY: dev-server test lint clean es5 docs build new $(TESTS) styles gen-sizing-styles
+.PHONY: gen-border-styles gen-border-radius-styles deploy-docs generate gen-colors
 
 GREEN_CHECK_MARK := " \033[0;32m✓\033[0m"
 clean:
@@ -52,17 +52,21 @@ styles:
 	@echo "Building stylesheet"
 	@$(WEBPACK) --config webpack_styles.config.js
 
-generate: sizing-styles border-styles border-radius-styles
+generate: gen-sizing-styles gen-border-styles gen-border-radius-styles gen-colors
 
-sizing-styles:
+gen-colors:
+	@echo "Generating color definitions..."
+	@./node_modules/.bin/ts-node --project ./tsconfig.json genColors.ts
+
+gen-sizing-styles:
 	@echo "Generating sizing style definitions..."
 	@node genSizing.js
 
-border-styles:
+gen-border-styles:
 	@echo "Generating border style definitions..."
 	@node genBorder.js
 
-border-radius-styles:
+gen-border-radius-styles:
 	@echo "Generating border-radius style definitions..."
 	@node genBorderRadius.js
 

--- a/docs/components/ColorsView.jsx
+++ b/docs/components/ColorsView.jsx
@@ -1,5 +1,6 @@
 import React, {PureComponent} from "react";
 
+import Colors from "src/utils/Colors";
 import Example from "./Example";
 import View from "./View";
 import {Grid} from "src";
@@ -59,7 +60,7 @@ export default class ColorsView extends PureComponent {
               <div>
                 <h2>Neutral Colors</h2>
                 <p>
-                  To support the Clever Blue, these neutral colors have been chosen to add contrast and heirarchy
+                  To support the Clever Blue, these neutral colors have been chosen to add contrast and hierarchy
                   for borders, backgrounds, and text styles.
                 </p>
               </div>
@@ -104,7 +105,7 @@ export default class ColorsView extends PureComponent {
               <div>
                 <h2>Alert Colors</h2>
                 <p>
-                  To support the Clever Blue, these neutral colors have been chosen to add contrast and heirarchy
+                  To support the Clever Blue, these neutral colors have been chosen to add contrast and hierarchy
                   for borders, backgrounds, and text styles.
                 </p>
               </div>
@@ -201,7 +202,7 @@ export default class ColorsView extends PureComponent {
               <div>
                 <h2>Accent Colors</h2>
                 <p>
-                  To support the Clever Blue, these neutral colors have been chosen to add contrast and heirarchy
+                  To support the Clever Blue, these neutral colors have been chosen to add contrast and hierarchy
                   for borders, backgrounds, and text styles.
                 </p>
               </div>
@@ -311,15 +312,16 @@ export default class ColorsView extends PureComponent {
             </Col>
             <Col span={4} className="flexbox">
               <Example
-                title="Example"
+                title="LESS Example"
                 code={`
                   <span className="callout--box">This is a blue bordered box.</span>
-                  
+
                   <style>
                     .callout--box {
                       border: @size_3xs solid @primary_blue_tint_2;
                       background-color: @neutral_off_white;
                       height: 3rem;
+
                       &:hover {
                         border-color: @primary_blue_shade_2;
                       }
@@ -328,6 +330,45 @@ export default class ColorsView extends PureComponent {
                 `}
               >
                 <span className="callout--box">This is a blue bordered box.</span>
+              </Example>
+            </Col>
+          </Row>
+          <Row grow className="margin--bottom--5xl padding--right--m">
+            <Col span={6} className="flexbox self--start padding--right--l">
+              <div>
+                <h2>JS Color Variables</h2>
+                <p>
+                  In some cases, you may need to specify colors in JS. e.g. When using a third-party
+                  library that doesn't enable styling via CSS.
+                </p>
+                <p>
+                  There are pre-defined JS color variables available for this reason:
+                </p>
+                <code>import Colors from "clever-components/dist/utils/Colors";</code>
+              </div>
+            </Col>
+            <Col span={4} className="flexbox">
+              <Example
+                title="JS Example"
+                code={`
+                  import Colors from "clever-components/dist/utils/Colors";
+                  import Circle from "third-party-library";
+
+                  <Circle
+                    borderColor={Colors.NEUTRAL_GRAY}
+                    fillColor={Colors.NEUTRAL_SILVER}
+                  />
+                `}
+              >
+                <svg viewBox="0 0 20 12">
+                  <circle
+                    cx={10}
+                    cy={6}
+                    r={5}
+                    fill={Colors.NEUTRAL_SILVER}
+                    stroke={Colors.NEUTRAL_GRAY}
+                  />
+                </svg>
               </Example>
             </Col>
           </Row>

--- a/genColors.ts
+++ b/genColors.ts
@@ -1,0 +1,137 @@
+import * as fs from "fs";
+
+const FILENAME_JS = "src/utils/Colors.ts";
+const FILENAME_LESS = "src/less/colors.less";
+
+const FILE_HEADER =
+`/**
+ * ====  NOTE: Auto-generated file. Do NOT edit directly! ====
+ * ====  Edit genColors.ts instead and run make generate. ====
+ *
+ * Standard color variables.
+ */`;
+
+const Colors = {
+  // Primary colors:
+  Primary: {
+    PRIMARY_BLUE: "#2e00d9",
+    PRIMARY_BLUE_SHADE_1: "#0500b0",
+    PRIMARY_BLUE_SHADE_2: "#000087",
+    PRIMARY_BLUE_TINT_1: "#3e14fa",
+    PRIMARY_BLUE_TINT_2: "#473dff",
+  },
+
+  // Neutral colors:
+  Neutral: {
+    NEUTRAL_BLACK: "#15131c",
+    NEUTRAL_DARK_GRAY: "#474c5e",
+    NEUTRAL_GRAY: "#71738a",
+    NEUTRAL_SILVER: "#d6d7de",
+    NEUTRAL_OFF_WHITE: "#fbfafc",
+    NEUTRAL_WHITE: "#ffffff",
+  },
+
+  // Alert colors:
+  Alert: {
+    ALERT_GREEN: "#009e78",
+    ALERT_GREEN_SHADE_1: "#00754f",
+    ALERT_GREEN_SHADE_2: "#004c26",
+    ALERT_GREEN_TINT_1: "#14b28c",
+    ALERT_GREEN_TINT_2: "#3ddbb5",
+
+    ALERT_ORANGE: "#ed8a00",
+    ALERT_ORANGE_SHADE_1: "#d97600",
+    ALERT_ORANGE_SHADE_2: "#b04d00",
+    ALERT_ORANGE_TINT_1: "#ff9e14",
+    ALERT_ORANGE_TINT_2: "#ffc73d",
+
+    ALERT_RED: "#de004b",
+    ALERT_RED_SHADE_1: "#ca0037",
+    ALERT_RED_SHADE_2: "#a1000e",
+    ALERT_RED_TINT_1: "#f51152",
+    ALERT_RED_TINT_2: "#ff4268",
+  },
+
+  // Secondary colors:
+  Accent: {
+    ACCENT_TEAL: "#00c7c7",
+    ACCENT_TEAL_SHADE_1: "#00b3b3",
+    ACCENT_TEAL_SHADE_2: "#008a8a",
+    ACCENT_TEAL_TINT_1: "#14dbdb",
+    ACCENT_TEAL_TINT_2: "#29f0f0",
+
+    ACCENT_PINK: "#f70099",
+    ACCENT_PINK_SHADE_1: "#e30085",
+    ACCENT_PINK_SHADE_2: "#ba005c",
+    ACCENT_PINK_TINT_1: "#ff29ae",
+    ACCENT_PINK_TINT_2: "#ff52ce",
+
+    ACCENT_PURPLE: "#8000ff",
+    ACCENT_PURPLE_SHADE_1: "#6c00eb",
+    ACCENT_PURPLE_SHADE_2: "#4e00c2",
+    ACCENT_PURPLE_TINT_1: "#9414ff",
+    ACCENT_PURPLE_TINT_2: "#bd3dff",
+  },
+};
+
+const DeprecatedColors = {
+  ACCENT_AQUA: Colors.Accent.ACCENT_TEAL,
+};
+
+const jsColors = [];
+const lessColors = [];
+
+Object.keys(Colors).forEach(category => {
+  jsColors.push(`  // ${category} colors:`);
+  lessColors.push(`// ${category} colors:`);
+
+  Object.keys(Colors[category]).forEach(colorName => {
+    const colorValue = Colors[category][colorName];
+    jsColors.push(`  ${colorName}: "${colorValue}",`);
+    lessColors.push(`@${colorName.toLowerCase()}: ${colorValue};`);
+  });
+
+  jsColors.push("");
+  lessColors.push("");
+});
+
+jsColors.push("  // DEPRECATED COLORS:");
+lessColors.push("// DEPRECATED COLORS:");
+
+Object.keys(DeprecatedColors).forEach(colorName => {
+  const colorValue = DeprecatedColors[colorName];
+  jsColors.push(`  ${colorName}: "${colorValue}",`);
+  lessColors.push(`@${colorName.toLowerCase()}: ${colorValue};`);
+});
+
+const jsContents = [
+  FILE_HEADER,
+  "",
+  "const Colors = {",
+  ...jsColors,
+  "};",
+  "",
+  "export default Colors;",
+  "",
+];
+fs.writeFileSync(`${FILENAME_JS}`, jsContents.join("\n"));
+
+const DEPRECATED_LESS_HELPERS =
+`// DEPRECATED: Use pre-defined tints and shades above instead.
+@shadeStepAmount: 15%;
+.shade(@property, @color, @steps: 1) {
+  @{property}: shade(@color, @shadeStepAmount * @steps);
+}
+.tint(@property, @color, @steps: 1) {
+  @{property}: tint(@color, @shadeStepAmount * @steps);
+}`;
+
+const lessContents = [
+  FILE_HEADER,
+  "",
+  ...lessColors,
+  "",
+  DEPRECATED_LESS_HELPERS,
+  "",
+];
+fs.writeFileSync(`${FILENAME_LESS}`, lessContents.join("\n"));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/less/colors.less
+++ b/src/less/colors.less
@@ -1,3 +1,10 @@
+/**
+ * ====  NOTE: Auto-generated file. Do NOT edit directly! ====
+ * ====  Edit genColors.ts instead and run make generate. ====
+ *
+ * Standard color variables.
+ */
+
 // Primary colors:
 @primary_blue: #2e00d9;
 @primary_blue_shade_1: #0500b0;
@@ -19,41 +26,38 @@
 @alert_green_shade_2: #004c26;
 @alert_green_tint_1: #14b28c;
 @alert_green_tint_2: #3ddbb5;
-
 @alert_orange: #ed8a00;
 @alert_orange_shade_1: #d97600;
 @alert_orange_shade_2: #b04d00;
 @alert_orange_tint_1: #ff9e14;
 @alert_orange_tint_2: #ffc73d;
-
 @alert_red: #de004b;
 @alert_red_shade_1: #ca0037;
 @alert_red_shade_2: #a1000e;
 @alert_red_tint_1: #f51152;
 @alert_red_tint_2: #ff4268;
 
-// Secondary colors:
+// Accent colors:
 @accent_teal: #00c7c7;
 @accent_teal_shade_1: #00b3b3;
 @accent_teal_shade_2: #008a8a;
 @accent_teal_tint_1: #14dbdb;
 @accent_teal_tint_2: #29f0f0;
-
-@accent_aqua: @accent_teal; // to do: deprecate
-
 @accent_pink: #f70099;
 @accent_pink_shade_1: #e30085;
 @accent_pink_shade_2: #ba005c;
 @accent_pink_tint_1: #ff29ae;
 @accent_pink_tint_2: #ff52ce;
-
 @accent_purple: #8000ff;
 @accent_purple_shade_1: #6c00eb;
 @accent_purple_shade_2: #4e00c2;
 @accent_purple_tint_1: #9414ff;
 @accent_purple_tint_2: #bd3dff;
 
-// to do: deprecate
+// DEPRECATED COLORS:
+@accent_aqua: #00c7c7;
+
+// DEPRECATED: Use pre-defined tints and shades above instead.
 @shadeStepAmount: 15%;
 .shade(@property, @color, @steps: 1) {
   @{property}: shade(@color, @shadeStepAmount * @steps);

--- a/src/utils/Colors.ts
+++ b/src/utils/Colors.ts
@@ -1,0 +1,62 @@
+/**
+ * ====  NOTE: Auto-generated file. Do NOT edit directly! ====
+ * ====  Edit genColors.ts instead and run make generate. ====
+ *
+ * Standard color variables.
+ */
+
+const Colors = {
+  // Primary colors:
+  PRIMARY_BLUE: "#2e00d9",
+  PRIMARY_BLUE_SHADE_1: "#0500b0",
+  PRIMARY_BLUE_SHADE_2: "#000087",
+  PRIMARY_BLUE_TINT_1: "#3e14fa",
+  PRIMARY_BLUE_TINT_2: "#473dff",
+
+  // Neutral colors:
+  NEUTRAL_BLACK: "#15131c",
+  NEUTRAL_DARK_GRAY: "#474c5e",
+  NEUTRAL_GRAY: "#71738a",
+  NEUTRAL_SILVER: "#d6d7de",
+  NEUTRAL_OFF_WHITE: "#fbfafc",
+  NEUTRAL_WHITE: "#ffffff",
+
+  // Alert colors:
+  ALERT_GREEN: "#009e78",
+  ALERT_GREEN_SHADE_1: "#00754f",
+  ALERT_GREEN_SHADE_2: "#004c26",
+  ALERT_GREEN_TINT_1: "#14b28c",
+  ALERT_GREEN_TINT_2: "#3ddbb5",
+  ALERT_ORANGE: "#ed8a00",
+  ALERT_ORANGE_SHADE_1: "#d97600",
+  ALERT_ORANGE_SHADE_2: "#b04d00",
+  ALERT_ORANGE_TINT_1: "#ff9e14",
+  ALERT_ORANGE_TINT_2: "#ffc73d",
+  ALERT_RED: "#de004b",
+  ALERT_RED_SHADE_1: "#ca0037",
+  ALERT_RED_SHADE_2: "#a1000e",
+  ALERT_RED_TINT_1: "#f51152",
+  ALERT_RED_TINT_2: "#ff4268",
+
+  // Accent colors:
+  ACCENT_TEAL: "#00c7c7",
+  ACCENT_TEAL_SHADE_1: "#00b3b3",
+  ACCENT_TEAL_SHADE_2: "#008a8a",
+  ACCENT_TEAL_TINT_1: "#14dbdb",
+  ACCENT_TEAL_TINT_2: "#29f0f0",
+  ACCENT_PINK: "#f70099",
+  ACCENT_PINK_SHADE_1: "#e30085",
+  ACCENT_PINK_SHADE_2: "#ba005c",
+  ACCENT_PINK_TINT_1: "#ff29ae",
+  ACCENT_PINK_TINT_2: "#ff52ce",
+  ACCENT_PURPLE: "#8000ff",
+  ACCENT_PURPLE_SHADE_1: "#6c00eb",
+  ACCENT_PURPLE_SHADE_2: "#4e00c2",
+  ACCENT_PURPLE_TINT_1: "#9414ff",
+  ACCENT_PURPLE_TINT_2: "#bd3dff",
+
+  // DEPRECATED COLORS:
+  ACCENT_AQUA: "#00c7c7",
+};
+
+export default Colors;


### PR DESCRIPTION
**Jira:** N/A

**Overview:**
Adding a script for generating both LESS and JS color variable exports to enable consistent color usage across JS code and stylesheets.

**Screenshots/GIFs:**
![screen shot 2018-03-22 at 12 16 03 pm](https://user-images.githubusercontent.com/16216084/37793072-d8f63f14-2dca-11e8-97ec-729bec02fcf6.png)

**Testing:**
- [n/a] Unit tests
- Manual tests:
  - [n/a] Chrome
  - [n/a] Safari
  - [n/a] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
