### PR TITLE
Optionally hide labels on the FileInput component

### DIFF
--- a/docs/components/FileInputView.jsx
+++ b/docs/components/FileInputView.jsx
@@ -5,6 +5,28 @@ import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import {FileInput} from "src";
 
+import "./FileInputView.less";
+
+function isError() {
+  return false;
+}
+
+function storeFn(_file, { progress, success }) {
+  let currentProgress = 0;
+  progress(currentProgress);
+
+  const interval = setInterval(() => {
+    currentProgress += 2;
+
+    if (currentProgress < 100) {
+      progress(currentProgress);
+    } else {
+      clearInterval(interval);
+      success();
+    }
+  }, 32);
+}
+
 export default function FileInputView() {
   const {cssClass} = FileInputView;
 
@@ -25,7 +47,7 @@ export default function FileInputView() {
                   if (progressPercent !== 100) {
                     progressPercent += 5;
                     progress(progressPercent);
-                  } else if (this.state.error) {
+                  } else if (isError()) {
                     error("An error occurred");
                     clearInterval(intervalID);
                   } else {
@@ -44,6 +66,21 @@ export default function FileInputView() {
             <li><code>progress</code> - Called during upload with a number between 0-100 representing the % completed</li>
           </ul>
         </div>
+      </Example>
+
+      <Example>
+        <p>
+          To display a <code>FileInput</code> component without any text labels
+          pass in the <code>displayLabels=&#123;false&#125;</code> option.
+        </p>
+
+        <ExampleCode className="ExampleCode">
+          <FileInput
+            className="FileInputView--icon-only"
+            displayLabels={false}
+            store={storeFn}
+          />
+        </ExampleCode>
       </Example>
 
       <PropDocumentation
@@ -65,6 +102,7 @@ export default function FileInputView() {
             name: "label",
             type: "String",
             description: "Sets the label of the file input",
+            optional: true
           },
           {
             name: "store",
@@ -72,6 +110,13 @@ export default function FileInputView() {
             description: "Function to be called when the user has seleceted a file to be uploaded",
             defaultValue: "False",
           },
+          {
+            name: "displayLabels",
+            type: "Boolean",
+            description: "Display text labels inside of the component",
+            defaultValue: "true",
+            optional: true
+          }
         ]}
         className={cssClass.PROPS}
         title="FileInput"

--- a/docs/components/FileInputView.jsx
+++ b/docs/components/FileInputView.jsx
@@ -71,14 +71,14 @@ export default function FileInputView() {
       <Example>
         <p>
           To display a <code>FileInput</code> component without any text labels
-          pass in the <code>displayLabels=&#123;false&#125;</code> option.
+          pass in the <code>iconOnly</code> option.
         </p>
 
         <ExampleCode className="ExampleCode">
           <FileInput
             className="FileInputView--icon-only"
-            displayLabels={false}
             store={storeFn}
+            iconOnly
           />
         </ExampleCode>
       </Example>
@@ -111,10 +111,10 @@ export default function FileInputView() {
             defaultValue: "False",
           },
           {
-            name: "displayLabels",
+            name: "iconOnly",
             type: "Boolean",
-            description: "Display text labels inside of the component",
-            defaultValue: "true",
+            description: "Render a FileInput component with only an icon",
+            defaultValue: "false",
             optional: true,
           },
         ]}

--- a/docs/components/FileInputView.jsx
+++ b/docs/components/FileInputView.jsx
@@ -11,7 +11,7 @@ function isError() {
   return false;
 }
 
-function storeFn(_file, { progress, success }) {
+function storeFn(_file, {progress, success}) {
   let currentProgress = 0;
   progress(currentProgress);
 
@@ -102,7 +102,7 @@ export default function FileInputView() {
             name: "label",
             type: "String",
             description: "Sets the label of the file input",
-            optional: true
+            optional: true,
           },
           {
             name: "store",
@@ -115,8 +115,8 @@ export default function FileInputView() {
             type: "Boolean",
             description: "Display text labels inside of the component",
             defaultValue: "true",
-            optional: true
-          }
+            optional: true,
+          },
         ]}
         className={cssClass.PROPS}
         title="FileInput"

--- a/docs/components/FileInputView.less
+++ b/docs/components/FileInputView.less
@@ -1,0 +1,6 @@
+@import (reference) "~less/index";
+
+.FileInputView--icon-only {
+  height: @size_3xl;
+  width: @size_3xl;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.30.8",
+  "version": "0.30.9",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FileInput/FileInput.jsx
+++ b/src/FileInput/FileInput.jsx
@@ -54,7 +54,28 @@ UploadingIcon.propTypes = {
   percent: PropTypes.number.isRequired,
 };
 
+function renderLabel(text) {
+  return <label className="FileInput--Label">{text}</label>;
+}
+
+function renderMessage(text, selected) {
+  const classes = {
+    ["FileInput--Text"]: true,
+    ["FileInput--Text--selected"]: selected
+  };
+
+  return (
+    <FlexItem className={classnames(classes)} grow>
+      {text}
+    </FlexItem>
+  );
+}
+
 export class FileInput extends React.Component {
+  static defaultProps = {
+    displayLabels: true
+  }
+
   constructor(props) {
     super(props);
     this.state = {
@@ -95,9 +116,12 @@ export class FileInput extends React.Component {
   }
 
   render() {
+    const { displayLabels, label } = this.props;
+    const dropzoneStyle = displayLabels ? {} : { display: "inline-block" };
+
     return (<Dropzone
       accept={this.props.accept}
-      style={{}}
+      style={dropzoneStyle}
       multiple={false}
       onDropAccepted={this.onDropAccepted}
       onDropRejected={this.onDropRejected}
@@ -121,11 +145,9 @@ export class FileInput extends React.Component {
         message = this.state.filename;
         selected = true;
       }
-      return (<FlexBox className={classnames("FileInput", this.props.className)} grow>
-        {selected && <label className="FileInput--Label">{this.props.label}</label>}
-        <FlexItem className={`FileInput--Text ${selected ? "FileInput--Text--selected" : ""}`} grow>
-          {message}
-        </FlexItem>
+      return (<FlexBox className={classnames("FileInput", this.props.className)}>
+        {displayLabels && selected && renderLabel(label)}
+        {displayLabels && renderMessage(message, selected)}
         {icon}
       </FlexBox>);
     }}
@@ -135,7 +157,8 @@ export class FileInput extends React.Component {
 
 FileInput.propTypes = {
   className: PropTypes.string,
-  label: PropTypes.string.isRequired,
+  displayLabels: PropTypes.bool,
+  label: PropTypes.string,
   store: PropTypes.func.isRequired,
   accept: PropTypes.string,
 };

--- a/src/FileInput/FileInput.jsx
+++ b/src/FileInput/FileInput.jsx
@@ -73,7 +73,7 @@ function renderMessage(text, selected) {
 
 export class FileInput extends React.Component {
   static defaultProps = {
-    displayLabels: true,
+    iconOnly: false,
   }
 
   constructor(props) {
@@ -116,8 +116,8 @@ export class FileInput extends React.Component {
   }
 
   render() {
-    const {displayLabels, label} = this.props;
-    const dropzoneStyle = displayLabels ? {} : {display: "inline-block"};
+    const {iconOnly, label} = this.props;
+    const dropzoneStyle = iconOnly ? {display: "inline-block"} : {};
 
     return (<Dropzone
       accept={this.props.accept}
@@ -146,8 +146,8 @@ export class FileInput extends React.Component {
         selected = true;
       }
       return (<FlexBox className={classnames("FileInput", this.props.className)}>
-        {displayLabels && selected && renderLabel(label)}
-        {displayLabels && renderMessage(message, selected)}
+        {!iconOnly && selected && renderLabel(label)}
+        {!iconOnly && renderMessage(message, selected)}
         {icon}
       </FlexBox>);
     }}
@@ -157,7 +157,7 @@ export class FileInput extends React.Component {
 
 FileInput.propTypes = {
   className: PropTypes.string,
-  displayLabels: PropTypes.bool,
+  iconOnly: PropTypes.bool,
   label: PropTypes.string,
   store: PropTypes.func.isRequired,
   accept: PropTypes.string,

--- a/src/FileInput/FileInput.jsx
+++ b/src/FileInput/FileInput.jsx
@@ -61,7 +61,7 @@ function renderLabel(text) {
 function renderMessage(text, selected) {
   const classes = {
     ["FileInput--Text"]: true,
-    ["FileInput--Text--selected"]: selected
+    ["FileInput--Text--selected"]: selected,
   };
 
   return (
@@ -73,7 +73,7 @@ function renderMessage(text, selected) {
 
 export class FileInput extends React.Component {
   static defaultProps = {
-    displayLabels: true
+    displayLabels: true,
   }
 
   constructor(props) {
@@ -116,8 +116,8 @@ export class FileInput extends React.Component {
   }
 
   render() {
-    const { displayLabels, label } = this.props;
-    const dropzoneStyle = displayLabels ? {} : { display: "inline-block" };
+    const {displayLabels, label} = this.props;
+    const dropzoneStyle = displayLabels ? {} : {display: "inline-block"};
 
     return (<Dropzone
       accept={this.props.accept}

--- a/src/FileInput/FileInput.less
+++ b/src/FileInput/FileInput.less
@@ -11,7 +11,6 @@
   cursor: pointer;
   height: @size_4xl;
   position: relative;
-  width: 100%;
 }
 
 .FileInput--Label {
@@ -25,6 +24,10 @@
 
 .FileInput--Text, .FileInput--Icon {
   .alignSelf(center);
+}
+
+.FileInput--Icon {
+  margin: auto;
 }
 
 .FileInput--Text--selected {


### PR DESCRIPTION
**Overview:**

We would like to reuse the functionality of the `FileInput` component
without having the labels present.

This adds a new option `displayLabels` which can be set to `false` to
hide the labels on the `FileInput` component. The default value of
`displayLabels` is `true`. This allows all of the existing code using
the `FileInput` component to remain unchanged.

**Screenshots/GIFs:**

![upload-component-no-labels](https://user-images.githubusercontent.com/1817/45063429-cb5db600-b062-11e8-84c1-328eb206259f.gif)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
