### PR TITLE
Add card component

### DIFF
--- a/docs/components/CardView.jsx
+++ b/docs/components/CardView.jsx
@@ -1,0 +1,168 @@
+import * as React from "react";
+
+import Example, {CodeSample, ExampleCode} from "./Example";
+import PropDocumentation from "./PropDocumentation";
+import View from "./View";
+import {Card, FlexBox, ItemAlign} from "src";
+
+import "./CardView.less";
+
+const Classes = {
+  CARD: "CardView--card",
+  CONFIG_CONTAINER: "CardView--configContainer",
+  CONFIG_OPTIONS: "CardView--configOptions",
+  CONFIG: "CardView--config",
+  CONFIG_TOGGLE: "CardView--configToggle",
+  CONTAINER: "CardView",
+  INTRO: "CardView--intro",
+  PROPS: "CardView--props",
+};
+
+export default class CardView extends React.PureComponent {
+  state = {
+    raised: true,
+    withFooter: false,
+    withTitle: true,
+    noPadding: false,
+  };
+
+  render() {
+    const {raised, withFooter, withTitle, noPadding} = this.state;
+
+    return (
+      <View className={Classes.CONTAINER} title="Card" sourcePath="src/Card/Card.tsx">
+        <header className={Classes.INTRO}>
+          <CodeSample>
+            {`
+              import Card from "goals-components/dist/Card";
+            `}
+          </CodeSample>
+        </header>
+
+        <Example title="Basic Usage:">
+          <ExampleCode>
+            <Card
+              className={Classes.CARD}
+              footer={withFooter && "You can add a footer as well"}
+              raised={raised}
+              title={withTitle && "You can add a title"}
+              noPadding={noPadding}
+            >
+              <p>Card content goes here</p>
+              <p>Can be anything you want</p>
+            </Card>
+          </ExampleCode>
+          {this._renderConfig()}
+        </Example>
+        {this._renderProps()}
+      </View>
+    );
+  }
+
+  _renderConfig() {
+    const {raised, withFooter, withTitle, noPadding} = this.state;
+
+    return (
+      <FlexBox alignItems={ItemAlign.CENTER} className={Classes.CONFIG_CONTAINER} wrap>
+        <label className={Classes.CONFIG}>
+          <input
+            type="checkbox"
+            checked={raised}
+            className={Classes.CONFIG_TOGGLE}
+            onChange={e => this.setState({raised: e.target.checked})}
+          />{" "}
+          Raised
+        </label>
+        <label className={Classes.CONFIG}>
+          <input
+            type="checkbox"
+            checked={withTitle}
+            className={Classes.CONFIG_TOGGLE}
+            onChange={e => this.setState({withTitle: e.target.checked})}
+          />{" "}
+          With title
+        </label>
+        <label className={Classes.CONFIG}>
+          <input
+            type="checkbox"
+            checked={withFooter}
+            className={Classes.CONFIG_TOGGLE}
+            onChange={e => this.setState({withFooter: e.target.checked})}
+          />{" "}
+          With footer
+        </label>
+        <label className={Classes.CONFIG}>
+          <input
+            type="checkbox"
+            checked={noPadding}
+            className={Classes.CONFIG_TOGGLE}
+            onChange={e => this.setState({noPadding: e.target.checked})}
+          />{" "}
+          No content padding
+        </label>
+      </FlexBox>
+    );
+  }
+
+  _renderProps() {
+    return (
+      <PropDocumentation
+        title="<Card /> Props"
+        availableProps={[
+          {
+            name: "children",
+            type: "React.Node",
+            description: "Card main content",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Optional additional CSS class name to apply to the container.",
+            optional: true,
+          },
+          {
+            name: "footer",
+            type: "React.Node",
+            description: "Optional footer content.",
+            optional: true,
+          },
+          {
+            name: "inline",
+            type: "boolean",
+            description: "Card should use inline-block display",
+            defaultValue: "false",
+            optional: true,
+          },
+          {
+            name: "noFooterPadding",
+            type: "boolean",
+            description: "Remove padding from the footer.",
+            defaultValue: "false",
+            optional: true,
+          },
+          {
+            name: "noPadding",
+            type: "boolean",
+            description: "Remove padding from the content section",
+            defaultValue: "false",
+            optional: true,
+          },
+          {
+            name: "raised",
+            type: "boolean",
+            description: "Add a dropshadow to the card",
+            defaultValue: "false",
+            optional: true,
+          },
+          {
+            name: "title",
+            type: "React.Node",
+            description: "Optional title content.",
+            optional: true,
+          },
+        ]}
+        className={Classes.PROPS}
+      />
+    );
+  }
+}

