### PR TITLE
spacing in Wizard documentation

### DIFF
--- a/docs/components/WizardView.jsx
+++ b/docs/components/WizardView.jsx
@@ -11,8 +11,8 @@ export default class WizardView extends PureComponent {
     return (
       <View className={cssClass.CONTAINER} title="Wizard">
         <p>
-          <code>Wizard</code> provides an interface for making guided wizards. A <code>Wizard</code>
-          is provided several steps that consist of a <code>Component</code> to render, a validate
+          <code>Wizard</code> provides an interface for making guided wizards. A <code>Wizard</code> is provided
+          several steps that consist of a <code>Component</code> to render, a validate
           function, and a few other fields.
         </p>
         <p>


### PR DESCRIPTION
**Jira:**

**Overview:**
I noticed the whitespace after the formatted `Wizard` gets stripped away, so I made a small change to prevent that from happening.

**Screenshots/GIFs:**
<img width="1056" alt="screen shot 2018-07-19 at 6 51 50 pm" src="https://user-images.githubusercontent.com/32328921/42979560-b50a45b2-8b87-11e8-8954-5ed485797506.png">
<img width="1109" alt="screen shot 2018-07-19 at 7 11 56 pm" src="https://user-images.githubusercontent.com/32328921/42979569-ba283b08-8b87-11e8-9330-b71bf99e69dc.png">


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
