### PR TITLE
Make docs sortable by required

### DIFF
--- a/docs/components/PropDocumentation.jsx
+++ b/docs/components/PropDocumentation.jsx
@@ -58,6 +58,8 @@ export default class PropDocumentation extends PureComponent {
             header={{content: "Required"}}
             cell={{renderer: p => (p.optional ? "False" : "True")}}
             noWrap
+            sortable
+            sortValueFn={p => p.optional}
           />
         </Table>
       </div>


### PR DESCRIPTION
Make Dewey docs sortable by `required`, makes it much easier to see all required props!

![screen recording 2018-12-13 at 03 56 pm](https://user-images.githubusercontent.com/4623985/49974775-aee9d900-feef-11e8-885a-6d9f6338dce5.gif)

