### PR TITLE
SYNC-1031: Divider without subtitle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/WizardLayout/WizardLayout.less
+++ b/src/WizardLayout/WizardLayout.less
@@ -81,7 +81,12 @@
   .text--medium();
   max-width: unset;
   width: 100%;
-  .padding--bottom--xs();
+  .padding--bottom--none();
+  .margin--bottom--none();
+}
+
+.WizardLayout--sectionDivider {
+  .padding--top--xs();
   .border--bottom--s(@neutral_gray);
   .margin--bottom--l();
 }

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -48,6 +48,7 @@ const cssClass = {
   HELP_IMG: "WizardLayout--helpImg",
   PREVIOUS_BUTTON: "WizardLayout--previousButton",
   STEPPER_CONTAINER: "WizardLayout--stepperContainer",
+  SECTION_DIVIDER: "WizardLayout--sectionDivider",
 };
 
 /**
@@ -102,6 +103,7 @@ export default class WizardLayout extends React.PureComponent {
               <div className={cssClass.SECTION} key={i}>
                 { elem.title && <p className={cssClass.SECTION_TITLE}>{elem.title}</p>}
                 { elem.subtitle && <p className={cssClass.SECTION_SUBTITLE}>{elem.subtitle}</p>}
+                { (elem.subtitle || elem.title) && <div className={cssClass.SECTION_DIVIDER} /> }
                 {elem.content}
               </div>
             ))}


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/SYNC-1031

**Overview:**
Currently subtitle of a wizard section renders the divider, so a section with no subtitle will not have a divider under the title.
![image](https://user-images.githubusercontent.com/18291415/53211664-e57e5700-35f6-11e9-9e54-53ca6d7e8422.png)

This PR decouples the divider from the section subtitle and maintains current styling. If a section has no subtitle or title the divider will not render.

**Screenshots/GIFs:**
![image](https://user-images.githubusercontent.com/18291415/53211711-0e9ee780-35f7-11e9-8b9a-d3be4bea5b1a.png)
![image](https://user-images.githubusercontent.com/18291415/53211721-152d5f00-35f7-11e9-99e3-2b20430bcb78.png)
![image](https://user-images.githubusercontent.com/18291415/53211923-cb914400-35f7-11e9-9029-32abaae003a6.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
