### PR TITLE
Set up pre-specified form element sizes

### DIFF
--- a/docs/components/CopyableInputView.jsx
+++ b/docs/components/CopyableInputView.jsx
@@ -106,7 +106,7 @@ export default class CopyableInputView extends Component {
                 {content: "small", value: FormElementSize.SMALL},
                 {content: "medium", value: FormElementSize.MEDIUM},
                 {content: "large", value: FormElementSize.LARGE},
-                {content: "unbounded", value: FormElementSize.UNBOUNDED},
+                {content: "full-width", value: FormElementSize.FULL_WIDTH},
               ]}
               value={this.state.size}
               onSelect={value => this.setState({size: value})}
@@ -225,7 +225,7 @@ export default class CopyableInputView extends Component {
                   <span key={size}><code>FormElementSize.{size}</code><br /></span>)}
               </p>,
               optional: true,
-              defaultValue: <code>FormElementSize.UNBOUNDED</code>,
+              defaultValue: <code>FormElementSize.FULL_WIDTH</code>,
             },
           ]}
           className={cssClass.PROPS}

--- a/docs/components/CopyableInputView.jsx
+++ b/docs/components/CopyableInputView.jsx
@@ -3,7 +3,7 @@ import React, {Component} from "react";
 import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import {CopyableInput} from "src";
+import {CopyableInput, FormElementSize, SegmentedControl} from "src";
 
 import "./CopyableInputView.less";
 
@@ -19,6 +19,7 @@ export default class CopyableInputView extends Component {
       inputValue: "🙈 🙉 🙊",
       obscured: true,
       required: false,
+      size: FormElementSize.MEDIUM,
     };
   }
 
@@ -33,7 +34,7 @@ export default class CopyableInputView extends Component {
         </p>
 
         <Example>
-          <div className={cssClass.INPUT_CONTAINER}>
+          <div>
             <ExampleCode>
               <CopyableInput
                 enableCopy
@@ -48,6 +49,7 @@ export default class CopyableInputView extends Component {
                 placeholder="CopyableInput Placeholder"
                 onChange={e => this.setState({inputValue: e.target.value})}
                 value={this.state.inputValue}
+                size={this.state.size}
               />
             </ExampleCode>
           </div>
@@ -96,6 +98,20 @@ export default class CopyableInputView extends Component {
             {" "}
             Obscured
           </label>
+          <div className={cssClass.CONFIG}>
+            Size:
+            <SegmentedControl
+              className={cssClass.CONFIG_OPTIONS}
+              options={[
+                {content: "small", value: FormElementSize.SMALL},
+                {content: "medium", value: FormElementSize.MEDIUM},
+                {content: "large", value: FormElementSize.LARGE},
+                {content: "unbounded", value: FormElementSize.UNBOUNDED},
+              ]}
+              value={this.state.size}
+              onSelect={value => this.setState({size: value})}
+            />
+          </div>
         </Example>
 
         <PropDocumentation
@@ -200,6 +216,17 @@ export default class CopyableInputView extends Component {
               description: "Value of input",
               optional: true,
             },
+            {
+              name: "size",
+              type: "string",
+              description: <p>
+                The size of the input. One of:<br />
+                {Object.keys(FormElementSize).map(size =>
+                  <span key={size}><code>FormElementSize.{size}</code><br /></span>)}
+              </p>,
+              optional: true,
+              defaultValue: <code>FormElementSize.UNBOUNDED</code>,
+            },
           ]}
           className={cssClass.PROPS}
         />
@@ -209,7 +236,7 @@ export default class CopyableInputView extends Component {
 }
 
 CopyableInputView.cssClass = {
-  CONFIG: "CopyableInputView--config",
   CONTAINER: "CopyableInputView",
-  INPUT_CONTAINER: "CopyableInputView--inputContainer",
+  CONFIG: "CopyableInputView--config",
+  CONFIG_OPTIONS: "CopyableInputView--configOptions",
 };

--- a/docs/components/CopyableInputView.less
+++ b/docs/components/CopyableInputView.less
@@ -1,11 +1,5 @@
 @import (reference) "~less/index";
 
-
-.CopyableInputView--inputContainer {
-  max-width: 25rem;
-  min-width: 15rem;
-}
-
 .CopyableInputView--config {
   .text--small;
   cursor: pointer;
@@ -13,4 +7,9 @@
   margin: @size_xs;
   margin-left: 0;
   text-transform: uppercase;
+}
+
+.CopyableInputView--configOptions {
+  .margin--left--2xs();
+  display: inline-block;
 }

--- a/docs/components/DateInputView.jsx
+++ b/docs/components/DateInputView.jsx
@@ -99,7 +99,7 @@ export default class DateInputView extends Component {
                 {content: "small", value: FormElementSize.SMALL},
                 {content: "medium", value: FormElementSize.MEDIUM},
                 {content: "large", value: FormElementSize.LARGE},
-                {content: "unbounded", value: FormElementSize.UNBOUNDED},
+                {content: "full-width", value: FormElementSize.FULL_WIDTH},
               ]}
               value={this.state.size}
               onSelect={value => this.setState({size: value})}
@@ -208,7 +208,7 @@ export default class DateInputView extends Component {
                   <span key={size}><code>FormElementSize.{size}</code><br /></span>)}
               </p>,
               optional: true,
