### PR TITLE
use portals for the modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.33.3",
+  "version": "0.33.4",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as PropTypes from "prop-types";
 import classnames from "classnames";
 import FocusTrap from "focus-trap-react";
+import reactDom from "react-dom";
 
 require("./Modal.less");
 
@@ -64,6 +65,9 @@ export class Modal extends React.Component {
       modal = <FocusTrap>{modalContent}</FocusTrap>;
     } else {
       modal = modalContent;
+    }
+    if (reactDom.createPortal) {
+      return reactDom.createPortal(modal, document.body);
     }
     return modal;
   }


### PR DESCRIPTION
Use portals for the modal so it won't inherit parent styles. 

Sadly components still needs to support React 15 (some consumers haven't updated is what I hear). As such do it in a backwards compatible way. 

Is this a smart way to do this? Does this make sense? Unclear. 