### PR TITLE
Fix color transition faster than width bug

### DIFF
--- a/src/ProgressBar/Progress.less
+++ b/src/ProgressBar/Progress.less
@@ -5,8 +5,8 @@
   height: 100%;
   width: 100%;
   position: absolute;
-  transition: width @timingSlowly ease-out @timingPromptly;
-  -webkit-transition: width @timingSlowly ease-out @timingPromptly;
+  transition: all @timingSlowly ease-out @timingPromptly;
+  -webkit-transition: all @timingSlowly ease-out @timingPromptly;
 }
 
 .ProgressBar--Progress--none {


### PR DESCRIPTION
**Jira:**
[SYNC-1035](https://clever.atlassian.net/browse/SYNC-1035)

**Overview:**
Previously, the color was transitioning faster than the width during animations of progress change, so going from 0% to any non-zero value would cause a brief 100% bar to occur before it went to 1%. This is because the 0% is effectively a 100% filled progress that is transparently colored with a red border. Making the transition apply to all css allows the transition to look smoother.

**Screenshots/GIFs:**
![kapture 2019-02-14 at 17 24 01](https://user-images.githubusercontent.com/7911027/52828441-a80d4d00-307d-11e9-8b32-ec7d16bde05f.gif)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