--- a/docs/components/CardView.less
+++ b/docs/components/CardView.less
@@ -1,0 +1,48 @@
+@import (reference) "~src/less/utilities";
+
+.CardView--intro {
+  .margin--bottom--xl;
+}
+
+.CardView--configContainer {
+  .border--top--l(@neutral_silver);
+  .margin--top--xl;
+  .padding--top--l;
+}
+
+.CardView--config {
+  .flexbox;
+  .items--center;
+  .margin--bottom--m;
+  .text--caps;
+  .text--small;
+
+  &:not(:last-child) {
+    .margin--right--m;
+  }
+}
+
+label.CardView--config {
+  cursor: pointer;
+}
+
+.CardView--configOptions {
+  .margin--left--2xs;
+  display: inline-block;
+}
+
+.CardView--configToggle {
+  cursor: pointer;
+
+  &[disabled] {
+    cursor: not-allowed;
+  }
+}
+
+.CardView--props {
+  .margin--top--l;
+}
+
+.CardView--card {
+  max-width: 20rem;
+}

--- a/docs/components/InfoPanelView.jsx
+++ b/docs/components/InfoPanelView.jsx
@@ -142,4 +142,3 @@ InfoPanelView.cssClass = {
   CONFIG: "TextAreaView--configContainer",
   CONFIG_CONTAINER: "TextAreaView--config",
 };
-

