### PR TITLE
Override search for lazy selects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.29.16",
+  "version": "0.29.17",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -87,6 +87,8 @@ export function Select({
     SelectComponent = ReactSelect.Async;
   }
 
+  const overrideProps = lazy ? {filterOptions: (results) => results} : {};
+
   // The label container must be returned after the ReactSelect otherwise it does not get displayed
   // in the browser.
   return (
@@ -107,6 +109,7 @@ export function Select({
           searchable={searchable}
           noResultsText={noResultsText}
           value={value}
+          {...overrideProps}
         />
       </div>
       <div className={cssClass.LABEL_CONTAINER}>


### PR DESCRIPTION
React Select has a bit of odd behavior which...makes sense but isn't what we want. 

> The Async component doesn't change the default behaviour for filtering the options based on user input, but if you're already filtering the options server-side you may want to customise or disable this feature. 

Specifically it'll apply the same relatively dumb (`indexOf`) search to any options returned by the server. In general this is the opposite of what we expect, and in fact in other repos where we use the lazy options this causes odd bugs where the returned result quality seems lower than expected. 

This makes a change to disable frontend filtering if we're using the `lazy` version of this component. 

Technically this wouldn't be backwards compatible but seems like everywhere we use this this is actually the expected behavior, and if this breaks anywhere we can update it do to the `indexOf` based search on the frontend. I don't think it's worth ballooning the API for this. 