### PR TITLE
Add RadioGroup component

### DIFF
--- a/docs/components/RadioGroupView.jsx
+++ b/docs/components/RadioGroupView.jsx
@@ -1,0 +1,198 @@
+import * as React from "react";
+
+import Example, {CodeSample, ExampleCode} from "./Example";
+import PropDocumentation from "./PropDocumentation";
+import View from "./View";
+import {RadioGroup, FlexBox, ItemAlign} from "src";
+
+import "./RadioGroupView.less";
+
+const cssClass = {
+  CONFIG_CONTAINER: "RadioGroupView--configContainer",
+  CONFIG_OPTIONS: "RadioGroupView--configOptions",
+  CONFIG: "RadioGroupView--config",
+  CONFIG_TOGGLE: "RadioGroupView--configToggle",
+  CONTAINER: "RadioGroupView",
+  INTRO: "RadioGroupView--intro",
+  PROPS: "RadioGroupView--props",
+};
+
+export default class RadioGroupView extends React.PureComponent {
+  static cssClass = cssClass;
+
+  state = {
+    disableAll: false,
+    selectedCity: null,
+    selectedFood: null,
+    requireSelection: false,
+  };
+
+  render() {
+    const {disableAll, requireSelection, selectedCity, selectedFood} = this.state;
+
+    return (
+      <View
+        className={cssClass.CONTAINER}
+        title="RadioGroup"
+        sourcePath="src/RadioGroup/RadioGroup.tsx"
+      >
+        <header className={cssClass.INTRO}>
+          <p>
+            This is a form element that allows for a single, required selection from a small set of
+            2 or more choices.
+          </p>
+          <p>
+            <b>Common use:</b> Use radio buttons when the user must make a single selection from a
+            list and when you want to expose all available options. If there are many options,
+            consider using the{" "}
+            <a href="/#/components/select">
+              <code>Select</code>
+            </a>{" "}
+            component.
+          </p>
+          <p>
+            Follows the roving tabindex convention for tab navigation between a radio group and
+            other form components: see{" "}
+            <a href="https://www.w3.org/TR/wai-aria-practices-1.1/#radiobutton">
+              Radio Group WAI-ARIA Spec
+            </a>
+            .
+          </p>
+          <CodeSample>
+            {`
+              import {Radio, RadioGroup} from "clever-components";
+              // OR
+              import RadioGroup from "clever-components/dist/RadioGroup"; // Avoids importing all of clever-components.
+            `}
+          </CodeSample>
+        </header>
+
+        <Example title="Basic Usage:">
+          <p>
+            Use the <code>TAB</code> key to move between radio groups and use the arrow keys to move
+            within radio groups.
+          </p>
+          <ExampleCode>
+            <RadioGroup
+              label="Favourite City"
+              onChange={id => this.setState({selectedCity: id})}
+              options={[
+                {id: "london", label: "London", disabled: disableAll},
+                {id: "paris", label: "Paris", disabled: disableAll},
+                {id: "sanFrancisco", label: "San Francisco", disabled: disableAll},
+                {id: "none", label: "None of the above", disabled: requireSelection || disableAll},
+              ]}
+              selectedID={selectedCity}
+            />
+
+            <RadioGroup
+              label="Favourite Food:"
+              onChange={id => this.setState({selectedFood: id})}
+              options={[
+                {id: "pies", label: "Pies", disabled: disableAll},
+                {id: "crepes", label: "Crepes", disabled: disableAll},
+                {id: "waffles", label: "Waffles", disabled: disableAll},
+                {id: "none", label: "None of the above", disabled: requireSelection || disableAll},
+              ]}
+              selectedID={selectedFood}
+            />
+          </ExampleCode>
+          {this._renderConfig()}
+        </Example>
+
+        {this._renderProps()}
+      </View>
+    );
+  }
+
+  _renderConfig() {
+    const {disableAll, requireSelection} = this.state;
+
+    return (
+      <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            checked={requireSelection}
+            className={cssClass.CONFIG_TOGGLE}
+            onChange={({target: {checked}}) => this.setState({requireSelection: checked})}
+          />{" "}
+          Disable "None" option
+        </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            checked={disableAll}
+            className={cssClass.CONFIG_TOGGLE}
+            onChange={({target: {checked}}) => this.setState({disableAll: checked})}
+          />{" "}
+          Disable All
+        </label>
+      </FlexBox>
+    );
+  }
+
+  _renderProps() {
+    return (
+      <PropDocumentation
+        title="<RadioGroup /> Props"
+        availableProps={[
+          {
+            name: "className",
+            type: "string",
+            description: "Optional additional CSS class name to apply to the container.",
+            optional: true,
+          },
+          {
+            name: "error",
+            type: "React.Node",
+            description: (
+              <p>
+                Error text to display, if any.
+                <br />
+                NOTE: Not yet implemented.
+              </p>
+            ),
+            optional: true,
+          },
+          {
+            name: "label",
+            type: "React.Node",
+            description: "Optional title label for the radio group. Recommended for a11y purposes.",
+            optional: true,
+          },
+          {
+            name: "onChange",
+            type: "Function",
+            description: (
+              <p>
+                Option change event handler, called with the ID and value (if available) of the
+                selected option when it changes.
+              </p>
+            ),
+          },
+          {
+            name: "options",
+            type: "Array<{id: string, disabled?: boolean, label: string, value?: any}>",
+            description: (
+              <p>
+                Array of option items to display in the radio group.
+                <br />
+                The <code>value</code> field provides the convenience of receiving a custom value in
+                the RadioGroup onChange event in addition to the selected ID to avoid having to do a
+                value lookup.
+              </p>
+            ),
+          },
+          {
+            name: "selectedID",
+            type: "string",
+            description: "ID of the currently selected option, if any.",
+            optional: true,
+          },
+        ]}
+        className={cssClass.PROPS}
+      />
+    );
+  }
+}