-              defaultValue: <code>FormElementSize.UNBOUNDED</code>,
+              defaultValue: <code>FormElementSize.FULL_WIDTH</code>,
             },
           ]}
         />

--- a/docs/components/DateInputView.jsx
+++ b/docs/components/DateInputView.jsx
@@ -3,7 +3,7 @@ import React, {Component} from "react";
 import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import {DateInput} from "src";
+import {DateInput, FormElementSize, SegmentedControl} from "src";
 
 import "./DateInputView.less";
 
@@ -18,6 +18,7 @@ export default class DateInputView extends Component {
       required: false,
       useTime: false,
       value: null,
+      size: FormElementSize.MEDIUM,
     };
   }
 
@@ -42,6 +43,7 @@ export default class DateInputView extends Component {
               required={this.state.required}
               value={this.state.value}
               useTime={this.state.useTime}
+              size={this.state.size}
             />
           </ExampleCode>
           <label className={cssClass.CONFIG}>
@@ -89,6 +91,20 @@ export default class DateInputView extends Component {
             {" "}
             Use Time
           </label>
+          <div className={cssClass.CONFIG}>
+            Size:
+            <SegmentedControl
+              className={cssClass.CONFIG_OPTIONS}
+              options={[
+                {content: "small", value: FormElementSize.SMALL},
+                {content: "medium", value: FormElementSize.MEDIUM},
+                {content: "large", value: FormElementSize.LARGE},
+                {content: "unbounded", value: FormElementSize.UNBOUNDED},
+              ]}
+              value={this.state.size}
+              onSelect={value => this.setState({size: value})}
+            />
+          </div>
         </Example>
 
         <PropDocumentation
@@ -183,6 +199,17 @@ export default class DateInputView extends Component {
               description: "Position of the pop-up calendar relative to the input.",
               optional: true,
             },
+            {
+              name: "size",
+              type: "string",
+              description: <p>
+                The size of the input. One of:<br />
+                {Object.keys(FormElementSize).map(size =>
+                  <span key={size}><code>FormElementSize.{size}</code><br /></span>)}
+              </p>,
+              optional: true,
+              defaultValue: <code>FormElementSize.UNBOUNDED</code>,
+            },
           ]}
         />
       </View>
@@ -191,7 +218,7 @@ export default class DateInputView extends Component {
 }
 
 DateInputView.cssClass = {
-  CONFIG: "DateInputView--config",
   CONTAINER: "DateInputView",
-  INPUT_CONTAINER: "DateInputView--inputContainer",
+  CONFIG: "DateInputView--config",
+  CONFIG_OPTIONS: "DateInputView--configOptions",
 };

--- a/docs/components/DateInputView.less
+++ b/docs/components/DateInputView.less
@@ -1,11 +1,5 @@
 @import (reference) "~less/index";
 
-
-.DateInputView--inputContainer {
-  max-width: 25rem;
-  min-width: 15rem;
-}
-
 .DateInputView--config {
   .text--small;
   cursor: pointer;
@@ -13,4 +7,9 @@
   margin: @size_xs;
   margin-left: 0;
   text-transform: uppercase;
+}
+
+.DateInputView--configOptions {
+  .margin--left--2xs();
+  display: inline-block;
 }

--- a/docs/components/FileInputView.jsx
+++ b/docs/components/FileInputView.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import {FileInput} from "src";
+import {FileInput, FormElementSize, SegmentedControl} from "src";
 
 import "./FileInputView.less";
 
@@ -27,11 +27,19 @@ function storeFn(_file, {progress, success}) {
   }, 32);
 }
 
-export default function FileInputView() {
-  const {cssClass} = FileInputView;
+const cssClass = {
+  CONTAINER: "FileInputView",
+  CONFIG: "FileInputView--config",
+  CONFIG_OPTIONS: "FileInputView--configOptions",
+};
 
-  return (
-    <View className={cssClass.CONTAINER} title="FileInput">
+export default class FileInputView extends React.PureComponent {
+  state = {
+    size: FormElementSize.MEDIUM,
+  };
+
+  render() {
+    return (<View className={cssClass.CONTAINER} title="FileInput">
       <p>An input component that allows users to drag and drop (or click and select) files.</p>
       <Example>
         <div>
@@ -56,6 +64,7 @@ export default function FileInputView() {
                   }
                 }, 100);
               }}
+              size={this.state.size}
             />
           </ExampleCode>
           <p>Takes a <code>store</code> function which is called when the user has selected a file that should be uploaded.
@@ -65,6 +74,20 @@ export default function FileInputView() {
             <li><code>error</code> - Called if the upload failed for unexpected reasons with an optional error message</li>
             <li><code>progress</code> - Called during upload with a number between 0-100 representing the % completed</li>
           </ul>
+          <div className={cssClass.CONFIG}>
+            Size:
+            <SegmentedControl
+              className={cssClass.CONFIG_OPTIONS}
+              options={[
+                {content: "small", value: FormElementSize.SMALL},
+                {content: "medium", value: FormElementSize.MEDIUM},
+                {content: "large", value: FormElementSize.LARGE},
+                {content: "unbounded", value: FormElementSize.UNBOUNDED},
+              ]}
+              value={this.state.size}
+              onSelect={value => this.setState({size: value})}
+            />
+          </div>
         </div>
       </Example>
 
@@ -117,14 +140,21 @@ export default function FileInputView() {
             defaultValue: "false",
             optional: true,
           },
+          {
+            name: "size",
+            type: "string",
+            description: <p>
+              The size of the input. One of:<br />
+              {Object.keys(FormElementSize).map(size =>
+                <span key={size}><code>FormElementSize.{size}</code><br /></span>)}
+            </p>,
+            optional: true,
+            defaultValue: <code>FormElementSize.UNBOUNDED</code>,
+          },
         ]}
         className={cssClass.PROPS}
         title="FileInput"
       />
