### PR TITLE
Updated InfoPanel to support hiding title

### DIFF
--- a/docs/components/InfoPanelView.jsx
+++ b/docs/components/InfoPanelView.jsx
@@ -18,6 +18,7 @@ export default class InfoPanelView extends React.Component {
       inputValue: "",
       collapsible: false,
       footer: false,
+      hideTitle: false,
     };
   }
 
@@ -39,7 +40,7 @@ export default class InfoPanelView extends React.Component {
 
   render() {
     const {cssClass} = InfoPanelView;
-    const {collapsible, footer} = this.state;
+    const {collapsible, footer, hideTitle} = this.state;
 
     return (
       <View className={cssClass.CONTAINER} title="InfoPanel">
@@ -48,6 +49,7 @@ export default class InfoPanelView extends React.Component {
           <InfoPanel title="Info Panel Title"
             collapsible={collapsible}
             footer={footer ? "footer content" : null}
+            hideTitle={hideTitle}
           >
             <InfoPanelColumn>
               <p>column 1 content</p>
@@ -60,6 +62,7 @@ export default class InfoPanelView extends React.Component {
           <FlexBox className={cssClass.CONFIG_CONTAINER}>
             {this._renderCheckbox("collapsible")}
             {this._renderCheckbox("footer")}
+            {this._renderCheckbox("hideTitle")}
           </FlexBox>
          </Example>
 
@@ -86,6 +89,13 @@ export default class InfoPanelView extends React.Component {
               name: "title",
               type: "String",
               description: "The InfoPanel title",
+              optional: true,
+            },
+            {
+              name: "hideTitle",
+              type: "Boolean",
+              description: "Determines if the title header should be hidden. No effect if collapsible is true",
+              optional: true,
             },
             {
               name: "collapsible",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.30.5",
+  "version": "0.30.6",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/InfoPanel/InfoPanel.jsx
+++ b/src/InfoPanel/InfoPanel.jsx
@@ -22,19 +22,18 @@ export default class InfoPanel extends Component {
   }
 
   render() {
-    const {children, className, title, footer, collapsible, defaultOpen} = this.props;
+    const {children, className, hideTitle, title, footer, collapsible, defaultOpen} = this.props;
     const {isCollapsed} = this.state;
     let {collapseArrow} = this.state;
     const {cssClass} = InfoPanel;
-
     if (!collapsible) {
       return (
         <div className={classnames(cssClass.CONTAINER, className)}>
-          <div className={cssClass.HEADER}>
+          {!hideTitle && <div className={cssClass.HEADER}>
             <h4 className={cssClass.TITLE}>
               {title}
             </h4>
-          </div>
+          </div>}
           <div className={cssClass.CONTENT}>
             {children}
           </div>
@@ -83,7 +82,8 @@ export default class InfoPanel extends Component {
 InfoPanel.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
-  title: PropTypes.node.isRequired,
+  title: PropTypes.node,
+  hideTitle: PropTypes.bool,
   footer: PropTypes.node,
   collapsible: PropTypes.bool,
   defaultOpen: PropTypes.bool,


### PR DESCRIPTION
**Jira:**

**Overview:**
Updated InfoPanel definition to have the option for a title to be hidden.

**Screenshots/GIFs:**
<img width="1108" alt="screen shot 2018-08-21 at 11 34 58 pm" src="https://user-images.githubusercontent.com/26425483/44446783-f8a66080-a59a-11e8-8e87-737e3b60f1b0.png">
<img width="1108" alt="screen shot 2018-08-21 at 11 34 51 pm" src="https://user-images.githubusercontent.com/26425483/44446785-f8a66080-a59a-11e8-8cbf-d211b4015364.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
