### PR TITLE
SYNC-949: sticky sidebar HOC

### DIFF
--- a/src/Sidebar/Sidebar.less
+++ b/src/Sidebar/Sidebar.less
@@ -1,0 +1,11 @@
+@import "../less/fonts.less";
+@import (reference) "../less/index";
+
+.Sidebar {
+  .flexbox();
+}
+
+.Sidebar--sidebar {
+  .flex(0, 1, 18rem);
+  max-width: 18rem;
+}

--- a/src/Sidebar/Sidebar.tsx
+++ b/src/Sidebar/Sidebar.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import * as classnames from "classnames";
+import * as PropTypes from "prop-types";
+import {Sticky, StickyContainer} from "react-sticky";
+
+import "./Sidebar.less";
+
+const cssClass = {
+  CONTAINER: "Sidebar",
+  SIDEBAR: "Sidebar--sidebar",
+};
+
+
+export default function sidebar(sticky, content) {
+  return class extends React.PureComponent {
+    propTypes = {
+      style: PropTypes.object,
+    }
+    render() {
+      return (
+        <StickyContainer className={classnames(cssClass.CONTAINER)}>
+          <div className={cssClass.SIDEBAR}>
+            {!sticky ? content :
+              <Sticky>
+                {({style}) => <div style={style}>{content}</div>}
+              </Sticky>}
+          </div>
+        </StickyContainer>
+      );
+    }
+  };
+}

--- a/src/Sidebar/index.ts
+++ b/src/Sidebar/index.ts
@@ -1,0 +1,2 @@
+import sidebar from "./Sidebar";
+export default sidebar;

--- a/src/index.js
+++ b/src/index.js
@@ -101,3 +101,6 @@ export {ProgressBar};
 
 import {ToastStack, ToastType} from "./ToastStack";
 export {ToastStack, ToastType};
+
+import Sidebar from "./Sidebar";
+export {Sidebar};


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/SYNC-949

**Overview:**
A sticky sidebar. There's nothing about this that makes it a sidebar. It's just a sticky container HOC. Maybe this should be renamed?

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
