### PR TITLE
Node 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/Clever/components
     docker:
-    - image: circleci/node:6.14.3-stretch
+    - image: circleci/node:10.15.3-stretch
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
+include node.mk
+
 SHELL = /bin/bash
+NODE_VERSION := "v10"
+$(eval $(call node-version-check,$(NODE_VERSION)))
 
 BABEL := node_modules/babel-cli/bin/babel.js
 JEST := ./node_modules/.bin/jest --maxWorkers=1 --config ./jestconfig.json

--- a/node.mk
+++ b/node.mk
@@ -1,0 +1,12 @@
+# This is the default Clever Node Makefile.
+# Please do not alter this file directly.
+NODE_MK_VERSION := 0.1.1
+
+# This block checks and confirms that the proper node version is installed.
+# arg1: node version. e.g. v6
+define node-version-check
+_ := $(if \
+	$(shell node -v | grep $(1)), \
+	@echo "", \
+	$(error "Node $(1) is required, use nvm to install / use node it"))
+endef


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/NODE-14

**Overview:**
This change uses node 10 in CircleCi builds. I also added node version checks. 

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
