### PR TITLE
Don't let other elements poke through the calendar popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-autosize-textarea": "^3.0.1",
     "react-bootstrap": "0.32.1",
     "react-copy-to-clipboard": "^4.2.1",
-    "react-datepicker": "1.2.2",
+    "react-datepicker": "^1.6.0",
     "react-datetime": "^2.14.0",
     "react-dropzone": "^3.11.0",
     "react-fontawesome": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.30.7",
+  "version": "0.30.8",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -101,6 +101,7 @@ export default class DateInput extends React.Component {
             ref="input"
             required={this.props.required}
             selected={this.props.value}
+            popperClassName="DatePicker--Popper"
           />
         }
       </div>

--- a/src/DateInput/DateInput.less
+++ b/src/DateInput/DateInput.less
@@ -4,6 +4,7 @@
 @import (reference) "../less/type-size";
 @import (reference) "../less/type-utilities";
 @import (reference) "../less/spacing";
+@import (reference) "../less/z-index";
 @import "~react-datetime/css/react-datetime.css";
 
 .DateInput {
@@ -97,4 +98,8 @@
     color: @neutral_black;
     background: transparent;
   }
+}
+
+.DatePicker--Popper.react-datepicker-popper {
+  .zIndex--3;
 }


### PR DESCRIPTION
**Jira:**
http://clever.atlassian.net/browse/soc-1767

**Overview:**
`react-popper` is used by `react-datepicker` to render the calendar popup in the `DateInput` component. [The z-index is set to 1](https://github.com/Hacker0x01/react-datepicker/blob/d25d0d7eb617800e943ef749d7f31cd6daec6fed/src/stylesheets/datepicker.scss#L43), so other components with higher z-index values can poke through. `SegmentedControl` uses z-index 2 for example. This change sets a higher z-index to make sure that the calendar popup is always in the forefront of the page.

I used `.zIndex--3` which is actually 300. Is this preferable over setting the z-index to 3?
https://github.com/Clever/components/blob/master/src/less/z-index.less

**Screenshots/GIFs:**
<img width="732" alt="screen shot 2018-08-30 at 8 04 35 pm" src="https://user-images.githubusercontent.com/32328921/44892526-2f1a6480-ac9a-11e8-986d-70d08c3fc281.png">
<img width="800" alt="screen shot 2018-08-30 at 8 04 23 pm" src="https://user-images.githubusercontent.com/32328921/44892527-2f1a6480-ac9a-11e8-9673-6964d0243630.png">




**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
