### PR TITLE
SYNC-1098: make save & exit button optional

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -56,3 +56,7 @@ rules:
     - 2
     - classes: false
       functions: false
+
+  react/jsx-curly-spacing:
+    - 2
+    - "never"

--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -221,6 +221,7 @@ export default class WizardLayoutView extends React.PureComponent {
             name: "onSaveAndExit",
             type: "Function",
             description: "Called when user clicks on 'Save & exit' button.",
+            optional: true,
           },
           {
             name: "prevStepButtonDisabled",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextTruncate/TextTruncate.tsx
+++ b/src/TextTruncate/TextTruncate.tsx
@@ -61,7 +61,7 @@ export default class TextTruncate extends React.PureComponent {
 
     const displayText = truncated ? `${this.truncate(text)}…` : text;
     return (<div className={classnames(cssClass.CONTAINER, className)}>
-      { useRichText ? <RichText text={displayText} /> : displayText }
+      {useRichText ? <RichText text={displayText} /> : displayText}
       {" "}
       <Button type="linkPlain" onClick={this.toggleTruncation} value={truncated ? showMoreLabel : showLessLabel} />
     </div>);

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -24,7 +24,7 @@ const propTypes = {
   nextStepButtonText: PropTypes.string,
   onNextStep: PropTypes.func.isRequired,
   onPrevStep: PropTypes.func.isRequired,
-  onSaveAndExit: PropTypes.func.isRequired,
+  onSaveAndExit: PropTypes.func,
   prevStepButtonDisabled: PropTypes.bool,
   prevStepButtonText: PropTypes.string,
   stepper: PropTypes.node.isRequired,
@@ -110,11 +110,11 @@ export default class WizardLayout extends React.PureComponent {
           </FlexBox>
         </FlexBox>
         <FlexBox className={cssClass.FOOTER}>
-          <Button
+          { onSaveAndExit && <Button
             type="link"
             value={"Save & exit"}
             onClick={() => onSaveAndExit()}
-          />
+          /> }
           {/* spacer for the buttons */}
           <FlexBox grow />
           <Button

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -77,7 +77,7 @@ export default class WizardLayout extends React.PureComponent {
     return (
       <FlexBox column grow className={classnames(cssClass.CONTAINER, className)}>
         <FlexBox className={cssClass.HEADER}>
-          { headerImg &&
+          {headerImg &&
             <div className={cssClass.HEADER_IMG}>
               {headerImg}
             </div>
@@ -91,30 +91,30 @@ export default class WizardLayout extends React.PureComponent {
           <FlexBox column className={cssClass.STEPPER_CONTAINER}>
             {stepper}
             <FlexBox grow />
-            { helpContent &&
+            {helpContent &&
               <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.HELP_CONTAINER}>
               <LifeFloat className={cssClass.HELP_IMG} />
-                { helpContent }
+                {helpContent}
               </FlexBox>
             }
           </FlexBox>
           <FlexBox column grow className={cssClass.SECTION_CONTAINER}>
             {sections.map((elem, i) => (
               <div className={cssClass.SECTION} key={i}>
-                { elem.title && <p className={cssClass.SECTION_TITLE}>{elem.title}</p>}
-                { elem.subtitle && <p className={cssClass.SECTION_SUBTITLE}>{elem.subtitle}</p>}
-                { (elem.subtitle || elem.title) && <div className={cssClass.SECTION_DIVIDER} /> }
+                {elem.title && <p className={cssClass.SECTION_TITLE}>{elem.title}</p>}
+                {elem.subtitle && <p className={cssClass.SECTION_SUBTITLE}>{elem.subtitle}</p>}
+                {(elem.subtitle || elem.title) && <div className={cssClass.SECTION_DIVIDER} />}
                 {elem.content}
               </div>
             ))}
           </FlexBox>
         </FlexBox>
         <FlexBox className={cssClass.FOOTER}>
-          { onSaveAndExit && <Button
+          {onSaveAndExit && <Button
             type="link"
             value={"Save & exit"}
             onClick={() => onSaveAndExit()}
-          /> }
+          />}
           {/* spacer for the buttons */}
           <FlexBox grow />
           <Button


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/SYNC-1098

**Overview:**
For content mapping the save & exit button should be hidden. This PR makes its rendering conditional based on if the onSaveAndExit prop is provided to the component.

**Screenshots/GIFs:**
![image](https://user-images.githubusercontent.com/18291415/53982670-55e2a900-40ca-11e9-8da9-10e34447893a.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
