### PR TITLE
Datepicker popper placement

### DIFF
--- a/docs/components/DateInputView.jsx
+++ b/docs/components/DateInputView.jsx
@@ -177,6 +177,12 @@ export default class DateInputView extends Component {
               description: "Flag to switch to date time picker input",
               optional: true,
             },
+            {
+              name: "popperPlacement",
+              type: "string",
+              description: "Position of the pop-up calendar relative to the input.",
+              optional: true,
+            },
           ]}
         />
       </View>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -7,7 +7,24 @@ import ReactDateTime from "react-datetime";
 
 import "./DateInput.less";
 
+const popperPlacementPositions = {
+  BOTTOM: "bottom",
+  BOTTOM_END: "bottom-end",
+  BOTTOM_START: "bottom-start",
+  LEFT: "left",
+  LEFT_END: "left-end",
+  LEFT_START: "left-start",
+  RIGHT: "right",
+  RIGHT_END: "right-end",
+  RIGHT_START: "right-start",
+  TOP: "top",
+  TOP_END: "top-end",
+  TOP_START: "top-start",
+};
+
 export default class DateInput extends React.Component {
+  static popperPlacementPositions = popperPlacementPositions;
+
   constructor(props) {
     super(props);
     this.state = {inFocus: false};
@@ -133,5 +150,5 @@ DateInput.propTypes = {
   min: dateType,
   max: dateType,
   useTime: PropTypes.bool,
-  popperPlacement: PropTypes.string,
+  popperPlacement: PropTypes.oneOf(Object.values(popperPlacementPositions)),
 };

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -103,6 +103,7 @@ export default class DateInput extends React.Component {
             required={this.props.required}
             selected={this.props.value}
             popperClassName="DatePicker--Popper"
+            popperPlacement={this.props.popperPlacement}
           />
         }
       </div>
@@ -132,4 +133,5 @@ DateInput.propTypes = {
   min: dateType,
   max: dateType,
   useTime: PropTypes.bool,
+  popperPlacement: PropTypes.string,
 };


### PR DESCRIPTION
**Jira:**

**Overview:**
This change exposes a new prop called `popperPlacement` which allows the pop-up to be placed in different positions relative to the input element. The default behavior remains the same when `popperPlacement` is omitted.

Here are the options provided by the underlying `react-datepicker` component:
https://github.com/Hacker0x01/react-datepicker/blob/24349d0d8d8182dc66c8e605aedf792391e73586/src/popper_component.jsx#L6-L19

**Screenshots/GIFs:**
:(
<img width="1298" alt="screen shot 2018-09-14 at 3 26 29 pm" src="https://user-images.githubusercontent.com/32328921/45580009-1c2e9500-b841-11e8-8b57-5cdad43befa3.png">

:) `"top-start"`
<img width="1300" alt="screen shot 2018-09-14 at 3 47 26 pm" src="https://user-images.githubusercontent.com/32328921/45580018-31a3bf00-b841-11e8-9db8-24da51fb49a2.png">

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
