### PR TITLE
allow users to pass through props to underlying react-select

### DIFF
--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -71,6 +71,7 @@ export default class SelectView extends Component {
                 }
                 placeholder="Select Placeholder"
                 value={this.state.selectValue}
+                additionalProps={{matchPos: "start"}} // example prop
               />
             </ExampleCode>
           </div>
@@ -295,6 +296,14 @@ export default class SelectView extends Component {
               name: "value",
               type: "String",
               description: "Selected value. Must be updated by caller in the onChange",
+              optional: true,
+            },
+            {
+              name: "additionalProps",
+              type: "Object",
+              description: "Key Value pairs which are passed down as props into react-select. "
+              + "Useful so that we can use react-select features without having to laboriously "
+              + "update this component. See options at the react-select page.",
               optional: true,
             },
           ]}

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -45,6 +45,7 @@ export function Select({
   value,
   className,
   error,
+  additionalProps,
 }) {
   const {cssClass} = Select;
 
@@ -94,7 +95,9 @@ export function Select({
     SelectComponent = ReactSelect.Async;
   }
 
-  const overrideProps = lazy ? {filterOptions: (results) => results} : {};
+  const overrideProps = lazy ?
+    {filterOptions: (results) => results, ...additionalProps} :
+    additionalProps;
 
   // The label container must be returned after the ReactSelect otherwise it does not get displayed
   // in the browser.
@@ -168,6 +171,7 @@ Select.propTypes = {
   ]),
   className: PropTypes.string,
   error: PropTypes.string,
+  additionalProps: PropTypes.object,
 };
 
 Select.defaultProps = {


### PR DESCRIPTION
**Overview:**
This might be more controversial...
Basically, this component is a light wrapper around the React-Select package. We should try to do as little wrapping as possible, and I think the best way to do this is to just get out of our users' way. This PR allows the user to pass props directly into the React-Select component.

This is me being a little lazy (in the good programmer way). Otherwise I'm going to have to cruft up the API of this component with a `matchPos` param as well as a `filterOptions` param.

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
