### PR TITLE
Prevent Checkbox and Radio from shrinking in their flexbox containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.36.10",
+  "version": "0.36.11",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Checkbox/Checkbox.less
+++ b/src/Checkbox/Checkbox.less
@@ -18,6 +18,7 @@
 }
 
 .Checkbox--outer {
+  .flexShrink(0);
   background-color: @neutral_white;
   border-radius: @checkboxBorderRadius;
   border: @checkboxBorderWidth solid @primary_blue_tint_2;

--- a/src/RadioGroup/Radio.less
+++ b/src/RadioGroup/Radio.less
@@ -17,6 +17,7 @@
 
 .Radio--outer {
   .circle(auto);
+  .flexShrink(0);
   background-color: @neutral_white;
   border: @radioOuterBorderWidth solid @primary_blue_tint_2;
   transition: @radioTransition;


### PR DESCRIPTION
**Overview:**
Forgot to add `flex-shrink: 0` rules to the checkbox and radio SVGs so they don't shrink when space-constrained.

**Screenshots/GIFs:**

**Before:**
<img width="266" alt="screen shot 2019-01-07 at 5 23 02 pm" src="https://user-images.githubusercontent.com/16216084/50803989-f3735500-12a0-11e9-9452-949820f2318a.png">

**After:**
<img width="261" alt="screen shot 2019-01-07 at 5 23 13 pm" src="https://user-images.githubusercontent.com/16216084/50803997-f8d09f80-12a0-11e9-809e-28fefaa13bb2.png">

**Testing:**
- [n/a] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