--- a/docs/components/SideBar/SideBar.jsx
+++ b/docs/components/SideBar/SideBar.jsx
@@ -69,6 +69,7 @@ export default class SideBar extends React.Component {
           {this._renderLink("/components/button", "Button")}
           {this._renderLink("/components/checkbox", "Checkbox")}
           {this._renderLink("/components/checkbox-group", "CheckboxGroup")}
+          {this._renderLink("/components/card", "Card")}
           {this._renderLink("/components/confirmation-button", "ConfirmationButton")}
           {this._renderLink("/components/copy-container", "CopyContainer")}
           {this._renderLink("/components/copyable-input", "CopyableInput")}

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -6,6 +6,7 @@ import AlertBoxView from "./components/AlertBoxView";
 import ButtonView from "./components/ButtonView";
 import CheckboxGroupView from "./components/CheckboxGroupView";
 import CheckboxView from "./components/CheckboxView";
+import CardView from "./components/CardView";
 import ColorsView from "./components/ColorsView";
 import ConfirmationButtonView from "./components/ConfirmationButtonView";
 import CopyContainerView from "./components/CopyContainerView";
@@ -77,6 +78,7 @@ render((
         <Route path="button(/*)" component={ButtonView} />
         <Route path="checkbox(/*)" component={CheckboxView} />
         <Route path="checkbox-group(/*)" component={CheckboxGroupView} />
+        <Route path="card(/*)" component={CardView} />
         <Route path="confirmation-button(/*)" component={ConfirmationButtonView} />
         <Route path="copy-container(/*)" component={CopyContainerView} />
         <Route path="copyable-input(/*)" component={CopyableInputView} />

--- a/src/Card/Card.less
+++ b/src/Card/Card.less
@@ -1,0 +1,50 @@
+@import (reference) "../less/utilities";
+
+.Card {
+  .border--s(@neutral_silver);
+  .borderRadius--l();
+  background-color: @neutral_white;
+  box-sizing: content-box;
+  font-family: "Proxima Nova", "Helvetica Neue", Arial, Helvetica, sans-serif;
+  overflow: hidden;
+  transition: all @timingPromptly ease-out;
+}
+
+.Card--inline {
+  display: inline-block;
+}
+
+.Card--raised {
+  box-shadow: 0 @size_4xs @size_2xs fade(@neutral_black, 10%);
+}
+
+.Card--header {
+  .border--bottom--s(@neutral_silver);
+  .padding--x--m();
+  .padding--y--s();
+  background-color: tint(@neutral_off_white, 30%);
+}
+
+.Card--header--title {
+  .text--semi-bold();
+}
+
+.Card--body {
+  .padding--x--m();
+  .padding--y--s();
+}
+
+.Card--body--noPadding {
+  .padding--none();
+}
+
+.Card--footer {
+  .border--top--s(@neutral_silver);
+   background-color: tint(@neutral_off_white, 30%);
+  .padding--x--m();
+  .padding--y--xs();
+}
+
+.Card--footer--noPadding {
+  .padding--none();
+}

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -1,0 +1,79 @@
+import "core-js";
+
+import {FlexBox, FlexItem} from "../flex";
+import * as classnames from "classnames";
+import * as React from "react";
+
+import "./Card.less";
+
+export type Props = {
+  children: React.ReactNode;
+  className?: string;
+  component?: string;
+  footer?: React.ReactNode;
+  htmlProps?: React.ReactNode;
+  inline?: boolean;
+  noFooterPadding?: boolean;
+  noPadding?: boolean;
+  raised?: boolean;
+  title?: React.ReactNode;
+};
+
+export const Classes = {
+  BODY: "Card--body",
+  NO_PADDING: "Card--body--noPadding",
+  CONTAINER: "Card",
+  FOOTER: "Card--footer",
+  FOOTER_NO_PADDING: "Card--footer--noPadding",
+  HEADER: "Card--header",
+  INLINE: "Card--inline",
+  RAISED: "Card--raised",
+  TITLE: "Card--header--title",
+};
+
+export default class Card extends React.PureComponent {
+  static defaultProps = {
+    component: "div",
+  };
+
+  render() {
+    const {
+      children,
+      className,
+      component: Wrapper,
+      footer,
+      inline,
+      noFooterPadding,
+      noPadding,
+      raised,
+      title,
+    } = this.props;
+
+    return (
+      <Wrapper
+        className={classnames(
+          Classes.CONTAINER,
+          inline && Classes.INLINE,
+          raised && Classes.RAISED,
+          className,
+        )}
+      >
+        {title && (
+          <FlexBox className={Classes.HEADER} component="header">
+            <FlexItem className={Classes.TITLE} grow>
+              {title}
+            </FlexItem>
+          </FlexBox>
+        )}
+
+        <div className={classnames(Classes.BODY, noPadding && Classes.NO_PADDING)}>{children}</div>
+
+        {footer && (
+          <div className={classnames(Classes.FOOTER, noFooterPadding && Classes.FOOTER_NO_PADDING)}>
+            {footer}
+          </div>
+        )}
+      </Wrapper>
+    );
+  }
+}

--- a/src/Card/index.ts
+++ b/src/Card/index.ts
@@ -1,0 +1,2 @@
+import Card from "./Card";
+export default Card;

--- a/src/index.js
+++ b/src/index.js
@@ -91,3 +91,5 @@ export {Checkbox};
 
 import CheckboxGroup from "./CheckboxGroup";
 export {CheckboxGroup};
+import Card from "./Card";
+export {Card};


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/GOAL-210

**Overview:**
Adds a card component to Dewey! Supports footer/header, raised/not raised, and noPadding if you want content to stretch end to end (useful for images)

Still waiting on design for final styles, but this is a v1! Mostly copied from goals-components with some minor tweaks to simplify it.

**Screenshots/GIFs:**
![screen recording 2018-12-13 at 04 04 pm](https://user-images.githubusercontent.com/4623985/49975040-d2615380-fef0-11e8-93a6-42f713fb9047.gif)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