--- a/docs/components/RadioGroupView.less
+++ b/docs/components/RadioGroupView.less
@@ -1,0 +1,45 @@
+@import (reference) "~src/less/utilities";
+
+.RadioGroupView--intro {
+  .margin--bottom--xl;
+}
+
+.RadioGroupView--configContainer {
+  .border--top--l(@neutral_silver);
+  .margin--top--xl;
+  .padding--top--l;
+}
+
+.RadioGroupView--config {
+  .flexbox;
+  .items--center;
+  .margin--bottom--m;
+  .text--caps;
+  .text--small;
+
+  &:not(:last-child) {
+    .margin--right--m;
+  }
+}
+
+label.RadioGroupView--config {
+  cursor: pointer;
+}
+
+.RadioGroupView--configOptions {
+  .margin--left--2xs;
+  display: inline-block;
+}
+
+.RadioGroupView--configToggle {
+  cursor: pointer;
+
+  &[disabled] {
+    cursor: not-allowed;
+  }
+}
+
+.RadioGroupView--props {
+  .margin--top--l;
+}
+

--- a/docs/components/SideBar/SideBar.jsx
+++ b/docs/components/SideBar/SideBar.jsx
@@ -92,6 +92,7 @@ export default class SideBar extends React.Component {
           {this._renderLink("/components/multiple-panel-modals", "MultiplePanelModals")}
           {this._renderLink("/components/number", "Number")}
           {this._renderLink("/components/progress-bar", "ProgressBar")}
+          {this._renderLink("/components/radio-group", "RadioGroup")}
           {this._renderLink("/components/rich-text", "RichText")}
           {this._renderLink("/components/segmented-control", "SegmentedControl")}
           {this._renderLink("/components/select", "Select")}

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -37,6 +37,7 @@ import MultiplePanelModalsView from "./components/MultiplePanelModalsView";
 import NumberView from "./components/NumberView";
 import PageLayoutView from "./components/PageLayoutView";
 import ProgressBarView from "./components/ProgressBarView";
+import RadioGroupView from "./components/RadioGroupView";
 import RichTextView from "./components/RichTextView";
 import SegmentedControlView from "./components/SegmentedControlView";
 import SelectView from "./components/SelectView";
@@ -96,6 +97,7 @@ render((
         <Route path="multiple-panel-modals(/*)" component={MultiplePanelModalsView} />
         <Route path="number(/*)" component={NumberView} />
         <Route path="progress-bar(/*)" component={ProgressBarView} />
+        <Route path="radio-group(/*)" component={RadioGroupView} />
         <Route path="rich-text(/*)" component={RichTextView} />
         <Route path="segmented-control(/*)" component={SegmentedControlView} />
         <Route path="select(/*)" component={SelectView} />

--- a/genBorderRadius.js
+++ b/genBorderRadius.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 
 const FILEPATH = "src/less/";
 const FILENAME = "border_radius.less";
+
 const borderRadii = {
   0: 0,
   s: 0.125, // 2px
@@ -12,6 +13,14 @@ const borderRadii = {
   xl: 0.5, // 8px
   "10percent": "10%",
 };
+
+const CIRCLE_MIXIN = `
+.circle(@width) {
+  border-radius: 50%;
+  height: @width;
+  width: @width;
+}
+`;
 
 const constants = [];
 let classes = [];
@@ -71,6 +80,7 @@ const contents = [
     "/**",
     " * Border radius classes.",
     " */",
+    CIRCLE_MIXIN,
   ],
   classes,
   ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.36.2",
+  "version": "0.36.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/RadioGroup/Radio.less
+++ b/src/RadioGroup/Radio.less
@@ -1,0 +1,98 @@
+@import (reference) "../less/utilities";
+
+@radioInnerWidth: 0.6875rem; // 11px
+@radioInnerBorderWidth: 0.0938rem; // 1.5px
+@radioOuterBorderWidth: 0.125rem; // 2px
+@radioTransition: all @timingQuickly ease-out;
+
+.Radio {
+  .button--reset;
+  .flexbox;
+  .font--ProximaNova;
+  .items--center;
+  cursor: pointer;
+  transition: @radioTransition;
+}
+
+.Radio--outer {
+  .circle(auto);
+  background-color: @neutral_white;
+  border: @radioOuterBorderWidth solid @primary_blue_tint_2;
+  transition: @radioTransition;
+}
+
+.Radio--inner {
+  .circle(@radioInnerWidth);
+  background-color: @primary_blue;
+  border: @radioInnerBorderWidth solid @neutral_white;
+  opacity: 0;
+  transition: @radioTransition;
+}
+
+.Radio--label {
+  .margin--left--xs;
+  .text--medium;
+  .text--regular;
+  color: @neutral_black;
+}
+
+.Radio--checked {
+  .Radio--outer {
+    border-color: @primary_blue;
+  }
+
+  .Radio--inner {
+    background-color: @primary_blue;
+    opacity: 1;
+  }
+}
+
+.Radio:focus,
+.Radio:hover {
+  .Radio--outer {
+    border-color: @primary_blue;
+  }
+
+  .Radio--label {
+    color: @primary_blue;
+  }
+}
+
+.Radio:active {
+  .Radio--outer {
+    border-color: @primary_blue;
+  }
+
+  .Radio--inner {
+    background-color: @primary_blue_tint_2;
+    opacity: 1;
+  }
+}
+
+.Radio.Radio--disabled {
+  cursor: not-allowed;
+
+  .Radio--outer {
+    background-color: @neutral_silver;
+    border-color: @neutral_gray;
+  }
+
+  .Radio--inner {
+    background-color: @neutral_gray;
+    opacity: 0;
+  }
+
+  .Radio--label {
+    color: @neutral_gray;
+  }
+
+  &.Radio--checked {
+    .Radio--outer {
+      background-color: @neutral_white;
+    }
+
+    .Radio--inner {
+      opacity: 1;
+    }
+  }
+}

--- a/src/RadioGroup/Radio.tsx
+++ b/src/RadioGroup/Radio.tsx
@@ -1,0 +1,91 @@
+import * as classnames from "classnames";
+import * as PropTypes from "prop-types";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+import "./Radio.less";
+
+const propTypes = {
+  checked: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  onSelect: PropTypes.func,
+  tabIndex: PropTypes.number,
+  value: PropTypes.any,
+};
+
+const cssClass = {
+  CHECKED: "Radio--checked",
+  CONTAINER: "Radio",
+  DISABLED: "Radio--disabled",
+  INNER: "Radio--inner",
+  LABEL: "Radio--label",
+  OUTER: "Radio--outer",
+};
+
+const LABEL_ID_PREFIX = "Radio--label";
+let nextLabelIDSuffix = 0;
+const getNextLabelID = () => `${LABEL_ID_PREFIX}--${nextLabelIDSuffix++}`;
+
+/**
+ * Single radio button input.
+ * Usually used in a RadioGroup for providing a list of mutually-exclusive options to the user.
+ */
+export default class Radio extends React.PureComponent {
+  static propTypes = propTypes;
+  static cssClass = cssClass;
+
+  _element = null;
+  _labelID = getNextLabelID();
+
+  focus() {
+    if (this._element) {
+      this._element.focus();
+    }
+  }
+
+  componentDidMount() {
+    this._element = ReactDOM.findDOMNode(this);
+  }
+
+  render() {
+    const {checked, children, className, disabled, tabIndex} = this.props;
+
+    return (
+      <button
+        aria-checked={!!checked}
+        aria-labelledby={this._labelID}
+        className={classnames(
+          cssClass.CONTAINER,
+          checked && cssClass.CHECKED,
+          disabled && cssClass.DISABLED,
+          className,
+        )}
+        disabled={disabled}
+        onClick={this._onClick}
+        onFocus={this._onClick}
+        role="radio"
+        tabIndex={tabIndex}
+      >
+        <div className={cssClass.OUTER}>
+          <div className={cssClass.INNER} />
+        </div>
+        <span className={cssClass.LABEL} id={this._labelID}>{children}</span>
+      </button>
+    );
+  }
+
+  _onClick = () => {
+    const {disabled, id, onSelect, value} = this.props;
+
+    if (disabled) {
+      return;
+    }
+
+    if (onSelect) {
+      onSelect(id, value);
+    }
+  };
+}

--- a/src/RadioGroup/RadioGroup.less
+++ b/src/RadioGroup/RadioGroup.less
@@ -1,0 +1,20 @@
+@import (reference) "../less/utilities";
+
+.RadioGroup {
+  &:not(:first-child) {
+    .margin--top--l;
+  }
+
+  .RadioGroup--radio {
+    &:not(:first-child) {
+      .margin--top--s;
+    }
+  }
+}
+
+.RadioGroup--label {
+  .margin--bottom--s;
+  .text--medium;
+  .text--semi-bold;
+}
+

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,133 @@
+import * as _ from "lodash";
+import * as classnames from "classnames";
+import * as PropTypes from "prop-types";
+import * as React from "react";
+
+import Radio from "./Radio";
+import WithKeyboardNav from "../WithKeyboardNav";
+
+import "./RadioGroup.less";
+
+const OPTION_PROP_TYPE = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  label: PropTypes.node.isRequired,
+  value: PropTypes.any,
+});
+
+const propTypes = {
+  className: PropTypes.string,
+  error: PropTypes.node,
+  label: PropTypes.node,
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.arrayOf(OPTION_PROP_TYPE).isRequired,
+  selectedID: PropTypes.string,
+};
+
+const cssClass = {
+  CONTAINER: "RadioGroup",
+  LABEL: "RadioGroup--label",
+  RADIO: "RadioGroup--radio",
+};
+
+const LABEL_ID_PREFIX = "RadioGroup--label";
+let nextLabelIDSuffix = 0;
+const getNextLabelID = () => `${LABEL_ID_PREFIX}--${nextLabelIDSuffix++}`;
+
+/**
+ * Form element that allows for a single, required selection from a small set of 2 or more options.
+ */
+export default class RadioGroup extends React.PureComponent {
+  static propTypes = propTypes;
+  static cssClass = cssClass;
+
+  _labelID = getNextLabelID();
+  _optionRefsByID = {};
+
+  render() {
+    const {className, label, onChange, options, selectedID} = this.props;
+
+    const focusableOptionID = this._getFocusableOptionID(options);
+
+    // TODO: Render error string if specified.
+    return (
+      <WithKeyboardNav
+        currentID={focusableOptionID}
+        itemIDs={options.map(o => (o.disabled ? undefined : o.id))}
+        onChange={this._handleNavChange}
+      >
+        <div
+          aria-labelledby={this._labelID}
+          className={classnames(cssClass.CONTAINER, className)}
+          role="radiogroup"
+        >
+          <div className={cssClass.LABEL} id={this._labelID}>
+            {label}
+          </div>
+          {_.map(options, o => (
+            <Radio
+              checked={o.id === selectedID}
+              className={cssClass.RADIO}
+              disabled={!!o.disabled}
+              id={o.id}
+              key={o.id}
+              onSelect={onChange}
+              ref={ref => this._handleRadioRef(ref)}
+              tabIndex={o.id === focusableOptionID ? 0 : -1}
+              value={o.value}
+            >
+              {o.label}
+            </Radio>
+          ))}
+        </div>
+      </WithKeyboardNav>
+    );
+  }
+
+  _handleRadioRef = ref => {
+    if (ref) {
+      this._optionRefsByID[ref.props.id] = ref;
+    }
+  };
+
+  _handleNavChange = selectedID => {
+    const selectedRadioRef = this._optionRefsByID[selectedID];
+    if (!selectedRadioRef) {
+      return;
+    }
+
+    selectedRadioRef.focus();
+  };
+
+  /**
+   * This implements the roving tabindex pattern as described in the w3.org spec for radio groups:
+   * https://www.w3.org/TR/wai-aria-practices-1.1/examples/radio/radio-1/radio-1.html
+   *
+   * We essentially set the tabindex for all options to -1 except the one that's currently selected
+   * or the first non-disabled one in the list.
+   */
+  _getFocusableOptionID(options) {
+    const {selectedID} = this.props;
+
+    let focusableOptionID = null;
+    _.forEach(options, option => {
+      if (!option) {
+        return;
+      }
+
+      // If we haven't found the selected option, pick the first non-disabled one.
+      if (!option.disabled && focusableOptionID === null) {
+        focusableOptionID = option.id;
+        return;
+      }
+
+      // If there's a selected, non-disabled option, pick that as the focusable option.
+      if (!option.disabled && option.id === selectedID) {
+        focusableOptionID = option.id;
+        return;
+      }
+    });
+
+    return focusableOptionID;
+  }
+}

--- a/src/RadioGroup/index.ts
+++ b/src/RadioGroup/index.ts
@@ -1,0 +1,3 @@
+import RadioGroup from "./RadioGroup";
+export default RadioGroup;
+export * from "./RadioGroup";

--- a/src/WithKeyboardNav/WithKeyboardNav.tsx
+++ b/src/WithKeyboardNav/WithKeyboardNav.tsx
@@ -25,8 +25,13 @@ export default class WithKeyboardNav extends React.PureComponent {
   static propTypes = propTypes;
 
   static defaultProps = {
-    backKeys: [KeyCode.ARROW_LEFT, KeyCode.ARROW_UP],
-    forwardKeys: [KeyCode.ARROW_RIGHT, KeyCode.ARROW_DOWN],
+    backKeys: [KeyCode.ARROW_LEFT_IE, KeyCode.ARROW_LEFT, KeyCode.ARROW_UP_IE, KeyCode.ARROW_UP],
+    forwardKeys: [
+      KeyCode.ARROW_DOWN_IE,
+      KeyCode.ARROW_DOWN,
+      KeyCode.ARROW_RIGHT_IE,
+      KeyCode.ARROW_RIGHT,
+    ],
   };
 
   _element = null;

--- a/src/index.js
+++ b/src/index.js
@@ -79,3 +79,6 @@ export {EditableInfoPanel};
 
 import WithKeyboardNav from "./WithKeyboardNav";
 export {WithKeyboardNav};
+
+import RadioGroup from "./RadioGroup";
+export {RadioGroup};

--- a/src/less/border_radius.less
+++ b/src/less/border_radius.less
@@ -22,6 +22,13 @@
  * Border radius classes.
  */
 
+.circle(@width) {
+  border-radius: 50%;
+  height: @width;
+  width: @width;
+}
+
+
 /** @borderRadius0 */
 .borderRadius--0 { border-radius: @borderRadius0; }
 

--- a/src/utils/KeyCode.ts
+++ b/src/utils/KeyCode.ts
@@ -3,9 +3,13 @@
  * NOTE: Please keep sorted for easy scanning.
  */
 const KeyCode = {
+  ARROW_DOWN_IE: "Down",
   ARROW_DOWN: "ArrowDown",
+  ARROW_LEFT_IE: "Left",
   ARROW_LEFT: "ArrowLeft",
+  ARROW_RIGHT_IE: "Right",
   ARROW_RIGHT: "ArrowRight",
+  ARROW_UP_IE: "Up",
   ARROW_UP: "ArrowUp",
   J: "j",
   K: "k",


### PR DESCRIPTION
[Might be easier reviewing commits separately]

**Jira:** https://clever.atlassian.net/browse/GOAL-206

**Spec:** https://invis.io/6YPCS27X2JP#/333969277_radio_Buttons_In_Dewey

**Overview:**
Adding a `RadioGroup` component for single-choice selection from a small list of options.

**Screenshots/GIFs:**
[![Screenshot from Gyazo](https://gyazo.com/fda852c5e89cef47e1d371f691b4907b/raw)](https://gyazo.com/fda852c5e89cef47e1d371f691b4907b)

**Testing:**
- [n/a] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
