### PR TITLE
pass className and customIcon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.33.4",
+  "version": "0.33.5",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FileInput/FileInput.jsx
+++ b/src/FileInput/FileInput.jsx
@@ -74,6 +74,7 @@ function renderMessage(text, selected) {
 export class FileInput extends React.Component {
   static defaultProps = {
     iconOnly: false,
+    className: "",
   }
 
   constructor(props) {
@@ -121,6 +122,7 @@ export class FileInput extends React.Component {
 
     return (<Dropzone
       accept={this.props.accept}
+      className={this.props.className}
       style={dropzoneStyle}
       multiple={false}
       onDropAccepted={this.onDropAccepted}
@@ -145,6 +147,9 @@ export class FileInput extends React.Component {
         message = this.state.filename;
         selected = true;
       }
+      if (this.props.customIcon) {
+        icon = this.props.customIcon;
+      }
       return (<FlexBox className={classnames("FileInput", this.props.className)}>
         {!iconOnly && selected && renderLabel(label)}
         {!iconOnly && renderMessage(message, selected)}
@@ -157,6 +162,7 @@ export class FileInput extends React.Component {
 
 FileInput.propTypes = {
   className: PropTypes.string,
+  customIcon: PropTypes.func,
   iconOnly: PropTypes.bool,
   label: PropTypes.string,
   store: PropTypes.func.isRequired,


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/IL-812

**Overview:**
Pass in `className` to the `<DropZone>` in FileInput.
Optional `customIcon` prop to override FileInput stateful icons.

**Screenshots/GIFs:**

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
