### PR TITLE
Textarea default rows

### DIFF
--- a/docs/components/TextAreaView.jsx
+++ b/docs/components/TextAreaView.jsx
@@ -229,6 +229,7 @@ export default class TextAreaView extends React.Component {
               type: "number",
               description: "The number of rows to start the textarea with",
               optional: true,
+              defaultValue: 1,
             },
           ]}
         />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.30.10",
+  "version": "0.31.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextArea/TextArea.jsx
+++ b/src/TextArea/TextArea.jsx
@@ -82,7 +82,7 @@ export class TextArea extends React.Component {
       inputNote = <span className="TextArea--error">{this.props.error}</span>;
     }
 
-    const props = {
+    const textAreaProps = {
       className: "TextArea--input",
       disabled: this.props.disabled,
       maxLength: this.props.maxLength,
@@ -97,20 +97,20 @@ export class TextArea extends React.Component {
       required: this.props.required,
       spellCheck: this.props.spellCheck,
       value: this.props.value,
-      rows: this.props.rows || 1,
+      rows: this.props.rows,
     };
 
     let rows = this.props.rows;
     if (this.props.placeholder) {
       // Need to add another row for autoGrow since it seems to collapse in a way that conflicts with the placeholder
       // margin
-      rows = this.props.rows + 1;
+      rows++;
     }
 
-    let textarea = <textarea {...props} rows={rows} />;
+    let textarea = <textarea {...textAreaProps} rows={rows} />;
     if (this.props.autoResize) {
       rows++;
-      textarea = <TextareaAutosize {...props} rows={rows} />;
+      textarea = <TextareaAutosize {...textAreaProps} rows={rows} />;
     }
 
     return (
@@ -144,4 +144,8 @@ TextArea.propTypes = {
   className: PropTypes.string,
   autoResize: PropTypes.bool,
   rows: PropTypes.number,
+};
+
+TextArea.defaultProps = {
+  rows: 1,
 };

--- a/src/TextArea/TextArea.jsx
+++ b/src/TextArea/TextArea.jsx
@@ -104,12 +104,12 @@ export class TextArea extends React.Component {
     if (this.props.placeholder) {
       // Need to add another row for autoGrow since it seems to collapse in a way that conflicts with the placeholder
       // margin
-      rows++;
+      rows = this.props.rows + 1;
     }
 
     let textarea = <textarea {...textAreaProps} rows={rows} />;
     if (this.props.autoResize) {
-      rows++;
+      rows = this.props.rows + 1;
       textarea = <TextareaAutosize {...textAreaProps} rows={rows} />;
     }
 


### PR DESCRIPTION
Error from console:
![screenshot 2018-09-07 11 40 09](https://user-images.githubusercontent.com/13126257/45237446-92f0ee80-b293-11e8-89cb-c039782e74ed.png)

Stepping through old code:
![textarea-broken](https://user-images.githubusercontent.com/13126257/45237582-fb3fd000-b293-11e8-96f6-dae1af9d1d3d.gif)

Stepping through new code:
![textarea-fixed](https://user-images.githubusercontent.com/13126257/45237593-02ff7480-b294-11e8-85d2-b2a9e1931260.gif)

Verified that visual sizing of textarea is the same with the new code

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
