### PR TITLE
make the TextArea component space better

### DIFF
--- a/src/TextArea/TextArea.less
+++ b/src/TextArea/TextArea.less
@@ -2,6 +2,7 @@
 
 .TextArea {
   .padding--left--s;
+  .padding--y--3xs;
   .text--regular;
   .border--s(@neutral_silver);
   position: relative;
@@ -9,9 +10,7 @@
   background: @neutral_white;
   box-sizing: border-box;
   width: 100%;
-  min-height: 3.5rem;
-  padding-top: 0.125rem;
-  padding-bottom: 0.125rem;
+  min-height: @size_4xl;
 }
 
 .TextArea--infoRow {
@@ -48,7 +47,7 @@
   .text--medium;
   display: block;
   width: 100%;
-  min-height: 2.5rem;
+  min-height: @size_2xl;
   border: none;
   .margin--top--l;
 

--- a/src/TextArea/TextArea.less
+++ b/src/TextArea/TextArea.less
@@ -9,6 +9,9 @@
   background: @neutral_white;
   box-sizing: border-box;
   width: 100%;
+  min-height: 3.5rem;
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
 }
 
 .TextArea--infoRow {
@@ -45,6 +48,7 @@
   .text--medium;
   display: block;
   width: 100%;
+  min-height: 2.5rem;
   border: none;
   .margin--top--l;
 
@@ -66,7 +70,6 @@
     .text--small;
     .text--caps;
     color: @neutral_dark_gray;
-    .margin--top--m;
   }
 }
 


### PR DESCRIPTION
**Overview:**
The TextArea component kept:
1) Jumping around in size when going from placeholder to input text
2) Overlapping with the OPTIONAL / REQUIRED keywords on the top

**Screenshots/GIFs:**
before - jumping around sizes:
![before](https://user-images.githubusercontent.com/603357/39025696-906dc430-43fd-11e8-8802-2afdc8376513.gif)

after:
![after](https://user-images.githubusercontent.com/603357/39025659-57ff33f4-43fd-11e8-9652-ea1291e2eb7c.gif)

before - interference from top bar on placeholder text:
<img width="629" alt="screen shot 2018-04-19 at 16 56 16" src="https://user-images.githubusercontent.com/603357/39025786-18e8dc0a-43fe-11e8-89b8-b779febac76f.png">

after:
![screen shot 2018-04-19 at 18 16 30](https://user-images.githubusercontent.com/603357/39025768-0408b6e8-43fe-11e8-94ee-63eee4dd0d65.png)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
