### PR TITLE
Code font

### DIFF
--- a/docs/components/ConfirmationButtonView.jsx
+++ b/docs/components/ConfirmationButtonView.jsx
@@ -59,14 +59,14 @@ export default class ConfirmationButtonView extends Component {
             {
               name: "confirmButtonType",
               type: "String",
-              description: "One of primary, secondary, destructive, link, linkPlain, plain",
+              description: <div>One of <code>primary</code>, <code>secondary</code>, <code>destructive</code>, <code>link</code>, <code>linkPlain</code>, <code>plain</code></div>,
               defaultValue: "primary",
               optional: true,
             },
             {
               name: "confirmButtonSize",
               type: "String",
-              description: "One of large, regular, small",
+              description: <div>One of <code>large</code>, <code>regular</code>, <code>small</code></div>,
               defaultValue: "regular",
               optional: true,
             },
@@ -104,7 +104,7 @@ export default class ConfirmationButtonView extends Component {
             {
               name: "confirmButtonTarget",
               type: "String",
-              description: "For links, either _self or _blank",
+              description: <div>For links, either <code>_self</code> or <code>_blank</code></div>,
               defaultValue: "_blank",
               optional: true,
             },

--- a/docs/components/PropDocumentation.jsx
+++ b/docs/components/PropDocumentation.jsx
@@ -86,5 +86,4 @@ PropDocumentation.cssClass = {
   CONTAINER: "PropDocumentation",
   TABLE: "PropDocumentation--table",
   TITLE: "PropDocumentation--title",
-  CODE: "PropDocumentation--code",
 };

--- a/docs/components/PropDocumentation.jsx
+++ b/docs/components/PropDocumentation.jsx
@@ -31,10 +31,11 @@ export default class PropDocumentation extends PureComponent {
           <Column
             id="name"
             header={{content: "Prop Name"}}
-            cell={{renderer: p => p.name}}
+            cell={{renderer: p => <code>{p.name}</code>}}
             noWrap
             sortable
             sortValueFn={p => p.name.trim().toLowerCase()}
+            className={cssClass.CODE}
           />
           <Column
             id="type"
@@ -50,7 +51,7 @@ export default class PropDocumentation extends PureComponent {
           <Column
             id="defaultValue"
             header={{content: "Default Value"}}
-            cell={{renderer: p => p.defaultValue || "None"}}
+            cell={{renderer: p => (p.defaultValue ? <code>{p.defaultValue}</code> : "None")}}
             noWrap
           />
           <Column
@@ -85,4 +86,5 @@ PropDocumentation.cssClass = {
   CONTAINER: "PropDocumentation",
   TABLE: "PropDocumentation--table",
   TITLE: "PropDocumentation--title",
+  CODE: "PropDocumentation--code",
 };


### PR DESCRIPTION
**Jira:**
N/A

**Overview:**
Adds `<code></code>` tags to the name column and default value column in our documentation. It is up to individual components to apply it in the description strings. I did it for the confirmation button one as an example.

**Screenshots/GIFs:**
![screen shot 2018-12-13 at 5 17 41 pm](https://user-images.githubusercontent.com/7911027/49978108-d182ee80-fefd-11e8-860e-60428eda9139.png)

**Testing:**
- [ ] Unit tests N/A
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
