### PR TITLE
SYNC-1031: Wizard Layout: section title and subtitle optional

### DIFF
--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -10,8 +10,8 @@ import LifeFloat from "./LifeFloat";
 import "./WizardLayout.less";
 
 const SECTION_PROP_TYPE = PropTypes.shape({
-  title: PropTypes.string.isRequired,
-  subtitle: PropTypes.string.isRequired,
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
   content: PropTypes.node.isRequired,
 });
 
@@ -100,8 +100,8 @@ export default class WizardLayout extends React.PureComponent {
           <FlexBox column grow className={cssClass.SECTION_CONTAINER}>
             {sections.map((elem, i) => (
               <div className={cssClass.SECTION} key={i}>
-                <p className={cssClass.SECTION_TITLE}>{elem.title}</p>
-                <p className={cssClass.SECTION_SUBTITLE}>{elem.subtitle}</p>
+                { elem.title && <p className={cssClass.SECTION_TITLE}>{elem.title}</p>}
+                { elem.subtitle && <p className={cssClass.SECTION_SUBTITLE}>{elem.subtitle}</p>}
                 {elem.content}
               </div>
             ))}


### PR DESCRIPTION
**Jira:**
For content mapping project, some wizard sections must not have a title and subtitle.
https://projects.invisionapp.com/share/7XPR27Y3SH9#/screens/345440224
![image](https://user-images.githubusercontent.com/18291415/53130402-feb3d480-351e-11e9-92e3-7ea73b0231a2.png)

**Overview:**
Make the title and subtitle props optional for wizard layout sections. Conditionally render the steps title and subtitle.

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
