### PR TITLE
fix DateInput failing to render

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.36.12",
+  "version": "0.36.13",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-autosize-textarea": "^3.0.1",
     "react-bootstrap": "0.32.1",
     "react-copy-to-clipboard": "^4.3.1",
-    "react-datepicker": "^1.6.0",
+    "react-datepicker": "~1.6.0",
     "react-datetime": "^2.14.0",
     "react-dropzone": "^3.11.0",
     "react-fontawesome": "^1.6.1",


### PR DESCRIPTION
**Overview:**
We noticed that the DateInput page in the docs is broken. This change locks react-datepicker to the last version that renders without failing.

The error
<img width="789" alt="screen shot 2019-01-16 at 12 06 45 am" src="https://user-images.githubusercontent.com/32328921/51267363-5edcb700-1972-11e9-997a-5dc697a6989c.png">


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
