### PR TITLE
Dont close modal if overridden

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.32.3",
+  "version": "0.33.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MultiplePanelModals/MultiplePanelModals.jsx
+++ b/src/MultiplePanelModals/MultiplePanelModals.jsx
@@ -102,7 +102,10 @@ export class MultiplePanelModals extends React.Component {
               onClick={() => {
                 rightButtonOnClick();
                 if (isLastPanel) {
-                  closeModal();
+                  if (!overrideOnClickRightButton) {
+                    closeModal();
+                  }
+                  return;
                 }
                 this.setState({currentPanel: this.state.currentPanel + 1});
               }}

--- a/src/MultiplePanelModals/MultiplePanelModals.jsx
+++ b/src/MultiplePanelModals/MultiplePanelModals.jsx
@@ -102,11 +102,10 @@ export class MultiplePanelModals extends React.Component {
               onClick={() => {
                 rightButtonOnClick();
                 if (isLastPanel) {
-                  if (!overrideOnClickRightButton) {
-                    closeModal();
-                  } else {
+                  if (overrideOnClickRightButton) {
                     return;
                   }
+                  closeModal();
                 }
                 this.setState({currentPanel: this.state.currentPanel + 1});
               }}

--- a/src/MultiplePanelModals/MultiplePanelModals.jsx
+++ b/src/MultiplePanelModals/MultiplePanelModals.jsx
@@ -104,8 +104,9 @@ export class MultiplePanelModals extends React.Component {
                 if (isLastPanel) {
                   if (!overrideOnClickRightButton) {
                     closeModal();
+                  } else {
+                    return;
                   }
-                  return;
                 }
                 this.setState({currentPanel: this.state.currentPanel + 1});
               }}


### PR DESCRIPTION
**Overview:**

Prior to this change, the `MultiplePanelModals` component would always run `closeModal` when the last button in the modal was clicked, even if an override function was provided for that button. This prevented doing input validations since clicking "Save" would always result in the modal closing rather than remaining open and showing potential errors. 

This change makes it so that we do not run `closeModal` if an override is provided. This of course has the trade off of forcing the override function to run `closeModal` itself. This shouldn't be too onerous since the component already needs `closeModal` to be provided as a prop.

This component is currently not in use in prod, so should not be dangerous to deploy (NB: goals uses a custom component that inherits from `Modal`, not this one: https://github.com/Clever/goals-components/blob/36a19efae445daa5dd3ab62f05475ce2d3128490/src/MultiplePanelModals/MultiplePanelModals.tsx).

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
