### PR TITLE
Removed unneeded "Install awscli for ECR publish" command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,15 +21,5 @@ jobs:
         name: npm install
     - run: make build
     - run: make test
-    - run:
-        command: |-
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            cd /tmp/ && wget https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
-            sudo apt-get -y update
-            sudo apt-get install python-dev
-            sudo pip install --upgrade awscli && aws --version
-            pip install --upgrade --user awscli
-          fi;
-        name: Install awscli for s3 asset upload
     - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN .; fi;
     - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/s3-upload dist/css/ s3://assets.clever.com/design/; fi;


### PR DESCRIPTION
## This an automated PR
*Risk rating*: low :cat:

Individual circle-ci commands now install the awscli automatically.

Also removed deprecated report-card commands.

Context:
- https://clever.atlassian.net/browse/INFRA-3343
