### PR TITLE
Updates dependencies to pass npm audit, bumps version to 0.35.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
     "classnames": "^2.2.5",
     "core-js": "^2.4.1",
     "focus-trap-react": "^3.0.4",
-    "less": "^2.6.1",
+    "less": "^3.8.1",
     "lodash": "^4.14.1",
     "moment": "^2.18.1",
     "numeral": "^2.0.4",
@@ -82,7 +82,7 @@
     "jsdom": "^8.4.0",
     "jsdom-global": "^1.7.0",
     "jsx-loader": "^0.13.2",
-    "less-loader": "^2.2.3",
+    "less-loader": "^4.1.0",
     "lorem-ipsum": "^1.0.3",
     "mocha": "^2.4.5",
     "postcss-loader": "^1.1.1",


### PR DESCRIPTION
**Jira:**
SEC-730

**Overview:**
`npm audit` returns several vulnerable dependencies.

I ran `npm audit fix` and `npm audit fix --force`, so there may be some breaking changes. I assume that our tests should validate that the breaking changes don't affect us, but let me know if there's more testing I should do.

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