-    </View>
-  );
+    </View>);
+  }
 }
-
-FileInputView.cssClass = {
-  CONTAINER: "FileInputView",
-};

--- a/docs/components/FileInputView.jsx
+++ b/docs/components/FileInputView.jsx
@@ -82,7 +82,7 @@ export default class FileInputView extends React.PureComponent {
                 {content: "small", value: FormElementSize.SMALL},
                 {content: "medium", value: FormElementSize.MEDIUM},
                 {content: "large", value: FormElementSize.LARGE},
-                {content: "unbounded", value: FormElementSize.UNBOUNDED},
+                {content: "full-width", value: FormElementSize.FULL_WIDTH},
               ]}
               value={this.state.size}
               onSelect={value => this.setState({size: value})}
@@ -149,7 +149,7 @@ export default class FileInputView extends React.PureComponent {
                 <span key={size}><code>FormElementSize.{size}</code><br /></span>)}
             </p>,
             optional: true,
-            defaultValue: <code>FormElementSize.UNBOUNDED</code>,
+            defaultValue: <code>FormElementSize.FULL_WIDTH</code>,
           },
         ]}
         className={cssClass.PROPS}

--- a/docs/components/FileInputView.less
+++ b/docs/components/FileInputView.less
@@ -4,3 +4,17 @@
   height: @size_3xl;
   width: @size_3xl;
 }
+
+.FileInputView--config {
+  .margin--xs();
+  .margin--left--none();
+  .text--caps();
+  .text--small();
+  cursor: pointer;
+  display: inline-block;
+}
+
+.FileInputView--configOptions {
+  .margin--left--2xs();
+  display: inline-block;
+}

--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -4,7 +4,7 @@ import React, {Component} from "react";
 import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import {Select, TextInput} from "src";
+import {FormElementSize, SegmentedControl, Select, TextInput} from "src";
 
 import "./SelectView.less";
 
@@ -24,6 +24,7 @@ export default class SelectView extends Component {
       selectValue: null,
       required: false,
       error: "",
+      size: FormElementSize.MEDIUM,
     };
   }
 
@@ -42,10 +43,11 @@ export default class SelectView extends Component {
         </p>
 
         <Example>
-          <div className={cssClass.INPUT_CONTAINER}>
+          <div>
             <ExampleCode>
               <Select
                 id="select"
+                className={cssClass.INPUT}
                 label="Select Label"
                 disabled={this.state.disabled}
                 clearable={this.state.clearable}
@@ -71,6 +73,7 @@ export default class SelectView extends Component {
                 }
                 placeholder="Select Placeholder"
                 value={this.state.selectValue}
+                size={this.state.size}
               />
             </ExampleCode>
           </div>
@@ -162,6 +165,20 @@ export default class SelectView extends Component {
               name="InputError"
               onChange={e => this.setState({error: e.target.value})}
               value={this.state.error}
+            />
+          </div>
+          <div className={cssClass.CONFIG}>
+            Size:
+            <SegmentedControl
+              className={cssClass.CONFIG_OPTIONS}
+              options={[
+                {content: "small", value: FormElementSize.SMALL},
+                {content: "medium", value: FormElementSize.MEDIUM},
+                {content: "large", value: FormElementSize.LARGE},
+                {content: "unbounded", value: FormElementSize.UNBOUNDED},
+              ]}
+              value={this.state.size}
+              onSelect={value => this.setState({size: value})}
             />
           </div>
         </Example>
@@ -305,6 +322,17 @@ export default class SelectView extends Component {
               description: "Selected option. Must be updated by caller in the onChange",
               optional: true,
             },
+            {
+              name: "size",
+              type: "string",
+              description: <p>
+                The size of the input. One of:<br />
+                {Object.keys(FormElementSize).map(size =>
+                  <span key={size}><code>FormElementSize.{size}</code><br /></span>)}
+              </p>,
+              optional: true,
+              defaultValue: <code>FormElementSize.UNBOUNDED</code>,
+            },
           ]}
           className={cssClass.PROPS}
           title="Select"
@@ -315,7 +343,8 @@ export default class SelectView extends Component {
 }
 
 SelectView.cssClass = {
-  CONFIG: "SelectView--config",
   CONTAINER: "SelectView",
-  INPUT_CONTAINER: "SelectView--inputContainer",
+  INPUT: "SelectView--input",
+  CONFIG: "SelectView--config",
+  CONFIG_OPTIONS: "SelectView--configOptions",
 };

