### PR TITLE
add filterOptions param to the select component, useful for searching

### DIFF
--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -220,6 +220,14 @@ export default class SelectView extends Component {
               optional: true,
             },
             {
+              name: "filterOptions",
+              type: "Function",
+              description: "Function to filter options when searching - see react-select docs for more. "
+              + "Signature: function(Array options, String filter, Array currentValues) returns Array",
+              defaultValue: "a simple search function included in react-select",
+              optional: true,
+            },
+            {
               name: "label",
               type: "String",
               description: "Label for the select element",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -35,6 +35,7 @@ export function Select({
   options,
   lazy,
   loadOptions,
+  filterOptions,
   placeholder = "",
   readOnly,
   required,
@@ -94,7 +95,7 @@ export function Select({
     SelectComponent = ReactSelect.Async;
   }
 
-  const overrideProps = lazy ? {filterOptions: (results) => results} : {};
+  const overrideProps = (lazy && !filterOptions) ? {filterOptions: (results) => results} : {};
 
   // The label container must be returned after the ReactSelect otherwise it does not get displayed
   // in the browser.
@@ -112,6 +113,7 @@ export function Select({
           optionRenderer={optionRenderer}
           options={options}
           loadOptions={loadOptions}
+          filterOptions={filterOptions}
           placeholder={placeholder}
           searchable={searchable}
           noResultsText={noResultsText}
@@ -153,6 +155,7 @@ Select.propTypes = {
   options: PropTypes.arrayOf(selectValuePropType),
   lazy: PropTypes.bool,
   loadOptions: PropTypes.func,
+  filterOptions: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   searchable: PropTypes.bool,


### PR DESCRIPTION
**Jira:**
see: https://clever.atlassian.net/browse/IL-403

**Overview:**
I added Fuse.js in another repo, and to use that I need to pass in a custom filterOptions function.

**Testing:**
- [x] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
