### PR TITLE
Fix multi panel modal bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MultiplePanelModals/MultiplePanelModals.jsx
+++ b/src/MultiplePanelModals/MultiplePanelModals.jsx
@@ -56,7 +56,7 @@ export class MultiplePanelModals extends React.Component {
 
     let rightButtonValue;
     if (rightButtonName) {
-      rightButtonValue = leftButtonName;
+      rightButtonValue = rightButtonName;
     } else if (isLastPanel) {
       rightButtonValue = "Done";
     } else {


### PR DESCRIPTION
**Overview:**
The MultiplePanelModals component was incorrectly using the `leftButtonName` prop to define the name of the right button, making the `rightButtonName` prop useless. This fixes the bug to make the component work as documented.

Docs already state the patched functionality, and component is not in use anywhere (yet) so no danger to production code. Tested locally to ensure right button can now be properly named.

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs __N/A__
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`) __N/A__