--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -175,7 +175,7 @@ export default class SelectView extends Component {
                 {content: "small", value: FormElementSize.SMALL},
                 {content: "medium", value: FormElementSize.MEDIUM},
                 {content: "large", value: FormElementSize.LARGE},
-                {content: "unbounded", value: FormElementSize.UNBOUNDED},
+                {content: "full-width", value: FormElementSize.FULL_WIDTH},
               ]}
               value={this.state.size}
               onSelect={value => this.setState({size: value})}
@@ -331,7 +331,7 @@ export default class SelectView extends Component {
                   <span key={size}><code>FormElementSize.{size}</code><br /></span>)}
               </p>,
               optional: true,
-              defaultValue: <code>FormElementSize.UNBOUNDED</code>,
+              defaultValue: <code>FormElementSize.FULL_WIDTH</code>,
             },
           ]}
           className={cssClass.PROPS}

--- a/docs/components/SelectView.less
+++ b/docs/components/SelectView.less
@@ -1,9 +1,7 @@
 @import (reference) "~less/index";
 
-
-.SelectView--inputContainer {
-  max-width: 25rem;
-  min-width: 15rem;
+.SelectView--input {
+  .zIndex--1();
 }
 
 .SelectView--config {
@@ -13,4 +11,9 @@
   margin: @size_xs;
   margin-left: 0;
   text-transform: uppercase;
+}
+
+.SelectView--configOptions {
+  .margin--left--2xs();
+  display: inline-block;
 }

--- a/docs/components/TextAreaView.jsx
+++ b/docs/components/TextAreaView.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import Example, {ExampleCode} from "./Example";
 import View from "./View";
-import {TextArea} from "src";
+import {FormElementSize, SegmentedControl, TextArea} from "src";
 import PropDocumentation from "./PropDocumentation";
 
 import "./TextAreaView.less";
@@ -18,6 +18,7 @@ export default class TextAreaView extends React.Component {
       inputValue: "",
       autoResize: true,
       placeholder: true,
+      size: FormElementSize.MEDIUM,
     };
   }
 
@@ -44,6 +45,7 @@ export default class TextAreaView extends React.Component {
               placeholder={this.state.placeholder ? "TextArea Placeholder" : ""}
               onChange={e => this.setState({inputValue: e.target.value})}
               value={this.state.inputValue}
+              size={this.state.size}
             />
           </ExampleCode>
           <label className={cssClass.CONFIG}>
@@ -111,6 +113,20 @@ export default class TextAreaView extends React.Component {
             {" "}
             Show Placeholder
           </label>
+          <div className={cssClass.CONFIG}>
+            Size:
+            <SegmentedControl
+              className={cssClass.CONFIG_OPTIONS}
+              options={[
+                {content: "small", value: FormElementSize.SMALL},
+                {content: "medium", value: FormElementSize.MEDIUM},
+                {content: "large", value: FormElementSize.LARGE},
+                {content: "unbounded", value: FormElementSize.UNBOUNDED},
+              ]}
+              value={this.state.size}
+              onSelect={value => this.setState({size: value})}
+            />
+          </div>
         </Example>
 
         <PropDocumentation
@@ -231,15 +247,26 @@ export default class TextAreaView extends React.Component {
               optional: true,
               defaultValue: 1,
             },
+            {
+              name: "size",
+              type: "string",
+              description: <p>
+                The size of the input. One of:<br />
+                {Object.keys(FormElementSize).map(size =>
+                  <span key={size}><code>FormElementSize.{size}</code><br /></span>)}
+              </p>,
+              optional: true,
+              defaultValue: <code>FormElementSize.UNBOUNDED</code>,
+            },
           ]}
         />
       </View>
     );
   }
-
 }
 
 TextAreaView.cssClass = {
-  CONFIG: "TextAreaView--config",
   CONTAINER: "TextAreaView",
+  CONFIG: "TextAreaView--config",
+  CONFIG_OPTIONS: "TextAreaView--configOptions",
 };

--- a/docs/components/TextAreaView.jsx
+++ b/docs/components/TextAreaView.jsx
@@ -121,7 +121,7 @@ export default class TextAreaView extends React.Component {
                 {content: "small", value: FormElementSize.SMALL},
                 {content: "medium", value: FormElementSize.MEDIUM},
                 {content: "large", value: FormElementSize.LARGE},
-                {content: "unbounded", value: FormElementSize.UNBOUNDED},
+                {content: "full-width", value: FormElementSize.FULL_WIDTH},
               ]}
               value={this.state.size}
               onSelect={value => this.setState({size: value})}
@@ -256,7 +256,7 @@ export default class TextAreaView extends React.Component {
                   <span key={size}><code>FormElementSize.{size}</code><br /></span>)}
               </p>,
               optional: true,
-              defaultValue: <code>FormElementSize.UNBOUNDED</code>,
+              defaultValue: <code>FormElementSize.FULL_WIDTH</code>,
             },
           ]}
         />

--- a/docs/components/TextAreaView.less
+++ b/docs/components/TextAreaView.less
@@ -1,24 +1,15 @@
 @import (reference) "~less/index";
 
