### PR TITLE
fix customIcon propType

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FileInput/FileInput.jsx
+++ b/src/FileInput/FileInput.jsx
@@ -122,7 +122,7 @@ export class FileInput extends React.Component {
 
     return (<Dropzone
       accept={this.props.accept}
-      className={this.props.className}
+      className={this.props.dropzoneClass}
       style={dropzoneStyle}
       multiple={false}
       onDropAccepted={this.onDropAccepted}
@@ -162,7 +162,8 @@ export class FileInput extends React.Component {
 
 FileInput.propTypes = {
   className: PropTypes.string,
-  customIcon: PropTypes.object,
+  customIcon: PropTypes.node,
+  dropzoneClass: PropTypes.string,
   iconOnly: PropTypes.bool,
   label: PropTypes.string,
   store: PropTypes.func.isRequired,

--- a/src/FileInput/FileInput.jsx
+++ b/src/FileInput/FileInput.jsx
@@ -162,7 +162,7 @@ export class FileInput extends React.Component {
 
 FileInput.propTypes = {
   className: PropTypes.string,
-  customIcon: PropTypes.func,
+  customIcon: PropTypes.object,
   iconOnly: PropTypes.bool,
   label: PropTypes.string,
   store: PropTypes.func.isRequired,


### PR DESCRIPTION
**Jira:**

**Overview:**
customIcon is a react node, which is an object not a function.

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
