### PR TITLE
Add optional error message for FileInput

### DIFF
--- a/docs/components/FileInputView.jsx
+++ b/docs/components/FileInputView.jsx
@@ -17,7 +17,7 @@ export default function FileInputView() {
             <FileInput
               label="Icon"
               accept="image/png"
-              store={(file, {progress, success}) => {
+              store={(file, {progress, error, success}) => {
                 // Example store function using filestack
                 let progressPercent = 0;
                 progress(progressPercent);
@@ -25,6 +25,9 @@ export default function FileInputView() {
                   if (progressPercent !== 100) {
                     progressPercent += 5;
                     progress(progressPercent);
+                  } else if (this.state.error) {
+                    error("An error occurred");
+                    clearInterval(intervalID);
                   } else {
                     success();
                     clearInterval(intervalID);
@@ -37,7 +40,7 @@ export default function FileInputView() {
           The caller is responsible for calling 3 provided callbacks:</p>
           <ul>
             <li><code>success</code> - Called when the upload is complete</li>
-            <li><code>error</code> - Called if the upload failed for unexpected reasons</li>
+            <li><code>error</code> - Called if the upload failed for unexpected reasons with an optional error message</li>
             <li><code>progress</code> - Called during upload with a number between 0-100 representing the % completed</li>
           </ul>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.29.18",
+  "version": "0.29.19",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FileInput/FileInput.jsx
+++ b/src/FileInput/FileInput.jsx
@@ -78,8 +78,8 @@ export class FileInput extends React.Component {
         }
         this.setState({success: true});
       },
-      error: () => {
-        this.setState({error: "Unknown error"});
+      error: (errMsg = "Unknown error") => {
+        this.setState({error: errMsg});
       },
       progress: (progress) => {
         if (this.state.fileKey !== fileKey) {


### PR DESCRIPTION
**Jira:** N/A

**Overview:**
I want to provide an optional error message that can be displayed in the `FileInput` box if an identifiable error occurred.

**Screenshots/GIFs:**
No error message provided:
<img width="632" alt="screen shot 2018-04-26 at 12 00 58 pm" src="https://user-images.githubusercontent.com/3518597/39326383-a6e93ab8-4949-11e8-8904-b09baf895320.png">
Error message provided:
<img width="632" alt="screen shot 2018-04-26 at 12 01 55 pm" src="https://user-images.githubusercontent.com/3518597/39326386-a9ea9996-4949-11e8-8c78-e51625ce7eb7.png">

**Testing:**
- [x] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
