### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "numeral": "^2.0.4",
     "prop-types": "^15.5.10",
     "react-accessible-accordion": "^1.0.2",
-    "react-transition-group": "~1.2.0",
+    "react-transition-group": "^1.2.1",
     "react-autosize-textarea": "^3.0.1",
     "react-bootstrap": "^0.32.1",
     "react-copy-to-clipboard": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react-dropzone": "^3.11.0",
     "react-fontawesome": "^1.6.1",
     "react-linkify": "^0.2.1",
-    "react-onclickoutside": "^5.11.1",
     "react-overlays": "^0.8.3",
     "react-select": "^1.2.1",
     "react-sticky": "^6.0.1",


### PR DESCRIPTION
**Overview:**
`react-onclickoutside` was included here as part of a temporary fix: https://github.com/Clever/components/pull/176

And the temp fix was reverted here: https://github.com/Clever/components/pull/276
but I forgot to remove it as a dependency. 


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
