### PR TITLE
Add non cap option to placeholder text

### DIFF
--- a/docs/components/TextInputView.jsx
+++ b/docs/components/TextInputView.jsx
@@ -19,6 +19,7 @@ export default class TextInputView extends Component {
       inputValue: "",
       obscured: false,
       required: false,
+      placeholderCaps: true,
     };
   }
 
@@ -44,6 +45,7 @@ export default class TextInputView extends Component {
                 label="TextInput Label"
                 name="TextInputName"
                 placeholder="TextInput Placeholder"
+                placeholderCaps={this.state.placeholderCaps}
                 onChange={e => this.setState({inputValue: e.target.value})}
                 value={this.state.inputValue}
                 onMouseOver={e => {console.log("mouseover!", e);}}
@@ -94,6 +96,15 @@ export default class TextInputView extends Component {
             />
             {" "}
             Obscured
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={this.state.placeholderCaps}
+              onChange={({target}) => this.setState({placeholderCaps: target.checked})}
+            />
+            {" "}
+            Placeholder Caps
           </label>
         </Example>
 
@@ -165,6 +176,13 @@ export default class TextInputView extends Component {
               name: "placeholder",
               type: "Node",
               description: "Placeholder node for input",
+              optional: true,
+            },
+            {
+              name: "placeholderCaps",
+              type: "Bool",
+              description: "Determines if placeholder value is capitalized or not",
+              defaultValue: "true",
               optional: true,
             },
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import * as PropTypes from "prop-types";
 import classnames from "classnames";
 import _ from "lodash";
-import { relativeTimeThreshold } from "../../node_modules/moment";
 
 require("./TextInput.less");
 
@@ -63,9 +62,7 @@ export class TextInput extends React.Component {
     // placeholder shown with caps
     if (!this.props.value && this.props.placeholder && this.props.placeholderCaps) {
       wrapperClass += " TextInput--placeholder-shown";
-    }
-
-    else if(!this.props.value && this.props.placeholder) {
+    } else if (!this.props.value && this.props.placeholder) {
       wrapperClass += " TextInput--placeholder-shown-no-caps";
     }
 

--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -2,10 +2,15 @@ import React from "react";
 import * as PropTypes from "prop-types";
 import classnames from "classnames";
 import _ from "lodash";
+import { relativeTimeThreshold } from "../../node_modules/moment";
 
 require("./TextInput.less");
 
 export class TextInput extends React.Component {
+  static defaultProps = {
+    placeholderCaps: true,
+  }
+
   constructor(props) {
     super(props);
     this.state = {inFocus: false, hidden: true};
@@ -55,9 +60,13 @@ export class TextInput extends React.Component {
       wrapperClass += " TextInput--inFocus";
     }
 
-    // placeholder shown
-    if (!this.props.value && this.props.placeholder) {
+    // placeholder shown with caps
+    if (!this.props.value && this.props.placeholder && this.props.placeholderCaps) {
       wrapperClass += " TextInput--placeholder-shown";
+    }
+
+    else if(!this.props.value && this.props.placeholder) {
+      wrapperClass += " TextInput--placeholder-shown-no-caps";
     }
 
     // note on the upper right corner
@@ -123,6 +132,7 @@ TextInput.propTypes = {
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
   placeholder: PropTypes.node,
+  placeholderCaps: PropTypes.bool,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   type: PropTypes.string,

--- a/src/TextInput/TextInput.less
+++ b/src/TextInput/TextInput.less
@@ -65,6 +65,17 @@
     }
   }
 
+  &.TextInput--placeholder-shown-no-caps {
+    label { opacity: 0 !important; }
+    .TextInput--input {
+      .text--small;
+      .padding--top--xs;
+      line-height: @size_2xl;
+      min-height: @size_2xl;
+      color: @neutral_dark_gray;
+    }
+  }
+
   &.TextInput--hasError {
     box-shadow: inset @size_2xs 0 @alert_red;
     transition: box-shadow .25s ease-out;

--- a/src/TextInput/TextInput.less
+++ b/src/TextInput/TextInput.less
@@ -55,6 +55,7 @@
 
   &.TextInput--placeholder-shown {
     label { opacity: 0 !important; }
+
     .TextInput--input {
       .text--small;
       .text--caps;
@@ -67,6 +68,7 @@
 
   &.TextInput--placeholder-shown-no-caps {
     label { opacity: 0 !important; }
+
     .TextInput--input {
       .text--small;
       .padding--top--xs;


### PR DESCRIPTION
**Overview:**
We have wondered why make Placeholder text is all-caps. Well, we still don't know the real answer, but now it is at least an option. A new optional prop is passable to the TextInput that determines if all text will be all-caps. The default value is still true so retroactively, nothing changes, but future uses of Placeholder in TextInput will allow you to specify if the value should be all-caps or not

**Screenshots/GIFs:**
https://cl.ly/35170v050y1n

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
