### PR TITLE
[Menu] Fix click event handling in Safari

### DIFF
--- a/docs/components/MenuView.jsx
+++ b/docs/components/MenuView.jsx
@@ -197,7 +197,7 @@ export default class MenuView extends React.PureComponent {
               <Menu.Item
                 className={cssClass.CUSTOM_ITEM}
                 customStyles
-                onClick={this._goToPageTwo}
+                onClick={this._goToPageThree}
                 selected={page === "three"}
               >
                 Button With Custom Styling
@@ -351,4 +351,6 @@ export default class MenuView extends React.PureComponent {
   _goToPageOne = () => ReactRouter.hashHistory.push("/components/menu?page=one");
 
   _goToPageTwo = () => ReactRouter.hashHistory.push("/components/menu?page=two");
+
+  _goToPageThree = () => ReactRouter.hashHistory.push("/components/menu?page=three");
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Menu/MenuItem.tsx
+++ b/src/Menu/MenuItem.tsx
@@ -66,6 +66,20 @@ export default class MenuItem extends React.PureComponent {
       MenuButton = href ? "a" : "button";
     }
 
+    // Safari fires focusout events on button mousedown events - it basically removes and returns
+    // focus between mousedown and mouseup. Yes, that is quite weird.
+    //
+    // To avoid closing the menu before the user is done clicking a button menu item, we trigger
+    // onClick on mousedown instead.
+    //
+    // This only needs to be done for buttons, not anchors.
+    let safariSafeOnClick = onClick;
+    let onMouseDown;
+    if (MenuButton === "button") {
+      safariSafeOnClick = undefined;
+      onMouseDown = onClick;
+    }
+
     return (
       <MenuButton
         {...additionalProps}
@@ -78,7 +92,8 @@ export default class MenuItem extends React.PureComponent {
         )}
         href={href}
         onBlur={onBlur}
-        onClick={onClick}
+        onClick={safariSafeOnClick}
+        onMouseDown={onMouseDown}
         role="menuitem"
         tabIndex={-1}
         target={target}
@@ -87,11 +102,6 @@ export default class MenuItem extends React.PureComponent {
       </MenuButton>
     );
   }
-
-  _handleClick = () => {
-    this.props.onClick();
-    this.props.onBlur();
-  };
 
   _updateFocus(props) {
     if (props.focused) {


### PR DESCRIPTION
**Jira:** https://clever.atlassian.net/browse/GOAL-346

**Overview:**
Menu item selection was broken in Safari for `<button>` menu items. Apparently, in between mousedown and mouseup on `<button>`s, Safari fires a focusout event :shrug:

To get around this, when rendering a `<button>` menu item, we do our click handling on mousedown instead, to get ahead of the Safari focus change. (This is not an issue with `<a>` menu items)

**Screenshots/GIFs:**
[![Screenshot from Gyazo](https://gyazo.com/051ea1a6dd2d5d93ed905f38ce132165/raw)](https://gyazo.com/051ea1a6dd2d5d93ed905f38ce132165)

**Testing:**
- [n/a] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE11

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
