### PR TITLE
add class to next button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -49,6 +49,7 @@ const cssClass = {
   PREVIOUS_BUTTON: "WizardLayout--previousButton",
   STEPPER_CONTAINER: "WizardLayout--stepperContainer",
   SECTION_DIVIDER: "WizardLayout--sectionDivider",
+  NEXT_BUTTON: "WizardLayout--nextButton",
 };
 
 /**
@@ -127,6 +128,7 @@ export default class WizardLayout extends React.PureComponent {
           <Button
             type="primary"
             value={nextStepButtonText || "Next step"}
+            className={cssClass.NEXT_BUTTON}
             onClick={this._onNextStep}
             disabled={nextStepButtonDisabled}
           />


### PR DESCRIPTION
**Jira:**

**Overview:**
For non-impersonators pendo renders a Clever logo at the bottom right of all pages. This PR adds a css class to the next button so that clients can move the bottom button group out of the way of the pendo clever logo.

**Screenshots/GIFs:**
![image](https://user-images.githubusercontent.com/18291415/55193007-17895880-5163-11e9-88a7-5d3cca76cb16.png)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
