### PR TITLE
Move classname to top level of ProgressBar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "0.36.10",
+  "version": "0.37.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ProgressBar/ProgressBar.tsx
+++ b/src/ProgressBar/ProgressBar.tsx
@@ -74,6 +74,7 @@ export default class ProgressBar extends React.PureComponent {
         className={classnames(
           cssClass.CONTAINER,
           inactive && cssClass.INACTIVE,
+          className,
         )}
       >
         <FlexBox
@@ -91,7 +92,6 @@ export default class ProgressBar extends React.PureComponent {
               className={classnames(
                 cssClass.BAR_CONTAINER,
                 cssClass.containerSize(size),
-                className,
               )}
               style={{
                 ...style,

--- a/test/Button_test.jsx
+++ b/test/Button_test.jsx
@@ -29,7 +29,7 @@ describe("Button", () => {
   it("throws an error for small, destructive buttons", () => {
     assert.throws(() => {
       shallow(<Button size="small" type="destructive" value="A bad button" />);
-    }, "Small destructive buttons are not supported");
+    }, /Small destructive buttons are not supported$/);
   });
 
   it("renders a <button> element with [type=button]", () => {
@@ -56,7 +56,7 @@ describe("Button", () => {
   it("throws an error if href and submit are both set", () => {
     assert.throws(() => {
       shallow(<Button value="A bad button" href="http://clever.com" submit />);
-    }, "Buttons with href do not support the submit option");
+    }, /Buttons with href do not support the submit option$/);
   });
 
   it("calls the onClick handler when clicked", () => {


### PR DESCRIPTION
**Overview:** Moving up the className prop to allow for easier customization by consumers. If we need a className prop back where it was we can easily add it in under a different name later.

This PR also fixes the Button test that is now failing. Turns out, assert.throws no longer likes just a string, you have to pass in a regex for it to work.

**Testing:**
- [X] Unit tests

**Roll Out:**
- Before merging:
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version minor`
    - Backward compatible change? Run `npm version patch`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
