### PR TITLE
Remove react addons

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "postcss-loader": "^1.1.1",
     "prismjs": "^1.5.1",
     "react": "~15.3.0",
-    "react-addons-test-utils": "~15.3.0",
     "react-dom": "~15.3.0",
     "react-router": "^3.0.0",
     "sinon": "^1.17.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "numeral": "^2.0.4",
     "prop-types": "^15.5.10",
     "react-accessible-accordion": "^1.0.2",
-    "react-addons-css-transition-group": "^15.4.2",
+    "react-transition-group": "~1.2.0",
     "react-autosize-textarea": "^3.0.1",
     "react-bootstrap": "^0.30.0",
     "react-copy-to-clipboard": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/LeftNav/LeftNav.jsx
+++ b/src/LeftNav/LeftNav.jsx
@@ -2,7 +2,7 @@ import * as PropTypes from "prop-types";
 import * as React from "react";
 import _ from "lodash";
 import classnames from "classnames";
-import ReactCSSTransitionGroup from "react-addons-css-transition-group";
+import {CSSTransitionGroup} from "react-transition-group";
 import RootCloseWrapper from "react-overlays/lib/RootCloseWrapper";
 
 import MorePropTypes from "../utils/MorePropTypes";
@@ -91,7 +91,7 @@ export class LeftNav extends React.PureComponent {
           <div className={classnames(cssClass.TOPNAV, _collapsed && cssClass.TOPNAV_COLLAPSED)}>
             {navItems}
           </div>
-          <ReactCSSTransitionGroup
+          <CSSTransitionGroup
             className={classnames(cssClass.SUBNAV, openChild && cssClass.SUBNAV_OPEN)}
             transitionEnterTimeout={WIDTH_TRANSITION_DURATION_MS}
             transitionLeaveTimeout={WIDTH_TRANSITION_DURATION_MS}
@@ -103,7 +103,7 @@ export class LeftNav extends React.PureComponent {
                 {openChild.props.children}
               </div>
             )}
-          </ReactCSSTransitionGroup>
+          </CSSTransitionGroup>
         </nav>
       </RootCloseWrapper>
     );


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FEE-107

**Overview:**

Included are some changes to move components closer to React 16.

The React addons packages are being deprecated and moved to separate community maintained packages. 

https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#discontinuing-support-for-react-addons
https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#react-test-utils

The reason for the change from `react-addons-css-transition-group` to `react-transition-group` version 1 instead of version 2 is that 1 is API compatible. 

Relevant to the quest to React 16: https://github.com/Clever/components/pull/274

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