-.TextAreaView--inputContainer {
-  max-width: 25rem;
-  min-width: 15rem;
-}
-
-.TextAreaView--configContainer {
-  display: inline-block;
-  .margin--right--xl;
-  .margin--top--l;
-}
-
 .TextAreaView--config {
-  .border--top--l(@neutral_silver);
-  .margin--top--l;
-  .margin--right--xl;
+  .margin--xs();
+  .margin--left--none();
+  .text--caps();
+  .text--small();
   cursor: pointer;
-  display: block;
+  display: inline-block;
+}
 
-  &:not(:last-child) {
-    .margin--bottom--s;
-  }
+.TextAreaView--configOptions {
+  .margin--left--2xs();
+  display: inline-block;
 }

--- a/docs/components/TextInputView.jsx
+++ b/docs/components/TextInputView.jsx
@@ -116,7 +116,7 @@ export default class TextInputView extends Component {
                 {content: "small", value: FormElementSize.SMALL},
                 {content: "medium", value: FormElementSize.MEDIUM},
                 {content: "large", value: FormElementSize.LARGE},
-                {content: "unbounded", value: FormElementSize.UNBOUNDED},
+                {content: "full-width", value: FormElementSize.FULL_WIDTH},
               ]}
               value={this.state.size}
               onSelect={value => this.setState({size: value})}
@@ -222,7 +222,7 @@ export default class TextInputView extends Component {
                   <span key={size}><code>FormElementSize.{size}</code><br /></span>)}
               </p>,
               optional: true,
-              defaultValue: <code>FormElementSize.UNBOUNDED</code>,
+              defaultValue: <code>FormElementSize.FULL_WIDTH</code>,
             },
             {
               name: "type",

--- a/docs/components/TextInputView.jsx
+++ b/docs/components/TextInputView.jsx
@@ -3,7 +3,7 @@ import React, {Component} from "react";
 import Example, {ExampleCode} from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import {TextInput} from "src";
+import {FormElementSize, SegmentedControl, TextInput} from "src";
 
 import "./TextInputView.less";
 
@@ -20,6 +20,7 @@ export default class TextInputView extends Component {
       obscured: false,
       required: false,
       placeholderCaps: true,
+      size: FormElementSize.MEDIUM,
     };
   }
 
