### PR TITLE
Bring back react addons test utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.29.4",
+  "version": "0.29.5",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "postcss-loader": "^1.1.1",
     "prismjs": "^1.5.1",
     "react": "~15.3.0",
+    "react-addons-test-utils": "^15.3.2",
     "react-dom": "~15.3.0",
     "react-router": "^3.0.0",
     "sinon": "^1.17.3",


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FEE-107


**Overview:**
This change reintroduces the `react-addons-test-utils` package that was removed in this previous pull request: https://github.com/Clever/components/pull/275

It turns out that this package was removed in react 15.5, and components is locked at 15.3

`react-addons-test-utils` is an implicit dependency and not referenced directly in the repository. 

This deprecated package will be removed once we upgrade to a newer version of react.

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
