### PR TITLE
Add error message to selector

### DIFF
--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -4,7 +4,7 @@ import React, {Component} from "react";
 import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import {Select} from "src";
+import {Select, TextInput} from "src";
 
 import "./SelectView.less";
 
@@ -23,6 +23,7 @@ export default class SelectView extends Component {
       lazy: false,
       selectValue: null,
       required: false,
+      error: "",
     };
   }
 
@@ -55,6 +56,7 @@ export default class SelectView extends Component {
                 multi={this.state.multi}
                 readOnly={this.state.readOnly}
                 required={this.state.required}
+                error={this.state.error}
                 name="select"
                 onChange={value => this.setState({selectValue: value})}
                 options={!this.state.lazy && _.range(100).map(i => ({label: `Option ${i + 1}`, value: `${i + 1}`}))}
@@ -153,6 +155,15 @@ export default class SelectView extends Component {
             {" "}
             Required
           </label>
+          <div className={cssClass.CONFIG}>
+            <TextInput
+              className={cssClass.CONFIG}
+              label="Error"
+              name="InputError"
+              onChange={e => this.setState({error: e.target.value})}
+              value={this.state.error}
+            />
+          </div>
         </Example>
 
         <PropDocumentation
@@ -199,6 +210,13 @@ export default class SelectView extends Component {
               type: "Boolean",
               description: "Whether the select is disabled",
               defaultValue: "False",
+              optional: true,
+            },
+            {
+              name: "error",
+              type: "String",
+              description: "Error to show the user, hides the required label. Useful if using a 'creatable' select.",
+              defaultValue: "",
               optional: true,
             },
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -44,6 +44,7 @@ export function Select({
   creatablePromptFn,
   value,
   className,
+  error,
 }) {
   const {cssClass} = Select;
 
@@ -73,6 +74,12 @@ export function Select({
     inputNote = <span className="Select--required">required</span>;
   }
 
+  let wrapperClass = className;
+  if (error) { // error should overwrite required
+    inputNote = <span className="Select--error">{error}</span>;
+    wrapperClass += " Select--hasError";
+  }
+
   let reactSelectClasses = cssClass.REACT_SELECT;
   if (readOnly) {
     reactSelectClasses += ` ${cssClass.READ_ONLY}`;
@@ -92,7 +99,7 @@ export function Select({
   // The label container must be returned after the ReactSelect otherwise it does not get displayed
   // in the browser.
   return (
-    <div className={classnames(cssClass.CONTAINER, className)}>
+    <div className={classnames(cssClass.CONTAINER, wrapperClass)}>
       <div id={id}>
         <SelectComponent
           className={reactSelectClasses}
@@ -160,6 +167,7 @@ Select.propTypes = {
     PropTypes.arrayOf(selectValuePropType),
   ]),
   className: PropTypes.string,
+  error: PropTypes.string,
 };
 
 Select.defaultProps = {

--- a/src/Select/Select.less
+++ b/src/Select/Select.less
@@ -1,6 +1,7 @@
 @import (reference) "../less/colors";
 @import (reference) "../less/spacing";
 @import (reference) "../less/type-size";
+@import (reference) "../less/type-utilities";
 
 .Select--container {
   position: relative;
@@ -8,9 +9,9 @@
 
 .Select--labelContainer {
   .text--tiny;
+  .text--caps;
   color: @neutral_dark_gray;
   position: absolute;
-  text-transform: uppercase;
   top: @size_xs;
   width: 100%;
 
@@ -18,6 +19,12 @@
   .Select--required {
     position: absolute;
     right: 0.8rem;
+  }
+
+  .Select--error {
+    color: @alert_red;
+    position: absolute;
+    right: @size_s;
   }
 }
 

--- a/test/Select_test.jsx
+++ b/test/Select_test.jsx
@@ -229,6 +229,20 @@ describe("Select", () => {
     assert(select.find(".Select--required").exists());
   });
 
+  it("renders the error if specified, hiding required", () => {
+    const select = shallow(
+      <Select
+        id="testid"
+        name="testname"
+        required
+        error="ERROR"
+        options={[]}
+      />
+    );
+    assert(select.find(".Select--error").exists());
+    assert(!select.find(".Select--required").exists());
+  });
+
   it("uses the ReactSelect Creatable component to allow creating custom options if creatable prop is true", () => {
     const select = shallow(
       <Select

--- a/test/Select_test.jsx
+++ b/test/Select_test.jsx
@@ -226,7 +226,7 @@ describe("Select", () => {
         options={[]}
       />
     );
-    assert(select.find("Select--required"));
+    assert(select.find(".Select--required").exists());
   });
 
   it("uses the ReactSelect Creatable component to allow creating custom options if creatable prop is true", () => {


### PR DESCRIPTION
**Jira:**
Related to: https://clever.atlassian.net/browse/IL-403

**Overview:**
Adds the ability to show an error message to our selector component. This is useful when we allow users to custom-add items to the selector. Currently it would be a bit tricky to add error handling inside the "add an item" functionality.

Hmmm, or maybe there's a better hook in react-select...

**Screenshots/GIFs:**
![screen recording 2018-06-06 at 12 17](https://user-images.githubusercontent.com/603357/41060733-5551a13e-6985-11e8-9626-7c0bc11d11ef.gif)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
