### PR TITLE
0.29.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.29.17",
+  "version": "0.29.18",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",


### PR DESCRIPTION
bumping version, forgot in #287 
**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
