### PR TITLE
fix console warnings in docs

### DIFF
--- a/docs/components/DateInputView.jsx
+++ b/docs/components/DateInputView.jsx
@@ -37,6 +37,7 @@ export default class DateInputView extends Component {
               label="label"
               onChange={(value) => this.setState({value})}
               placeholder="Placeholder"
+              name="name"
               readOnly={this.state.readOnly}
               required={this.state.required}
               value={this.state.value}

--- a/docs/components/GettingStartedView.jsx
+++ b/docs/components/GettingStartedView.jsx
@@ -133,13 +133,13 @@ export default function GettingStartedView() {
             <h3>Updating Documentation</h3>
             <p>
               After merging to master, you can update the live examples by running <code>make deploy-docs</code>:
+            </p>
               <CodeSample>
                 sh
                 git checkout master
                 git pull
                 make deploy-docs
               </CodeSample>
-            </p>
             <h3>Testing</h3>
             <p>Run the entire test suite with <code>make test</code> or a single component with <code>make test/component_test.jsx</code></p>
           </Col>

--- a/docs/components/IntroView.jsx
+++ b/docs/components/IntroView.jsx
@@ -35,35 +35,35 @@ export default function IntroView() {
           <Col span={3} className="flexbox">
             <img src="./assets/img/deweyFox.svg" alt="Dewey the mascot for the design system" />
           </Col>
-          <Row grow className="margin--top--xl">
-            <Col span={4} className="flexbox padding--right--xl">
-              <div>
-                <Icon size={Icon.sizes.LARGE} name={Icon.names.TYPEWRITER} />
-                <h3 className="text--light display--inlineBlock padding--left--m">Cohesive experiences</h3>
-                <p>
-                  Create a system of coherent UI and interaction patterns to improve usability, visual
-                  consistency, and clarity instead of reinventing the radio button.
-                </p>
-              </div>
-            </Col>
-            <Col span={4} className="flexbox padding--right--xl">
-              <div>
-                <Icon size={Icon.sizes.LARGE} name={Icon.names.WEBSITE_HTML} />
-                <h3 className="display--inlineBlock padding--left--m ">Faster development</h3>
-                <p>
-                  Provide reusable utilities and components that accelerate the development of interfaces
-                  allowing us to focus on workflows and logic.
-                </p>
-              </div>
-            </Col>
-            <Col span={4} className="flexbox padding--right--xl">
-              <div>
-                <Icon size={Icon.sizes.LARGE} name={Icon.names.PEN} />
-                <h3 className="text--light display--inlineBlock padding--left--m">Clear documentation</h3>
-                <p>Showcase good examples for when to use which component or layout, and how to implement them.</p>
-              </div>
-            </Col>
-          </Row>
+        </Row>
+        <Row grow className="margin--bottom--xl">
+          <Col span={4} className="flexbox padding--right--xl">
+            <div>
+              <Icon size={Icon.sizes.LARGE} name={Icon.names.TYPEWRITER} />
+              <h3 className="text--light display--inlineBlock padding--left--m">Cohesive experiences</h3>
+              <p>
+                Create a system of coherent UI and interaction patterns to improve usability, visual
+                consistency, and clarity instead of reinventing the radio button.
+              </p>
+            </div>
+          </Col>
+          <Col span={4} className="flexbox padding--right--xl">
+            <div>
+              <Icon size={Icon.sizes.LARGE} name={Icon.names.WEBSITE_HTML} />
+              <h3 className="display--inlineBlock padding--left--m ">Faster development</h3>
+              <p>
+                Provide reusable utilities and components that accelerate the development of interfaces
+                allowing us to focus on workflows and logic.
+              </p>
+            </div>
+          </Col>
+          <Col span={4} className="flexbox padding--right--xl">
+            <div>
+              <Icon size={Icon.sizes.LARGE} name={Icon.names.PEN} />
+              <h3 className="text--light display--inlineBlock padding--left--m">Clear documentation</h3>
+              <p>Showcase good examples for when to use which component or layout, and how to implement them.</p>
+            </div>
+          </Col>
         </Row>
         <Row grow>
           <Col span={12}>

--- a/docs/components/LayoutCompoundForm.jsx
+++ b/docs/components/LayoutCompoundForm.jsx
@@ -112,10 +112,8 @@ export default class LayoutCompoundForm extends PureComponent {
           <Row>
             <Col span={12} className="flexbox margin--top--2xl">
               <div>
-                <p>
-                  <p className="text--semi-bold">
-                    #3. Use concise and thoughtful input labels
-                  </p>
+                <p className="text--semi-bold">
+                  #3. Use concise and thoughtful input labels
                 </p>
                 <p>
                   This is one of the more difficult ones to achieve and often take several iterations to get right. However, the impact of having clear and concise instruction is definitely key to successful form design.
@@ -151,10 +149,8 @@ export default class LayoutCompoundForm extends PureComponent {
           <Row>
             <Col span={12} className="flexbox margin--top--2xl">
               <div>
-                <p>
-                  <p className="text--semi-bold">
-                    #4. Use the ‘hint’ pattern to only display more information about a field at the right time
-                  </p>
+                <p className="text--semi-bold">
+                  #4. Use the ‘hint’ pattern to only display more information about a field at the right time
                 </p>
                 <p>
                   When relying on labels alone is not enough, we can utilize additional screen real-estate with a pop-over.

--- a/docs/components/LessStyleGuideView.jsx
+++ b/docs/components/LessStyleGuideView.jsx
@@ -147,13 +147,12 @@ export default function LessStyleGuideView() {
               `}
             >
               <strong>Incorrect nesting</strong>
-              <p>When selectors become this long, you're likely writing CSS that is:
-                <ul>
-                  <li>Strongly coupled to the HTML (fragile) —OR—</li>
-                  <li>Overly specific (powerful) —OR—</li>
-                  <li>Not reusable</li>
-                </ul>
-              </p>
+              <p>When selectors become this long, you're likely writing CSS that is:</p>
+              <ul>
+                <li>Strongly coupled to the HTML (fragile) —OR—</li>
+                <li>Overly specific (powerful) —OR—</li>
+                <li>Not reusable</li>
+              </ul>
             </Example>
 
             <Example
@@ -193,13 +192,12 @@ export default function LessStyleGuideView() {
               `}
             >
               <strong>Incorrect specificity</strong>
-              <p>When selectors become this long, you're likely writing CSS that is:
-                <ul>
-                  <li>Strongly coupled to the HTML (fragile) —OR—</li>
-                  <li>Overly specific (powerful) —OR—</li>
-                  <li>Not reusable</li>
-                </ul>
-              </p>
+              <p>When selectors become this long, you're likely writing CSS that is:</p>
+              <ul>
+                <li>Strongly coupled to the HTML (fragile) —OR—</li>
+                <li>Overly specific (powerful) —OR—</li>
+                <li>Not reusable</li>
+              </ul>
             </Example>
 
             <Example

--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -58,12 +58,15 @@ export default class SelectView extends Component {
                 name="select"
                 onChange={value => this.setState({selectValue: value})}
                 options={!this.state.lazy && _.range(100).map(i => ({label: `Option ${i + 1}`, value: `${i + 1}`}))}
-                loadOptions={this.state.lazy && (async (input) => {
-                  await new Promise(resolve => setTimeout(resolve, 1000));
-                  const allOptions = _.range(100).map(i => ({label: `Option ${i + 1}`, value: `${i + 1}`}));
-                  const options = allOptions.filter(x => x.label.toLowerCase().startsWith(input.toLowerCase()));
-                  return {options};
-                })}
+                loadOptions={this.state.lazy ?
+                  async input => {
+                    await new Promise(resolve => setTimeout(resolve, 1000));
+                    const allOptions = _.range(100).map(i => ({label: `Option ${i + 1}`, value: `${i + 1}`}));
+                    const options = allOptions.filter(x => x.label.toLowerCase().startsWith(input.toLowerCase()));
+                    return {options};
+                  }
+                  : null
+                }
                 placeholder="Select Placeholder"
                 value={this.state.selectValue}
               />

--- a/docs/components/WizardView.jsx
+++ b/docs/components/WizardView.jsx
@@ -17,11 +17,12 @@ export default class WizardView extends PureComponent {
         </p>
         <p>
           The <code>Component</code> gets two props:
-          <ul>
-            <li><code>setWizardState</code>: setWizardState allows each step to add data to the wizardState</li>
-            <li><code>wizardState</code>: wizardState contains any data that has been set by any step before</li>
-          </ul>
-
+        </p>
+        <ul>
+          <li><code>setWizardState</code>: setWizardState allows each step to add data to the wizardState</li>
+          <li><code>wizardState</code>: wizardState contains any data that has been set by any step before</li>
+        </ul>
+        <p>
           The validate function receives this shared state as an argument, allowing each step to define
           the conditions under which their inputs are considered valid.
         </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.29.13",
+  "version": "0.29.14",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Overview:**
These minor changes address a number of console warnings in the docs.

fixes:
    `<ul> cannot be a descendant of <p>` warning in WizardView.jsx and LessStyleGuideView.jsx

   `Invalid prop 'loadOptions' of type 'boolean' supplied to 'Select', expected 'function'` 
        in SelectView.jsx

   `<p> cannot be a descendant of <p>` warning in LayoutCompoundForm.jsx

   `<pre> cannot be a descendant of <p>` warning in GettingStartedView.jsx

   supply required prop to DateInput in DateInputView.jsx

   Row nesting in IntroView.jsx - a Row cannot be a child element of another Row

**Screenshots/GIFs:**

Before and after:
<img width="1920" alt="screen shot 2018-04-03 at 12 53 56 pm" src="https://user-images.githubusercontent.com/32328921/38272516-497eb014-373e-11e8-8ed3-62f66cc57531.png">


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
