### PR TITLE
Making TextTruncate & RichText play nicely together

### DIFF
--- a/docs/components/TextTruncateView.jsx
+++ b/docs/components/TextTruncateView.jsx
@@ -29,7 +29,7 @@ export default class TextTruncateView extends React.PureComponent {
     showMoreLabel: "Show more",
     showLessLabel: "Show less",
     showLongText: true,
-    richText: false,
+    useRichText: false,
   };
 
   constructor(props) {
@@ -40,7 +40,7 @@ export default class TextTruncateView extends React.PureComponent {
   }
 
   render() {
-    const {maxCharsShown, showMoreLabel, showLessLabel, showLongText, richText} = this.state;
+    const {maxCharsShown, showMoreLabel, showLessLabel, showLongText, useRichText} = this.state;
 
     return (
       <View
@@ -66,7 +66,7 @@ export default class TextTruncateView extends React.PureComponent {
               maxCharsShown={maxCharsShown}
               showMoreLabel={showMoreLabel}
               showLessLabel={showLessLabel}
-              richText={richText}
+              useRichText={useRichText}
               text={showLongText ? this.longText : this.shortText}
             />
           </ExampleCode>
@@ -79,7 +79,7 @@ export default class TextTruncateView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const {showLongText, maxCharsShown, showMoreLabel, showLessLabel, richText} = this.state;
+    const {showLongText, maxCharsShown, showMoreLabel, showLessLabel, useRichText} = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -99,12 +99,12 @@ export default class TextTruncateView extends React.PureComponent {
           Rich text:
           <SegmentedControl
             className={cssClass.CONFIG_OPTIONS}
-            onSelect={value => this.setState({richText: value === "rich"})}
+            onSelect={value => this.setState({useRichText: value === "rich"})}
             options={[
               {content: "Rich", value: "rich"},
               {content: "Normal", value: "normal"},
             ]}
-            value={richText ? "rich" : "normal"}
+            value={useRichText ? "rich" : "normal"}
           />
         </div>
         <div className={cssClass.CONFIG}>
@@ -182,7 +182,7 @@ export default class TextTruncateView extends React.PureComponent {
             optional: true,
           },
           {
-            name: "richText",
+            name: "useRichText",
             type: "boolean",
             description: "Whether to render the text via the RichText component",
             defaultValue: "false",

--- a/docs/components/TextTruncateView.jsx
+++ b/docs/components/TextTruncateView.jsx
@@ -29,17 +29,18 @@ export default class TextTruncateView extends React.PureComponent {
     showMoreLabel: "Show more",
     showLessLabel: "Show less",
     showLongText: true,
+    richText: false,
   };
 
   constructor(props) {
     super(props);
 
     this.shortText = loremIpsum({count: 7, units: "words"});
-    this.longText = loremIpsum({count: 25, units: "sentences"});
+    this.longText = loremIpsum({count: 4, units: "paragraphs"});
   }
 
   render() {
-    const {maxCharsShown, showMoreLabel, showLessLabel, showLongText} = this.state;
+    const {maxCharsShown, showMoreLabel, showLessLabel, showLongText, richText} = this.state;
 
     return (
       <View
@@ -65,6 +66,7 @@ export default class TextTruncateView extends React.PureComponent {
               maxCharsShown={maxCharsShown}
               showMoreLabel={showMoreLabel}
               showLessLabel={showLessLabel}
+              richText={richText}
               text={showLongText ? this.longText : this.shortText}
             />
           </ExampleCode>
@@ -77,7 +79,7 @@ export default class TextTruncateView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const {showLongText, maxCharsShown, showMoreLabel, showLessLabel} = this.state;
+    const {showLongText, maxCharsShown, showMoreLabel, showLessLabel, richText} = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -91,6 +93,18 @@ export default class TextTruncateView extends React.PureComponent {
               {content: "Long", value: "long"},
             ]}
             value={showLongText ? "long" : "short"}
+          />
+        </div>
+        <div className={cssClass.CONFIG}>
+          Rich text:
+          <SegmentedControl
+            className={cssClass.CONFIG_OPTIONS}
+            onSelect={value => this.setState({richText: value === "rich"})}
+            options={[
+              {content: "Rich", value: "rich"},
+              {content: "Normal", value: "normal"},
+            ]}
+            value={richText ? "rich" : "normal"}
           />
         </div>
         <div className={cssClass.CONFIG}>
@@ -165,6 +179,13 @@ export default class TextTruncateView extends React.PureComponent {
             type: "number",
             description: "Number of characters to show before truncation",
             defaultValue: 300,
+            optional: true,
+          },
+          {
+            name: "richText",
+            type: "boolean",
+            description: "Whether to render the text via the RichText component",
+            defaultValue: "false",
             optional: true,
           },
         ]}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/RichText/RichText.jsx
+++ b/src/RichText/RichText.jsx
@@ -3,8 +3,13 @@ import * as PropTypes from "prop-types";
 import Linkify from "react-linkify";
 
 export default function RichText(props) {
+  const lines = props.text.split("\n");
+
   return (<Linkify properties={{target: "_blank"}}>
-    {props.text.split("\n").map((item, key) => <span key={key}>{item}<br /></span>)}
+    {lines.map((item, index) => <span key={index}>
+      {item}
+      {(index < lines.length - 1) && <br />}
+    </span>)}
   </Linkify>);
 }
 

--- a/src/TextTruncate/TextTruncate.tsx
+++ b/src/TextTruncate/TextTruncate.tsx
@@ -72,19 +72,18 @@ export default class TextTruncate extends React.PureComponent {
           }
         </div>
       );
-    } else {
-      return (
-        <div>
-          {truncated ?
-            <div className={classnames(cssClass.CONTAINER, className)}>
-              {this.truncate(text)}… <Button type="linkPlain" onClick={this.toggleTruncation} value={showMoreLabel} />
-            </div> :
-            <div className={classnames(cssClass.CONTAINER, className)}>
-              {text} <Button type="linkPlain" onClick={(e) => this.toggleTruncation(e)} value={showLessLabel} />
-            </div>
-          }
-        </div>
-      );
     }
+    return (
+      <div>
+        {truncated ?
+          <div className={classnames(cssClass.CONTAINER, className)}>
+            {this.truncate(text)}… <Button type="linkPlain" onClick={this.toggleTruncation} value={showMoreLabel} />
+          </div> :
+          <div className={classnames(cssClass.CONTAINER, className)}>
+            {text} <Button type="linkPlain" onClick={(e) => this.toggleTruncation(e)} value={showLessLabel} />
+          </div>
+        }
+      </div>
+    );
   }
 }

--- a/src/TextTruncate/TextTruncate.tsx
+++ b/src/TextTruncate/TextTruncate.tsx
@@ -3,6 +3,7 @@ import * as PropTypes from "prop-types";
 import * as React from "react";
 
 import {Button} from "../Button/Button";
+import RichText from "../RichText/RichText";
 
 const propTypes = {
   className: PropTypes.string,
@@ -11,12 +12,14 @@ const propTypes = {
   showLessLabel: PropTypes.string,
   lines: PropTypes.number,
   maxCharsShown: PropTypes.number,
+  richText: PropTypes.bool,
 };
 
 const defaultProps = {
   maxCharsShown: 300,
   showMoreLabel: "Show more",
   showLessLabel: "Show less",
+  richText: false,
 };
 
 const cssClass = {
@@ -47,26 +50,41 @@ export default class TextTruncate extends React.PureComponent {
   }
 
   render() {
-    const {className, text, showMoreLabel, showLessLabel, maxCharsShown} = this.props;
+    const {className, text, showMoreLabel, showLessLabel, maxCharsShown, richText} = this.props;
     const {truncated} = this.state;
 
     if (text.length < maxCharsShown) {
       return (<div className={classnames(cssClass.CONTAINER, className)}>
-        {text}
+        {richText ? <RichText text={text} /> : text}
       </div>);
     }
 
-    return (
-      <div>
-        {truncated ?
-          <div className={classnames(cssClass.CONTAINER, className)}>
-            {this.truncate(text)} ... <Button type="linkPlain" onClick={this.toggleTruncation} value={showMoreLabel} />
-          </div> :
-          <div className={classnames(cssClass.CONTAINER, className)}>
-            {text} <Button type="linkPlain" onClick={(e) => this.toggleTruncation(e)} value={showLessLabel} />
-          </div>
-        }
-      </div>
-    );
+    if (richText) {
+      return (
+        <div>
+          {truncated ?
+            <div className={classnames(cssClass.CONTAINER, className)}>
+              <RichText text={`${this.truncate(text)}…`} /> <Button type="linkPlain" onClick={this.toggleTruncation} value={showMoreLabel} />
+            </div> :
+            <div className={classnames(cssClass.CONTAINER, className)}>
+              <RichText text={text} /> <Button type="linkPlain" onClick={(e) => this.toggleTruncation(e)} value={showLessLabel} />
+            </div>
+          }
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          {truncated ?
+            <div className={classnames(cssClass.CONTAINER, className)}>
+              {this.truncate(text)}… <Button type="linkPlain" onClick={this.toggleTruncation} value={showMoreLabel} />
+            </div> :
+            <div className={classnames(cssClass.CONTAINER, className)}>
+              {text} <Button type="linkPlain" onClick={(e) => this.toggleTruncation(e)} value={showLessLabel} />
+            </div>
+          }
+        </div>
+      );
+    }
   }
 }

--- a/src/TextTruncate/TextTruncate.tsx
+++ b/src/TextTruncate/TextTruncate.tsx
@@ -12,14 +12,14 @@ const propTypes = {
   showLessLabel: PropTypes.string,
   lines: PropTypes.number,
   maxCharsShown: PropTypes.number,
-  richText: PropTypes.bool,
+  useRichText: PropTypes.bool,
 };
 
 const defaultProps = {
   maxCharsShown: 300,
   showMoreLabel: "Show more",
   showLessLabel: "Show less",
-  richText: false,
+  useRichText: false,
 };
 
 const cssClass = {
@@ -50,40 +50,20 @@ export default class TextTruncate extends React.PureComponent {
   }
 
   render() {
-    const {className, text, showMoreLabel, showLessLabel, maxCharsShown, richText} = this.props;
+    const {className, text, showMoreLabel, showLessLabel, maxCharsShown, useRichText} = this.props;
     const {truncated} = this.state;
 
     if (text.length < maxCharsShown) {
       return (<div className={classnames(cssClass.CONTAINER, className)}>
-        {richText ? <RichText text={text} /> : text}
+        {useRichText ? <RichText text={text} /> : text}
       </div>);
     }
 
-    if (richText) {
-      return (
-        <div>
-          {truncated ?
-            <div className={classnames(cssClass.CONTAINER, className)}>
-              <RichText text={`${this.truncate(text)}…`} /> <Button type="linkPlain" onClick={this.toggleTruncation} value={showMoreLabel} />
-            </div> :
-            <div className={classnames(cssClass.CONTAINER, className)}>
-              <RichText text={text} /> <Button type="linkPlain" onClick={(e) => this.toggleTruncation(e)} value={showLessLabel} />
-            </div>
-          }
-        </div>
-      );
-    }
-    return (
-      <div>
-        {truncated ?
-          <div className={classnames(cssClass.CONTAINER, className)}>
-            {this.truncate(text)}… <Button type="linkPlain" onClick={this.toggleTruncation} value={showMoreLabel} />
-          </div> :
-          <div className={classnames(cssClass.CONTAINER, className)}>
-            {text} <Button type="linkPlain" onClick={(e) => this.toggleTruncation(e)} value={showLessLabel} />
-          </div>
-        }
-      </div>
-    );
+    const displayText = truncated ? `${this.truncate(text)}…` : text;
+    return (<div className={classnames(cssClass.CONTAINER, className)}>
+      { useRichText ? <RichText text={displayText} /> : displayText }
+      {" "}
+      <Button type="linkPlain" onClick={this.toggleTruncation} value={truncated ? showMoreLabel : showLessLabel} />
+    </div>);
   }
 }


### PR DESCRIPTION
**Jira:**
Blocker of https://clever.atlassian.net/browse/DISC-162

**Overview:**
Also fixed a bug with RichText where it would add an extra, final
newline. Also fixed a small nit with TextTruncate so that it uses the
ellipsis character, not three periods.

**Screenshots/GIFs:**
![truncate](https://user-images.githubusercontent.com/1316859/46324420-3c33b780-c5a8-11e8-993f-1ec4482023d9.gif)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [X] Chrome
  - [X] Safari
  - [X] IE10 (via browserstack)

**Roll Out:**
- Before merging:
  - [X] Updated docs
  - [X] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
