### PR TITLE
Add box shadow mixins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.36.5",
+  "version": "0.36.6",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/less/box-shadow.less
+++ b/src/less/box-shadow.less
@@ -1,0 +1,37 @@
+@import (reference) "./colors";
+@import (reference) "./sizing";
+
+// Opinionated defaults for box shadows
+
+@boxShadowDefaultXOffset: 0;
+@boxShadowDefaultYOffset: @size_4xs;
+
+@boxShadowLightBlack: fade(@neutral_black, 25%);
+@boxShadowMediumBlack: fade(@neutral_black, 50%);
+@boxShadowHeavyBlack: fade(@neutral_black, 75%);
+
+@boxShadowBlurRadiusS: @size_xs;
+@boxShadowBlurRadiusM: @size_s;
+@boxShadowBlurRadiusL: @size_m;
+
+.boxShadow(@blurRadius, @color) {
+  box-shadow:
+    @boxShadowDefaultXOffset
+    @boxShadowDefaultYOffset
+    @blurRadius
+    @color;
+}
+
+// Convenience mixins
+
+.boxShadow--light {
+  .boxShadow(@boxShadowBlurRadiusS, @boxShadowLightBlack);
+}
+
+.boxShadow--medium {
+  .boxShadow(@boxShadowBlurRadiusM, @boxShadowMediumBlack);
+}
+
+.boxShadow--heavy {
+  .boxShadow(@boxShadowBlurRadiusL, @boxShadowHeavyBlack);
+}

--- a/src/less/box-shadow.less
+++ b/src/less/box-shadow.less
@@ -6,9 +6,9 @@
 @boxShadowDefaultXOffset: 0;
 @boxShadowDefaultYOffset: @size_4xs;
 
-@boxShadowLightBlack: fade(@neutral_black, 25%);
+@boxShadowLightBlack: fade(@neutral_black, 40%);
 @boxShadowMediumBlack: fade(@neutral_black, 50%);
-@boxShadowHeavyBlack: fade(@neutral_black, 75%);
+@boxShadowHeavyBlack: fade(@neutral_black, 70%);
 
 @boxShadowBlurRadiusS: @size_xs;
 @boxShadowBlurRadiusM: @size_s;

--- a/src/less/utilities.less
+++ b/src/less/utilities.less
@@ -4,6 +4,7 @@
 @import "./animations";
 @import "./border";
 @import "./border_radius";
+@import "./box-shadow";
 @import "./colors";
 @import "./display";
 @import "./flex";


### PR DESCRIPTION
While adding box shadows to toast notifications (coming soon!), I realized that box shadows in our product are pretty inconsistent. This PR sets up defaults and convenience mixins, based on existing box shadows in the product.

*No box shadow*

<img width="635" alt="none" src="https://user-images.githubusercontent.com/12616928/50112870-376cc000-01f5-11e9-81e0-f75332ab49ce.png">

*`.boxShadow--light`*

<img width="635" alt="light" src="https://user-images.githubusercontent.com/12616928/50112882-3b98dd80-01f5-11e9-9b38-e8c0540ed2bb.png">

*`.boxShadow--medium`*

<img width="635" alt="medium" src="https://user-images.githubusercontent.com/12616928/50112912-53706180-01f5-11e9-9189-41fce7234b4e.png">

*`.boxShadow--heavy`*

<img width="635" alt="heavy" src="https://user-images.githubusercontent.com/12616928/50112915-55d2bb80-01f5-11e9-88e8-b9bca4bf1563.png">