### PR TITLE
Make 'Step X:' prefix optional in Wizard steps titles

### DIFF
--- a/docs/WizardExample.jsx
+++ b/docs/WizardExample.jsx
@@ -142,6 +142,7 @@ export default class WizardExample extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      stepNumberInTitle: true,
       seekable: false,
       showHelp: false,
       sticky: false,
@@ -212,6 +213,16 @@ export default class WizardExample extends React.Component {
       <fieldset>
         <legend>Wizard controls</legend>
         <ul style={{listStyleType: "none"}}>
+          <li>
+            <label>
+              <input
+                type="checkbox"
+                checked={this.state.stepNumberInTitle}
+                onChange={(e) => this.setState({stepNumberInTitle: e.target.checked})}
+              />
+              Show step number in title?
+            </label>
+          </li>
           <li>
             <label>
               <input
@@ -296,6 +307,7 @@ export default class WizardExample extends React.Component {
           </div>
         )}
         seekable={this.state.seekable}
+        stepNumberInTitle={this.state.stepNumberInTitle}
         hideProgressBar={this.state.hideProgressBar}
         style={{height: 700}}
       />

--- a/docs/components/WizardView.jsx
+++ b/docs/components/WizardView.jsx
@@ -103,6 +103,13 @@ export default class WizardView extends PureComponent {
               optional: true,
             },
             {
+              name: "stepNumberInTitle",
+              type: "Boolean",
+              description: "Whether or not to prefix step X's title with 'Step X'",
+              defaultValue: "True",
+              optional: true,
+            },
+            {
               name: "seekable",
               type: "Boolean",
               description: "Whether or not you can skip to other steps before completing the current one",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Wizard/Wizard.jsx
+++ b/src/Wizard/Wizard.jsx
@@ -176,7 +176,7 @@ export class Wizard extends React.Component {
   render() {
     const {
       className, style, help, steps, nextButtonValue,
-      prevButtonValue, stickySidebar,
+      prevButtonValue, stickySidebar, stepNumberInTitle,
     } = this.props;
 
     const baseClasses = ["Wizard", className].filter(c => !!c);
@@ -208,6 +208,7 @@ export class Wizard extends React.Component {
             Component={steps[this.state.currentStep].component}
             componentProps={steps[this.state.currentStep].props}
             stepNumber={this.state.currentStep}
+            stepNumberInTitle={stepNumberInTitle}
             setWizardState={changes => {
               const newState = Object.assign(this.state.data, changes);
               this.setState({data: newState});
@@ -293,4 +294,9 @@ Wizard.propTypes = {
   seekable: PropTypes.bool,
   hideProgressBar: PropTypes.bool,
   stickySidebar: PropTypes.bool,
+  stepNumberInTitle: PropTypes.bool,
+};
+
+Wizard.defaultProps = {
+  stepNumberInTitle: true,
 };

--- a/src/Wizard/WizardStep.jsx
+++ b/src/Wizard/WizardStep.jsx
@@ -43,7 +43,7 @@ export default class WizardStep extends React.Component {
     const {
       title, description, Component, setWizardState, currentStep, wizardState, help,
       percentComplete, calculatePercentComplete, updatePercentComplete, totalSteps,
-      componentProps, className,
+      componentProps, className, stepNumberInTitle,
     } = this.props;
     const props = _.omit(componentProps || {}, ["wizardState", "setWizardState"]);
     const baseClasses = ["Wizard", className].filter(c => !!c).map(c =>
@@ -53,7 +53,7 @@ export default class WizardStep extends React.Component {
     return (
       <div className={classnames(baseClasses)} ref={e => { this.component = e; }}>
         <div className={classNameFor(baseClasses, "title")}>
-          <h1>Step {currentStep + 1}: {title}</h1>
+          <h1>{stepNumberInTitle && `Step ${currentStep + 1}: `}{title}</h1>
         </div>
 
         <div className={classNameFor(baseClasses, "topInfo")}>
@@ -113,6 +113,7 @@ export default class WizardStep extends React.Component {
 WizardStep.propTypes = {
   // external facing
   title: PropTypes.string.isRequired,
+  stepNumberInTitle: PropTypes.bool.isRequired,
   description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   help: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   Component: PropTypes.oneOfType([PropTypes.func, PropTypes.instanceOf(React.Component)]).isRequired,

--- a/test/Wizard_test.jsx
+++ b/test/Wizard_test.jsx
@@ -47,6 +47,7 @@ describe("WizardStep", () => {
           percentComplete={0}
           setWizardState={() => {}}
           wizardState={{}}
+          stepNumberInTitle
         />);
 
         const descriptionMatches = renderedStep.find(selector);
@@ -91,6 +92,7 @@ describe("WizardStep", () => {
           percentComplete={0}
           setWizardState={() => {}}
           wizardState={{}}
+          stepNumberInTitle
         />);
 
         const helpMatches = renderedStep.find(selector);
@@ -117,11 +119,31 @@ describe("WizardStep", () => {
           percentComplete={0}
           setWizardState={() => {}}
           wizardState={{}}
+          stepNumberInTitle
         />);
         const headingMatch = renderedStep.find("h1");
         assert.equal(headingMatch.length, 1);
         assert.equal(headingMatch.text(), `Step ${curStep + 1}: ${title}`);
       }
+    });
+
+    it("omits step title prefix if stepNumberInTitle is set to false", () => {
+      const title = "My super cool title";
+      const renderedStep = mount(<WizardStep
+        title={title}
+        Component={() => <div />}
+        currentStep={3}
+        totalSteps={7}
+        updatePercentComplete={() => {}}
+        calculatePercentComplete={() => {}}
+        percentComplete={0}
+        setWizardState={() => {}}
+        wizardState={{}}
+        stepNumberInTitle={false}
+      />);
+      const headingMatch = renderedStep.find("h1");
+      assert.equal(headingMatch.length, 1);
+      assert.equal(headingMatch.text(), title);
     });
 
     it("renders the component with setWizardState and wizardState", () => {
@@ -138,6 +160,7 @@ describe("WizardStep", () => {
         percentComplete={0}
         setWizardState={spySetWizardState}
         wizardState={testState}
+        stepNumberInTitle
       />);
       const componentMatch = renderedStep.find(TestComponent);
       assert.equal(componentMatch.length, 1);
@@ -164,6 +187,7 @@ describe("WizardStep", () => {
           percentComplete={0}
           setWizardState={() => {}}
           wizardState={{}}
+          stepNumberInTitle
         />);
         const componentMatch = renderedStep.find(TestComponent);
         assert.equal(componentMatch.length, 1);
@@ -187,6 +211,7 @@ describe("WizardStep", () => {
           percentComplete={0.5}
           setWizardState={() => {}}
           wizardState={{}}
+          stepNumberInTitle
         />);
         const componentMatch = renderedStep.find(TestComponent);
         assert.equal(componentMatch.length, 1);
@@ -210,6 +235,7 @@ describe("WizardStep", () => {
           percentComplete={0.25}
           setWizardState={() => {}}
           wizardState={{}}
+          stepNumberInTitle
         />);
         const componentMatch = renderedStep.find(TestComponent);
         assert.equal(componentMatch.length, 1);
@@ -233,6 +259,7 @@ describe("WizardStep", () => {
           percentComplete={0.5}
           setWizardState={() => {}}
           wizardState={{}}
+          stepNumberInTitle
         />);
         const componentMatch = renderedStep.find(TestComponent);
         assert.equal(componentMatch.length, 1);


### PR DESCRIPTION
**Jira:** Part of [IP-1937](https://clever.atlassian.net/browse/IP-1937)

**Overview:**

Product would like for the Apps BTS guide to not have this prefix on the step title. I made it an option that defaults to true. All existing Wizards should be unaffected even if the `clever-components` version is upped.

**Screenshots/GIFs:**

https://cl.ly/2c3e442h2N0D

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
