### PR TITLE
import propTypes from prop-types package

### DIFF
--- a/docs/WizardExample.jsx
+++ b/docs/WizardExample.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-multi-comp, no-alert */
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import {Button, Wizard, TextInput} from "../src/";
 

--- a/docs/components/Example/CodeSample.jsx
+++ b/docs/components/Example/CodeSample.jsx
@@ -1,6 +1,7 @@
 import classnames from "classnames";
 import Prism from "prismjs";
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import * as PropTypes from "prop-types";
 import "prismjs/components/prism-jsx";
 import "prismjs/components/prism-less";
 

--- a/docs/components/Example/Demo.jsx
+++ b/docs/components/Example/Demo.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import "./Demo.less";
 

--- a/docs/components/Example/Example.jsx
+++ b/docs/components/Example/Example.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import CodeSample from "./CodeSample";
 import Demo from "./Demo";

--- a/docs/components/Example/ExampleCode.jsx
+++ b/docs/components/Example/ExampleCode.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 
 /**

--- a/docs/components/Layout.jsx
+++ b/docs/components/Layout.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import SideBar from "./SideBar";
 import TopBar from "./TopBar";

--- a/docs/components/PropDocumentation.jsx
+++ b/docs/components/PropDocumentation.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes, PureComponent} from "react";
+import React, {PureComponent} from "react";
+import * as PropTypes from "prop-types";
 
 import {Table} from "src";
 

--- a/docs/components/SideBar/SideBar.jsx
+++ b/docs/components/SideBar/SideBar.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 import {Link as ReactRouterLink, routerShape} from "react-router";
 
 import {Icon, LeftNav} from "../../../src";

--- a/docs/components/TopBar/Logo.jsx
+++ b/docs/components/TopBar/Logo.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 
 export default function Logo({className}) {

--- a/docs/components/TopBar/TopBar.jsx
+++ b/docs/components/TopBar/TopBar.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import {FlexBox, FlexItem, ItemAlign} from "../../../src";
 import Logo from "./Logo";

--- a/docs/components/View.jsx
+++ b/docs/components/View.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import * as PropTypes from "prop-types";
 
 import {Button} from "src";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AlertBox/AlertBox.jsx
+++ b/src/AlertBox/AlertBox.jsx
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import classnames from "classnames";
-import React, {PureComponent, PropTypes} from "react";
+import React, {PureComponent} from "react";
+import * as PropTypes from "prop-types";
 
 import {CloseIcon, WarningIcon, SuccessIcon, ErrorIcon, InfoIcon} from "./icons";
 import {FlexBox, FlexItem, ItemAlign} from "../flex";

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import classnames from "classnames";
 import React from "react";
+import * as PropTypes from "prop-types";
 
 import "./Button.less";
 
@@ -103,14 +104,14 @@ Button.defaultProps = {
 };
 
 Button.propTypes = {
-  className: React.PropTypes.string,
-  type: React.PropTypes.oneOf(_.values(Button.Type)),
-  size: React.PropTypes.oneOf(_.values(Button.Size)),
-  value: React.PropTypes.node.isRequired,
-  href: React.PropTypes.string,
-  target: React.PropTypes.oneOf(["_self", "_blank"]),
-  disabled: React.PropTypes.bool,
-  onClick: React.PropTypes.func,
-  submit: React.PropTypes.bool,
-  style: React.PropTypes.object,
+  className: PropTypes.string,
+  type: PropTypes.oneOf(_.values(Button.Type)),
+  size: PropTypes.oneOf(_.values(Button.Size)),
+  value: PropTypes.node.isRequired,
+  href: PropTypes.string,
+  target: PropTypes.oneOf(["_self", "_blank"]),
+  disabled: PropTypes.bool,
+  onClick: PropTypes.func,
+  submit: PropTypes.bool,
+  style: PropTypes.object,
 };

--- a/src/ConfirmationButton/ConfirmationButton.jsx
+++ b/src/ConfirmationButton/ConfirmationButton.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 import classnames from "classnames";
 
 import {Button, ModalButton} from "..";

--- a/src/CopyableInput/CopyableInput.jsx
+++ b/src/CopyableInput/CopyableInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import * as PropTypes from "prop-types";
 import classnames from "classnames";
 import CopyToClipboard from "react-copy-to-clipboard";
 
@@ -64,8 +65,8 @@ export class CopyableInput extends React.Component {
 CopyableInput.propTypes = Object.assign({},
   TextInput.propTypes,
   {
-    className: React.PropTypes.string,
-    enableCopy: React.PropTypes.bool,
+    className: PropTypes.string,
+    enableCopy: PropTypes.bool,
   }
 );
 

--- a/src/Count/Count.jsx
+++ b/src/Count/Count.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes, PureComponent} from "react";
+import React, {PureComponent} from "react";
+import * as PropTypes from "prop-types";
 
 import Number from "../Number";
 

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -1,5 +1,6 @@
 import moment from "moment";
 import React from "react";
+import * as PropTypes from "prop-types";
 import classnames from "classnames";
 import ReactDatePicker from "../../vendor/react-datepicker/dist/react-datepicker.min.js";
 import ReactDateTime from "react-datetime";
@@ -107,26 +108,26 @@ export default class DateInput extends React.Component {
   }
 }
 
-const dateType = React.PropTypes.oneOfType([
-  React.PropTypes.instanceOf(Date),
-  React.PropTypes.instanceOf(moment),
+const dateType = PropTypes.oneOfType([
+  PropTypes.instanceOf(Date),
+  PropTypes.instanceOf(moment),
 ]);
 
 DateInput.propTypes = {
-  disabled: React.PropTypes.bool,
-  error: React.PropTypes.string,
-  label: React.PropTypes.string,
-  name: React.PropTypes.string.isRequired,
-  onChange: React.PropTypes.func,
-  onFocus: React.PropTypes.func,
-  onBlur: React.PropTypes.func,
-  placeholder: React.PropTypes.node,
-  readOnly: React.PropTypes.bool,
-  required: React.PropTypes.bool,
-  type: React.PropTypes.string,
+  disabled: PropTypes.bool,
+  error: PropTypes.string,
+  label: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  placeholder: PropTypes.node,
+  readOnly: PropTypes.bool,
+  required: PropTypes.bool,
+  type: PropTypes.string,
   value: dateType,
-  className: React.PropTypes.string,
+  className: PropTypes.string,
   min: dateType,
   max: dateType,
-  useTime: React.PropTypes.bool,
+  useTime: PropTypes.bool,
 };

--- a/src/DatePicker/DatePicker.jsx
+++ b/src/DatePicker/DatePicker.jsx
@@ -1,7 +1,8 @@
 import moment from "moment";
 import classnames from "classnames";
-import React, {PropTypes} from "react";
 import ReactDatePicker from "../../vendor/react-datepicker/dist/react-datepicker.min.js";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import "./DatePicker.less";
 

--- a/src/DollarAmount/DollarAmount.jsx
+++ b/src/DollarAmount/DollarAmount.jsx
@@ -1,6 +1,7 @@
 import classnames from "classnames";
 import numeral from "numeral";
-import React, {PropTypes, PureComponent} from "react";
+import React, {PureComponent} from "react";
+import * as PropTypes from "prop-types";
 
 
 /**

--- a/src/DropdownButton/DropdownButton.jsx
+++ b/src/DropdownButton/DropdownButton.jsx
@@ -2,7 +2,8 @@ import _ from "lodash";
 import classnames from "classnames";
 import MorePropTypes from "../utils/MorePropTypes";
 import Overlay from "react-bootstrap/lib/Overlay";
-import React, {PropTypes, PureComponent} from "react";
+import React, {PureComponent} from "react";
+import * as PropTypes from "prop-types";
 
 import FlexBox from "../flex/FlexBox";
 import FlexItem from "../flex/FlexItem";

--- a/src/DropdownButton/Menu.jsx
+++ b/src/DropdownButton/Menu.jsx
@@ -1,7 +1,8 @@
 import _ from "lodash";
 import classnames from "classnames";
 import MorePropTypes from "../utils/MorePropTypes";
-import React, {PropTypes, PureComponent} from "react";
+import React, {PureComponent} from "react";
+import * as PropTypes from "prop-types";
 
 import {Button} from "../Button/Button";
 import FlexBox from "../flex/FlexBox";

--- a/src/DropdownButton/Option.jsx
+++ b/src/DropdownButton/Option.jsx
@@ -1,4 +1,5 @@
-import {PropTypes, PureComponent} from "react";
+import {PureComponent} from "react";
+import * as PropTypes from "prop-types";
 
 
 export default class Option extends PureComponent {

--- a/src/FileInput/FileInput.jsx
+++ b/src/FileInput/FileInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import * as PropTypes from "prop-types";
 import Dropzone from "react-dropzone";
 import {FlexBox, FlexItem} from "../flex";
 import classnames from "classnames";
@@ -50,7 +51,7 @@ function UploadingIcon(props) {
 }
 
 UploadingIcon.propTypes = {
-  percent: React.PropTypes.number.isRequired,
+  percent: PropTypes.number.isRequired,
 };
 
 export class FileInput extends React.Component {
@@ -133,8 +134,8 @@ export class FileInput extends React.Component {
 }
 
 FileInput.propTypes = {
-  className: React.PropTypes.string,
-  label: React.PropTypes.string.isRequired,
-  store: React.PropTypes.func.isRequired,
-  accept: React.PropTypes.string,
+  className: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  store: PropTypes.func.isRequired,
+  accept: PropTypes.string,
 };

--- a/src/Grid/Col.jsx
+++ b/src/Grid/Col.jsx
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import Size from "./Size";
 

--- a/src/Grid/Grid.jsx
+++ b/src/Grid/Grid.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import Col from "./Col";
 import MorePropTypes from "../utils/MorePropTypes";

--- a/src/Grid/Row.jsx
+++ b/src/Grid/Row.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import * as PropTypes from "prop-types";
+import React from "react";
 
 import Col from "./Col";
 import MorePropTypes from "../utils/MorePropTypes";

--- a/src/Icon/Icon.jsx
+++ b/src/Icon/Icon.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import * as PropTypes from "prop-types";
 import classnames from "classnames";
 import lodash from "lodash";
 
@@ -104,9 +105,9 @@ Icon.defaultProps = {
 };
 
 Icon.propTypes = {
-  name: React.PropTypes.oneOf(lodash.values(Icon.names)).isRequired,
-  size: React.PropTypes.oneOf(lodash.values(Icon.sizes)),
-  className: React.PropTypes.string,
+  name: PropTypes.oneOf(lodash.values(Icon.names)).isRequired,
+  size: PropTypes.oneOf(lodash.values(Icon.sizes)),
+  className: PropTypes.string,
 };
 
 Icon.cssClass = {

--- a/src/InfoPanel/InfoPanel.jsx
+++ b/src/InfoPanel/InfoPanel.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import * as PropTypes from "prop-types";
 import FontAwesome from "react-fontawesome";
 import {Accordion, AccordionItem, AccordionItemTitle, AccordionItemBody} from "react-accessible-accordion";
 import "./InfoPanel.less";

--- a/src/InfoPanel/InfoPanelColumn.jsx
+++ b/src/InfoPanel/InfoPanelColumn.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 
 export default function InfoPanelColumn({children, className}) {

--- a/src/Label/Label.jsx
+++ b/src/Label/Label.jsx
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import classnames from "classnames";
-import React, {PropTypes, PureComponent} from "react";
+import React, {PureComponent} from "react";
+import * as PropTypes from "prop-types";
 
 import Tooltip from "../Tooltip";
 

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import * as PropTypes from "prop-types";
 import classnames from "classnames";
 import FocusTrap from "focus-trap-react";
 
@@ -69,12 +70,12 @@ export class Modal extends React.Component {
 }
 
 Modal.propTypes = {
-  className: React.PropTypes.string,
-  width: React.PropTypes.number,
-  title: React.PropTypes.string.isRequired,
-  closeModal: React.PropTypes.func.isRequired,
-  children: React.PropTypes.node.isRequired,
-  focusLocked: React.PropTypes.bool,
+  className: PropTypes.string,
+  width: PropTypes.number,
+  title: PropTypes.string.isRequired,
+  closeModal: PropTypes.func.isRequired,
+  children: PropTypes.node.isRequired,
+  focusLocked: PropTypes.bool,
 };
 
 Modal.defaultProps = {

--- a/src/ModalButton/ModalButton.jsx
+++ b/src/ModalButton/ModalButton.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import * as PropTypes from "prop-types";
 import classnames from "classnames";
 
 import {Button, Modal} from "..";
@@ -53,7 +54,7 @@ ModalButton.propTypes = Object.assign({},
   modalPropTypes,
   {
     children: Modal.propTypes.children,
-    onClose: React.PropTypes.func, // not required; just closes modal otherwise
+    onClose: PropTypes.func, // not required; just closes modal otherwise
   }
 );
 

--- a/src/Number/Number.jsx
+++ b/src/Number/Number.jsx
@@ -1,6 +1,7 @@
 import classnames from "classnames";
 import numeral from "numeral";
-import React, {PropTypes, PureComponent} from "react";
+import React, {PureComponent} from "react";
+import * as PropTypes from "prop-types";
 import shortNumber from "short-number";
 
 

--- a/src/ProgressBar/ProgressBar.jsx
+++ b/src/ProgressBar/ProgressBar.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 import classnames from "classnames";
 import _ from "lodash";
 

--- a/src/RichText/RichText.jsx
+++ b/src/RichText/RichText.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import * as PropTypes from "prop-types";
 import Linkify from "react-linkify";
 
 export default function RichText(props) {
@@ -8,5 +9,5 @@ export default function RichText(props) {
 }
 
 RichText.propTypes = {
-  text: React.PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
 };

--- a/src/SegmentedControl/SegmentedControl.jsx
+++ b/src/SegmentedControl/SegmentedControl.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 import lodash from "lodash";
 
 import "./SegmentedControl.less";

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import * as PropTypes from "prop-types";
 import ReactSelect from "react-select";
 import classnames from "classnames";
 
@@ -125,37 +126,37 @@ Select.cssClass = {
   READ_ONLY: "Select--readOnly",
 };
 
-const selectValuePropType = React.PropTypes.shape({
-  label: React.PropTypes.string.isRequired,
-  value: React.PropTypes.string.isRequired,
+const selectValuePropType = PropTypes.shape({
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
 });
 
 Select.propTypes = {
-  id: React.PropTypes.string.isRequired,
-  name: React.PropTypes.string.isRequired,
-  clearable: React.PropTypes.bool,
-  disabled: React.PropTypes.bool,
-  label: React.PropTypes.string,
-  multi: React.PropTypes.bool,
-  onChange: React.PropTypes.func,
-  optionRenderer: React.PropTypes.func,
-  options: React.PropTypes.arrayOf(selectValuePropType),
-  lazy: React.PropTypes.bool,
-  loadOptions: React.PropTypes.func,
-  placeholder: React.PropTypes.string,
-  readOnly: React.PropTypes.bool,
-  searchable: React.PropTypes.bool,
-  creatable: React.PropTypes.bool,
-  creatablePromptFn: React.PropTypes.func,
-  noResultsText: React.PropTypes.node,
-  required: React.PropTypes.bool,
-  value: React.PropTypes.oneOfType([
-    React.PropTypes.string,
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  clearable: PropTypes.bool,
+  disabled: PropTypes.bool,
+  label: PropTypes.string,
+  multi: PropTypes.bool,
+  onChange: PropTypes.func,
+  optionRenderer: PropTypes.func,
+  options: PropTypes.arrayOf(selectValuePropType),
+  lazy: PropTypes.bool,
+  loadOptions: PropTypes.func,
+  placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
+  searchable: PropTypes.bool,
+  creatable: PropTypes.bool,
+  creatablePromptFn: PropTypes.func,
+  noResultsText: PropTypes.node,
+  required: PropTypes.bool,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
     selectValuePropType,
-    React.PropTypes.arrayOf(React.PropTypes.string),
-    React.PropTypes.arrayOf(selectValuePropType),
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(selectValuePropType),
   ]),
-  className: React.PropTypes.string,
+  className: PropTypes.string,
 };
 
 Select.defaultProps = {

--- a/src/TabBar/Tab.jsx
+++ b/src/TabBar/Tab.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import "./Tab.less";
 

--- a/src/TabBar/TabBar.jsx
+++ b/src/TabBar/TabBar.jsx
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import MorePropTypes from "../utils/MorePropTypes";
 import Tab from "./Tab";

--- a/src/Table/Cell.jsx
+++ b/src/Table/Cell.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 require("./Cell.less");
 

--- a/src/Table/Column.jsx
+++ b/src/Table/Column.jsx
@@ -1,4 +1,4 @@
-import {PropTypes} from "react";
+import * as PropTypes from "prop-types";
 
 
 export default function Column() {

--- a/src/Table/Footer.jsx
+++ b/src/Table/Footer.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import * as tablePropTypes from "./tablePropTypes";
 import Cell from "./Cell";

--- a/src/Table/Header.jsx
+++ b/src/Table/Header.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import * as tablePropTypes from "./tablePropTypes";
 import Column from "./Column";

--- a/src/Table/HeaderCell.jsx
+++ b/src/Table/HeaderCell.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import * as tablePropTypes from "./tablePropTypes";
 import Cell from "./Cell";

--- a/src/Table/SortIcons.jsx
+++ b/src/Table/SortIcons.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import * as tablePropTypes from "./tablePropTypes";
 import sortDirection from "./sortDirection";

--- a/src/Table/Table.jsx
+++ b/src/Table/Table.jsx
@@ -1,6 +1,7 @@
 import classnames from "classnames";
 import lodash from "lodash";
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import * as PropTypes from "prop-types";
 
 import * as tablePropTypes from "./tablePropTypes";
 import Cell from "./Cell";

--- a/src/Table/tablePropTypes.js
+++ b/src/Table/tablePropTypes.js
@@ -1,4 +1,4 @@
-import {PropTypes} from "react";
+import * as PropTypes from "prop-types";
 
 import sortDir from "./sortDirection";
 

--- a/src/TextArea/TextArea.jsx
+++ b/src/TextArea/TextArea.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import * as PropTypes from "prop-types";
 import classnames from "classnames";
 import TextareaAutosize from "react-autosize-textarea";
 
@@ -125,22 +126,22 @@ export class TextArea extends React.Component {
 }
 
 TextArea.propTypes = {
-  disabled: React.PropTypes.bool,
-  error: React.PropTypes.string,
-  label: React.PropTypes.string,
-  maxLength: React.PropTypes.number,
-  minLength: React.PropTypes.number,
-  name: React.PropTypes.string.isRequired,
-  onBlur: React.PropTypes.func,
-  onChange: React.PropTypes.func,
-  onFocus: React.PropTypes.func,
-  optional: React.PropTypes.bool,
-  placeholder: React.PropTypes.node,
-  readOnly: React.PropTypes.bool,
-  required: React.PropTypes.bool,
-  spellCheck: React.PropTypes.bool,
-  value: React.PropTypes.node,
-  className: React.PropTypes.string,
-  autoResize: React.PropTypes.bool,
-  rows: React.PropTypes.number,
+  disabled: PropTypes.bool,
+  error: PropTypes.string,
+  label: PropTypes.string,
+  maxLength: PropTypes.number,
+  minLength: PropTypes.number,
+  name: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  optional: PropTypes.bool,
+  placeholder: PropTypes.node,
+  readOnly: PropTypes.bool,
+  required: PropTypes.bool,
+  spellCheck: PropTypes.bool,
+  value: PropTypes.node,
+  className: PropTypes.string,
+  autoResize: PropTypes.bool,
+  rows: PropTypes.number,
 };

--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import * as PropTypes from "prop-types";
 import classnames from "classnames";
 import _ from "lodash";
 
@@ -111,20 +112,20 @@ export class TextInput extends React.Component {
 }
 
 TextInput.propTypes = {
-  disabled: React.PropTypes.bool,
-  disableAutocomplete: React.PropTypes.bool,
-  enableShow: React.PropTypes.bool,
-  error: React.PropTypes.string,
-  label: React.PropTypes.string,
-  name: React.PropTypes.string.isRequired,
-  onChange: React.PropTypes.func,
-  onKeyPress: React.PropTypes.func,
-  onFocus: React.PropTypes.func,
-  onBlur: React.PropTypes.func,
-  placeholder: React.PropTypes.node,
-  readOnly: React.PropTypes.bool,
-  required: React.PropTypes.bool,
-  type: React.PropTypes.string,
-  value: React.PropTypes.node,
-  className: React.PropTypes.string,
+  disabled: PropTypes.bool,
+  disableAutocomplete: PropTypes.bool,
+  enableShow: PropTypes.bool,
+  error: PropTypes.string,
+  label: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  onKeyPress: PropTypes.func,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  placeholder: PropTypes.node,
+  readOnly: PropTypes.bool,
+  required: PropTypes.bool,
+  type: PropTypes.string,
+  value: PropTypes.node,
+  className: PropTypes.string,
 };

--- a/src/Tooltip/Tooltip.jsx
+++ b/src/Tooltip/Tooltip.jsx
@@ -3,7 +3,8 @@ import _ from "lodash";
 import classnames from "classnames";
 import BootstrapTooltip from "react-bootstrap/lib/Tooltip";
 import OverlayTrigger from "react-bootstrap/lib/OverlayTrigger";
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import * as PropTypes from "prop-types";
 
 import "./Tooltip.less";
 
@@ -70,7 +71,7 @@ Tooltip.propTypes = {
   hide: PropTypes.bool,
   placement: PropTypes.oneOf(_.values(Tooltip.Placement)),
   textAlign: PropTypes.oneOf(_.values(Tooltip.Align)),
-  className: React.PropTypes.string,
+  className: PropTypes.string,
 };
 
 Tooltip.defaultProps = {

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 import {Sticky, StickyContainer} from "react-sticky";
 import _ from "lodash";
 

--- a/src/Wizard/WizardStep.jsx
+++ b/src/Wizard/WizardStep.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 import _ from "lodash";
 import classnames from "classnames";
 import {classNameFor} from "../utils";

--- a/src/flex/FlexBox.jsx
+++ b/src/flex/FlexBox.jsx
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import ContentAlign from "./ContentAlign";
 import FlexItem from "./FlexItem";

--- a/src/flex/FlexItem.jsx
+++ b/src/flex/FlexItem.jsx
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import classnames from "classnames";
-import React, {PropTypes} from "react";
+import React from "react";
+import * as PropTypes from "prop-types";
 
 import ItemAlign from "./ItemAlign";
 

--- a/src/utils/MorePropTypes.js
+++ b/src/utils/MorePropTypes.js
@@ -1,4 +1,4 @@
-import {PropTypes} from "react";
+import * as PropTypes from "prop-types";
 
 export default class MorePropTypes {
   static makeRequirable(propType) {


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FEE-107

**Overview:**
`propTypes` has moved from the main React object to a separate package. This changes the imports to pull `propTypes` from the separate `prop-types` package.

This is a required step before upgrading to React 16.
https://reactjs.org/blog/2017/04/07/react-v15.5.0.html


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
