### PR TITLE
Switch: display focus on click

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.36.6",
+  "version": "0.36.7",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Switch/Switch.less
+++ b/src/Switch/Switch.less
@@ -14,7 +14,8 @@
 
 .Switch {
   position: relative;
-  display: inline-block;
+  width: 4rem;
+  height: 2rem;
   touch-action: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -22,40 +23,32 @@
   user-select: none;
   outline: none;
   font-size: initial;
-  display: block;
-  border: none;
   padding: 0;
   text-align: justify;
-}
-
-.Switch--bg {
   background-color: @neutral_gray;
   border: @size_3xs solid @neutral_gray;
-  width: 3.75rem;
-  height: 1.75rem;
-  position: relative;
   border-radius: @size_2xs;
   cursor: pointer;
   transition: background-color @timingPromptly;
+  transition: box-shadow @timingPromptly;
 }
 
-.Switch--bg.Switch--checked {
+.Switch:focus {
+  box-shadow: 0 0 0 0.375rem rgba(128, 157, 255, 0.5);
+}
+
+
+.Switch.Switch--checked {
   background-color: @alert_green_tint_2;
   border: @size_3xs solid @alert_green_tint_2;
 }
 
-.Switch:hover {
-  :not(.Switch--disabled).Switch--bg.Switch--checked {
-    border: @size_3xs solid @alert_green_shade_1;
-  }
-
-  :not(.Switch--disabled).Switch--bg {
-    border: @size_3xs solid @neutral_dark_gray;
-  }
+.Switch:hover:not(.Switch--disabled).Switch--checked {
+  border: @size_3xs solid @alert_green_shade_1;
 }
 
-.Switch--outline {
-  box-shadow: 0 0 0 0.375rem rgba(128, 157, 255, 0.5),
+.Switch:hover:not(.Switch--disabled) {
+  border: @size_3xs solid @neutral_dark_gray;
 }
 
 .Switch--checkedIcon {
@@ -80,7 +73,7 @@
   overflow: visible;
 }
 
-.Switch--bg.Switch--disabled {
+.Switch.Switch--disabled {
   cursor: not-allowed;
   background-color: @neutral_silver;
   border: @size_3xs solid @neutral_silver;
@@ -98,19 +91,19 @@
   outline: none;
   width: 1.813rem;
   height: 1.375rem;
-  transform: translateX(@size_2xs);
+  transform: translateX(@size_3xs);
   background-color: transparent;
   background-color: @neutral_white;
   cursor: pointer;
   display: inline-block;
   border-radius: @size_3xs;
   position: absolute;
-  top: 0.313rem;
+  top: 0.188em;
   transition: background-color 0.25s, transform 0.25s, box-shadow 0.15s;
 }
 
 .Switch--handle.Switch--checked {
-  transform: translateX(1.94em);
+  transform: translateX(1.813em);
 }
 
 .Switch--handle.Switch--disabled {

--- a/src/Switch/Switch.tsx
+++ b/src/Switch/Switch.tsx
@@ -49,12 +49,6 @@ export default class Switch extends React.PureComponent {
   static cssClass = cssClass;
   static defaultProps = defaultProps;
 
-  state = {
-    hasOutline: false,
-    hover: false,
-    mouseDown: false,
-  };
-
   render() {
     const {
       ariaLabelledby,
@@ -64,32 +58,22 @@ export default class Switch extends React.PureComponent {
       disabled,
     } = this.props;
 
-    const {hasOutline} = this.state;
-
     return (
       <button
         aria-checked={checked}
         aria-disabled={disabled}
         aria-labelledby={ariaLabelledby}
         aria-label={ariaLabel}
-        className={classnames(cssClass.CONTAINER, className)}
-        onMouseDown={() => this._onMouseDown()}
-        onMouseUp={() => this._onMouseUp()}
-        onFocus={this._onFocus}
-        onBlur={this._onBlur}
+        className={classnames(cssClass.CONTAINER, className, "flexbox", cssClass.BG,
+          checked && cssClass.CHECKED,
+          disabled && cssClass.DISABLED,
+        )}
         role="checkbox"
+        onClick={this._onClick}
       >
-        <FlexBox
-          className={classnames(cssClass.BG,
-            checked && cssClass.CHECKED,
-            disabled && cssClass.DISABLED,
-            hasOutline && cssClass.OUTLINE,
-          )}
-        >
-          <FlexBox justify={Justify.BETWEEN} grow>
-            <FlexBox column justify={Justify.CENTER}><Checkmark className={cssClass.CHECKED_ICON} /></FlexBox>
-            <FlexBox column justify={Justify.CENTER}><CloseIcon className={cssClass.UNCHECKED_ICON} /></FlexBox>
-          </FlexBox>
+        <FlexBox justify={Justify.BETWEEN} grow>
+          <FlexBox column justify={Justify.CENTER}><Checkmark className={cssClass.CHECKED_ICON} /></FlexBox>
+          <FlexBox column justify={Justify.CENTER}><CloseIcon className={cssClass.UNCHECKED_ICON} /></FlexBox>
         </FlexBox>
         <div
           className={classnames(cssClass.HANDLE, checked && cssClass.CHECKED, disabled && cssClass.DISABLED)}
@@ -101,21 +85,7 @@ export default class Switch extends React.PureComponent {
     );
   }
 
-  _onFocus = () => {
-    if (!this.state.mouseDown && !this.props.disabled) {
-      this.setState({hasOutline: true});
-    }
-  }
-
-  _onBlur = () => {
-    this.setState({hasOutline: false});
-  }
-
-  _onMouseDown = () => {
-    this.setState({mouseDown: true});
-  }
-
-  _onMouseUp = () => {
+  _onClick = () => {
     const {onChange, checked, disabled} = this.props;
     this.setState({mouseDown: false});
     if (!disabled) {


### PR DESCRIPTION
**Jira:**

**Overview:**
Display switch focus when focus is trigged by clicking.

**Screenshots/GIFs:**
![screen recording 2018-12-18 at 04 13 pm](https://user-images.githubusercontent.com/18291415/50190886-e84f8980-02df-11e9-9a08-fed96548d0c5.gif)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
