### PR TITLE
Fix documentation on Select component

### DIFF
--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -301,8 +301,8 @@ export default class SelectView extends Component {
             },
             {
               name: "value",
-              type: "String",
-              description: "Selected value. Must be updated by caller in the onChange",
+              type: "{label: string; value: string}",
+              description: "Selected option. Must be updated by caller in the onChange",
               optional: true,
             },
           ]}


### PR DESCRIPTION
**Overview:**
Our documentation of the value prop in `Select` is incorrect. It is an option object rather than a string.

**Testing:**
- [x] Unit tests
- Manual tests: N/A

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