@@ -33,7 +34,7 @@ export default class TextInputView extends Component {
         </p>
 
         <Example>
-          <div className={cssClass.INPUT_CONTAINER}>
+          <div>
             <ExampleCode>
               <TextInput
                 disabled={this.state.disabled}
@@ -49,6 +50,7 @@ export default class TextInputView extends Component {
                 onChange={e => this.setState({inputValue: e.target.value})}
                 value={this.state.inputValue}
                 onMouseOver={e => {console.log("mouseover!", e);}}
+                size={this.state.size}
               />
             </ExampleCode>
           </div>
@@ -106,6 +108,20 @@ export default class TextInputView extends Component {
             {" "}
             Placeholder Caps
           </label>
+          <div className={cssClass.CONFIG}>
+            Size:
+            <SegmentedControl
+              className={cssClass.CONFIG_OPTIONS}
+              options={[
+                {content: "small", value: FormElementSize.SMALL},
+                {content: "medium", value: FormElementSize.MEDIUM},
+                {content: "large", value: FormElementSize.LARGE},
+                {content: "unbounded", value: FormElementSize.UNBOUNDED},
+              ]}
+              value={this.state.size}
+              onSelect={value => this.setState({size: value})}
+            />
+          </div>
         </Example>
 
         <PropDocumentation
@@ -198,6 +214,17 @@ export default class TextInputView extends Component {
               optional: true,
             },
             {
+              name: "size",
+              type: "string",
+              description: <p>
+                The size of the input. One of:<br />
+                {Object.keys(FormElementSize).map(size =>
+                  <span key={size}><code>FormElementSize.{size}</code><br /></span>)}
+              </p>,
+              optional: true,
+              defaultValue: <code>FormElementSize.UNBOUNDED</code>,
+            },
+            {
               name: "type",
               type: "String",
               description: "The type of control to display, tested 'number' and 'text'",
@@ -219,7 +246,7 @@ export default class TextInputView extends Component {
 }
 
 TextInputView.cssClass = {
-  CONFIG: "TextInputView--config",
   CONTAINER: "TextInputView",
-  INPUT_CONTAINER: "TextInputView--inputContainer",
+  CONFIG: "TextInputView--config",
+  CONFIG_OPTIONS: "TextInputView--configOptions",
 };

--- a/docs/components/TextInputView.less
+++ b/docs/components/TextInputView.less
@@ -1,16 +1,15 @@
 @import (reference) "~less/index";
 
-
-.TextInputView--inputContainer {
-  max-width: 25rem;
-  min-width: 15rem;
-}
-
 .TextInputView--config {
-  .text--small;
+  .margin--xs();
+  .margin--left--none();
+  .text--caps();
+  .text--small();
   cursor: pointer;
   display: inline-block;
-  margin: @size_xs;
-  margin-left: 0;
-  text-transform: uppercase;
+}
+
+.TextInputView--configOptions {
+  .margin--left--2xs();
+  display: inline-block;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/CopyableInput/CopyableInput.jsx
+++ b/src/CopyableInput/CopyableInput.jsx
@@ -3,9 +3,11 @@ import * as PropTypes from "prop-types";
 import classnames from "classnames";
 import CopyToClipboard from "react-copy-to-clipboard";
 
+import {FormElementSize, formElementSizeClassName} from "../utils/Forms";
 import {TextInput} from "../TextInput/TextInput";
 
 import "./CopyableInput.less";
+import "../less/forms.less";
 
 /**
  * This is a text input that takes optional props
@@ -33,7 +35,13 @@ export class CopyableInput extends React.Component {
     const type = this.props.type === "password" && this.state.hidden ? "password" : "text";
     const wrapperClass = "CopyableInput";
     return (
-      <div className={classnames(wrapperClass, this.props.className)}>
+      <div
+        className={classnames(
+          wrapperClass,
+          formElementSizeClassName(this.props.size),
+          this.props.className,
+        )}
+      >
         <TextInput
           type={type}
           value={this.props.value}
@@ -42,6 +50,8 @@ export class CopyableInput extends React.Component {
           readOnly={this.props.readOnly}
           label={this.props.label}
           onChange={this.props.onChange}
+          size={FormElementSize.UNBOUNDED /* Rely on the fact that we're bounding the parent
+            container */}
         />
         <div className="CopyableInput--links">
           {this.props.enableShow &&
@@ -70,6 +80,7 @@ CopyableInput.propTypes = Object.assign({},
   }
 );
 
-CopyableInput.defaultPropTypes = {
+CopyableInput.defaultProps = {
   enableCopy: true,
+  size: FormElementSize.UNBOUNDED,
 };

--- a/src/CopyableInput/CopyableInput.jsx
+++ b/src/CopyableInput/CopyableInput.jsx
@@ -50,7 +50,7 @@ export class CopyableInput extends React.Component {
           readOnly={this.props.readOnly}
           label={this.props.label}
           onChange={this.props.onChange}
-          size={FormElementSize.UNBOUNDED /* Rely on the fact that we're bounding the parent
+          size={FormElementSize.FULL_WIDTH /* Rely on the fact that we're bounding the parent
             container */}
         />
         <div className="CopyableInput--links">
@@ -82,5 +82,5 @@ CopyableInput.propTypes = Object.assign({},
 
 CopyableInput.defaultProps = {
   enableCopy: true,
-  size: FormElementSize.UNBOUNDED,
+  size: FormElementSize.FULL_WIDTH,
 };

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -29,7 +29,7 @@ export default class DateInput extends React.Component {
   static popperPlacementPositions = popperPlacementPositions;
 
   static defaultProps = {
-    size: FormElementSize.UNBOUNDED,
+    size: FormElementSize.FULL_WIDTH,
   }
 
   constructor(props) {

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -5,7 +5,10 @@ import classnames from "classnames";
 import ReactDatePicker from "react-datepicker";
 import ReactDateTime from "react-datetime";
 
+import {FormElementSize, formElementSizeClassName} from "../utils/Forms";
+
 import "./DateInput.less";
+import "../less/forms.less";
 
 const popperPlacementPositions = {
   BOTTOM: "bottom",
@@ -24,6 +27,10 @@ const popperPlacementPositions = {
 
 export default class DateInput extends React.Component {
   static popperPlacementPositions = popperPlacementPositions;
+
+  static defaultProps = {
+    size: FormElementSize.UNBOUNDED,
+  }
 
   constructor(props) {
     super(props);
@@ -82,7 +89,13 @@ export default class DateInput extends React.Component {
 
 
     return (
-      <div className={classnames(classes, this.props.className)}>
+      <div
+        className={classnames(
+          classes,
+          formElementSizeClassName(this.props.size),
+          this.props.className,
+        )}
+      >
         <div className="DateInput--infoRow">
           <label className="DateInput--label" htmlFor={this.props.name}>{this.props.label}</label>
           {inputNote}
@@ -151,4 +164,5 @@ DateInput.propTypes = {
   max: dateType,
   useTime: PropTypes.bool,
   popperPlacement: PropTypes.oneOf(Object.values(popperPlacementPositions)),
+  size: PropTypes.oneOf(Object.values(FormElementSize)),
 };

--- a/src/FileInput/FileInput.jsx
+++ b/src/FileInput/FileInput.jsx
@@ -78,7 +78,7 @@ export class FileInput extends React.Component {
   static defaultProps = {
     iconOnly: false,
     className: "",
-    formElementSize: FormElementSize.UNBOUNDED,
+    formElementSize: FormElementSize.FULL_WIDTH,
   }
 
   constructor(props) {

--- a/src/FileInput/FileInput.jsx
+++ b/src/FileInput/FileInput.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 import * as PropTypes from "prop-types";
 import Dropzone from "react-dropzone";
-import {FlexBox, FlexItem} from "../flex";
 import classnames from "classnames";
 
-require("./FileInput.less");
+import {FlexBox, FlexItem} from "../flex";
+import {FormElementSize, formElementSizeClassName} from "../utils/Forms";
+
+import "./FileInput.less";
+import "../less/forms.less";
 
 function DefaultIcon() {
   return (<svg className="FileInput--Icon" width="42px" height="24px" viewBox="0 0 42 24">
@@ -75,6 +78,7 @@ export class FileInput extends React.Component {
   static defaultProps = {
     iconOnly: false,
     className: "",
+    formElementSize: FormElementSize.UNBOUNDED,
   }
 
   constructor(props) {
@@ -150,7 +154,12 @@ export class FileInput extends React.Component {
       if (this.props.customIcon) {
         icon = this.props.customIcon;
       }
-      return (<FlexBox className={classnames("FileInput", this.props.className)}>
+      return (<FlexBox className={classnames(
+        "FileInput",
+        formElementSizeClassName(this.props.size),
+        this.props.className,
+      )}
+      >
         {!iconOnly && selected && renderLabel(label)}
         {!iconOnly && renderMessage(message, selected)}
         {icon}
@@ -168,4 +177,5 @@ FileInput.propTypes = {
   label: PropTypes.string,
   store: PropTypes.func.isRequired,
   accept: PropTypes.string,
+  size: PropTypes.string,
 };

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -3,8 +3,11 @@ import * as PropTypes from "prop-types";
 import ReactSelect from "react-select";
 import classnames from "classnames";
 
+import {FormElementSize, formElementSizeClassName} from "../utils/Forms";
+
 import "react-select/dist/react-select.css";
 import "./Select.less";
+import "../less/forms.less";
 
 function isLabelHidden(placeholder, value) {
   if (!placeholder) {
@@ -46,6 +49,7 @@ export function Select({
   value,
   className,
   error,
+  size,
 }) {
   const {cssClass} = Select;
 
@@ -100,7 +104,13 @@ export function Select({
   // The label container must be returned after the ReactSelect otherwise it does not get displayed
   // in the browser.
   return (
-    <div className={classnames(cssClass.CONTAINER, wrapperClass)}>
+    <div
+      className={classnames(
+        cssClass.CONTAINER,
+        formElementSizeClassName(size),
+        wrapperClass,
+      )}
+    >
       <div id={id}>
         <SelectComponent
           className={reactSelectClasses}
@@ -171,6 +181,8 @@ Select.propTypes = {
   ]),
   className: PropTypes.string,
   error: PropTypes.string,
+  // Object.values isn't properly polyfilled in jsx files
+  size: PropTypes.oneOf(Object.keys(FormElementSize).map((key) => FormElementSize[key])),
 };
 
 Select.defaultProps = {
@@ -178,4 +190,5 @@ Select.defaultProps = {
   placeholder: "",
   searchable: false,
   creatable: false,
+  size: FormElementSize.UNBOUNDED,
 };

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -190,5 +190,5 @@ Select.defaultProps = {
   placeholder: "",
   searchable: false,
   creatable: false,
-  size: FormElementSize.UNBOUNDED,
+  size: FormElementSize.FULL_WIDTH,
 };

--- a/src/TextArea/TextArea.jsx
+++ b/src/TextArea/TextArea.jsx
@@ -159,5 +159,5 @@ TextArea.propTypes = {
 
 TextArea.defaultProps = {
   rows: 1,
-  size: FormElementSize.UNBOUNDED,
+  size: FormElementSize.FULL_WIDTH,
 };

--- a/src/TextArea/TextArea.jsx
+++ b/src/TextArea/TextArea.jsx
@@ -3,7 +3,10 @@ import * as PropTypes from "prop-types";
 import classnames from "classnames";
 import TextareaAutosize from "react-autosize-textarea";
 
+import {FormElementSize, formElementSizeClassName} from "../utils/Forms";
+
 import "./TextArea.less";
+import "../less/forms.less";
 
 export class TextArea extends React.Component {
   static validateProps(props) {
@@ -114,7 +117,13 @@ export class TextArea extends React.Component {
     }
 
     return (
-      <div className={classnames(wrapperClass, this.props.className)}>
+      <div
+        className={classnames(
+          wrapperClass,
+          formElementSizeClassName(this.props.size),
+          this.props.className,
+        )}
+      >
         <div className="TextArea--infoRow">
           <label className="TextArea--label" htmlFor={this.props.name}>{this.props.label}</label>
           {inputNote}
@@ -144,8 +153,11 @@ TextArea.propTypes = {
   className: PropTypes.string,
   autoResize: PropTypes.bool,
   rows: PropTypes.number,
+  // Object.values isn't properly polyfilled in jsx files
+  size: PropTypes.oneOf(Object.keys(FormElementSize).map((key) => FormElementSize[key])),
 };
 
 TextArea.defaultProps = {
   rows: 1,
+  size: FormElementSize.UNBOUNDED,
 };

--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -3,11 +3,15 @@ import * as PropTypes from "prop-types";
 import classnames from "classnames";
 import _ from "lodash";
 
-require("./TextInput.less");
+import {FormElementSize, formElementSizeClassName} from "../utils/Forms";
+
+import "./TextInput.less";
+import "../less/forms.less";
 
 export class TextInput extends React.Component {
   static defaultProps = {
     placeholderCaps: true,
+    size: FormElementSize.UNBOUNDED,
   }
 
   constructor(props) {
@@ -85,7 +89,13 @@ export class TextInput extends React.Component {
     const additionalProps = _.omit(this.props, Object.keys(TextInput.propTypes));
 
     return (
-      <div className={classnames(wrapperClass, this.props.className)}>
+      <div
+        className={classnames(
+          wrapperClass,
+          formElementSizeClassName(this.props.size),
+          this.props.className,
+        )}
+      >
         <div className="TextInput--infoRow">
           <label className="TextInput--label" htmlFor={this.props.name}>{this.props.label}</label>
           {inputNote}
@@ -118,6 +128,7 @@ export class TextInput extends React.Component {
 }
 
 TextInput.propTypes = {
+  className: PropTypes.string,
   disabled: PropTypes.bool,
   disableAutocomplete: PropTypes.bool,
   enableShow: PropTypes.bool,
@@ -132,7 +143,8 @@ TextInput.propTypes = {
   placeholderCaps: PropTypes.bool,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
+  // Object.values isn't properly polyfilled in jsx files
+  size: PropTypes.oneOf(Object.keys(FormElementSize).map((key) => FormElementSize[key])),
   type: PropTypes.string,
   value: PropTypes.node,
-  className: PropTypes.string,
 };

--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -11,7 +11,7 @@ import "../less/forms.less";
 export class TextInput extends React.Component {
   static defaultProps = {
     placeholderCaps: true,
-    size: FormElementSize.UNBOUNDED,
+    size: FormElementSize.FULL_WIDTH,
   }
 
   constructor(props) {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import "core-js"; // Provides es5 polyfills not included by the typescript compi
 
 export * from "./flex";
 export * from "./TabBar";
+export {FormElementSize} from "./utils/Forms";
 export {Modal} from "./Modal/Modal";
 export {Button} from "./Button/Button";
 export {ModalButton} from "./ModalButton/ModalButton";

--- a/src/less/forms.less
+++ b/src/less/forms.less
@@ -1,0 +1,17 @@
+// Keep this in sync with src/utils/Forms.ts
+
+@formElementSizeSmall: 12rem;
+@formElementSizeMedium: 20rem;
+@formElementSizeLarge: 30rem;
+
+.dewey--formElementSize--small {
+  max-width: @formElementSizeSmall;
+}
+
+.dewey--formElementSize--medium {
+  max-width: @formElementSizeMedium;
+}
+
+.dewey--formElementSize--large {
+  max-width: @formElementSizeLarge;
+}

--- a/src/less/utilities.less
+++ b/src/less/utilities.less
@@ -9,6 +9,7 @@
 @import "./display";
 @import "./flex";
 @import "./fonts";
+@import "./forms";
 @import "./grid";
 @import "./layout";
 @import "./resets";

--- a/src/utils/Forms.ts
+++ b/src/utils/Forms.ts
@@ -4,7 +4,7 @@ export const FormElementSize = {
   SMALL: "small",
   MEDIUM: "medium",
   LARGE: "large",
-  UNBOUNDED: "unbounded",
+  FULL_WIDTH: "fullWidth",
 };
 
 export function formElementSizeClassName(size: string): string {

--- a/src/utils/Forms.ts
+++ b/src/utils/Forms.ts
@@ -1,0 +1,12 @@
+// Keep this in sync with src/less/forms.less
+
+export const FormElementSize = {
+  SMALL: "small",
+  MEDIUM: "medium",
+  LARGE: "large",
+  UNBOUNDED: "unbounded",
+};
+
+export function formElementSizeClassName(size: string): string {
+  return `dewey--formElementSize--${size}`;
+}


### PR DESCRIPTION
# JIRA

https://clever.atlassian.net/browse/IL-1008

# Overview

Throughout our product, we have unbounded form elements. These elements look a bit strange and also aren't user friendly.

![oh-my](https://user-images.githubusercontent.com/12616928/52228220-a4e8b480-2866-11e9-8125-63ae7c316e80.png)

This PR introduces a `size` prop

<img width="1035" alt="props-documentation" src="https://user-images.githubusercontent.com/12616928/52228373-1163b380-2867-11e9-85fb-c47ca5351005.png">

to all of the following form elements:

`CopyableInput`
`DateInput`
`FileInput`
`Select`
`TextArea`
`TextInput`

For backwards compatibility, the default `size` is still unbounded. Once we've done some auditing, we can switch the default to be one of the bounded sizes.

## GIFs

![copyableinput](https://user-images.githubusercontent.com/12616928/52228526-6ef80000-2867-11e9-87ef-cb60e44a9ed9.gif)

![dateinput](https://user-images.githubusercontent.com/12616928/52228543-79b29500-2867-11e9-8e9e-1c1531d11dc5.gif)

![fileinput](https://user-images.githubusercontent.com/12616928/52228546-7ddeb280-2867-11e9-93d9-1cc8c6de2760.gif)

![select](https://user-images.githubusercontent.com/12616928/52228552-82a36680-2867-11e9-8996-6e4f50c1ec5b.gif)

![textarea](https://user-images.githubusercontent.com/12616928/52228562-87681a80-2867-11e9-9704-0e2f9350f2d4.gif)

![textinput](https://user-images.githubusercontent.com/12616928/52228568-8b943800-2867-11e9-8dad-e67b64fade96.gif)

# Testing

See the above GIFs! Also browser tested.

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [x] IE

# Rollout

As noted in the Overview, the default size is still unbounded. So Dewey consumers won't experience any automatic changes.