### PR TITLE
Add support for onClose() for AlertBox

### DIFF
--- a/docs/components/AlertBoxView.jsx
+++ b/docs/components/AlertBoxView.jsx
@@ -83,6 +83,13 @@ export default class AlertBoxView extends PureComponent {
               optional: true,
             },
             {
+              name: "onClose",
+              type: "Function",
+              description: "Called when user closes AlertBox",
+              defaultValue: "None",
+              optional: true,
+            },
+            {
               name: "children",
               type: "node",
               description: "Body",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AlertBox/AlertBox.jsx
+++ b/src/AlertBox/AlertBox.jsx
@@ -32,7 +32,11 @@ export default class AlertBox extends PureComponent {
   }
 
   closeBox() {
+    const {onClose} = this.props;
     this.setState({isOpen: false});
+    if (onClose) {
+      onClose();
+    }
   }
 
   render() {


### PR DESCRIPTION
**Overview:**
I'm working on a launchpad change where I want to function to be called when the user exits the alert box (to persist that action so we don't display the alert box on a new session). This change adds the `onClose` property to the AlertBox component.

**Screenshots/GIFs:**
![](https://cl.ly/411b0eb86527/Screen%20Recording%202018-09-11%20at%2002.20%20PM.gif)

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
