### PR TITLE
Change var used for expanded prop in Accordion

### DIFF
--- a/src/InfoPanel/InfoPanel.jsx
+++ b/src/InfoPanel/InfoPanel.jsx
@@ -18,7 +18,6 @@ export default class InfoPanel extends Component {
     super(props);
     this.state = {
       isCollapsed: !props.defaultOpen,
-      collapseArrow: props.defaultOpen ? "caret-down" : "caret-right",
     };
   }
 
@@ -27,9 +26,8 @@ export default class InfoPanel extends Component {
   }
 
   render() {
-    const { children, className, hideTitle, title, footer, collapsible, defaultOpen } = this.props;
+    const { children, className, hideTitle, title, footer, collapsible } = this.props;
     const { isCollapsed } = this.state;
-    let { collapseArrow } = this.state;
     const { cssClass } = InfoPanel;
     if (!collapsible) {
       return (
@@ -45,6 +43,7 @@ export default class InfoPanel extends Component {
       );
     }
 
+    let collapseArrow;
     if (isCollapsed) {
       collapseArrow = "caret-right";
     } else {
@@ -54,7 +53,7 @@ export default class InfoPanel extends Component {
     return (
       <div className={classnames(cssClass.CONTAINER, className)}>
         <Accordion onChange={keys => this.toggleArrow(keys)}>
-          <AccordionItem expanded={defaultOpen}>
+          <AccordionItem expanded={!isCollapsed}>
             <AccordionItemTitle className={cssClass.COLLAPSIBLE_HEADER}>
               <div>
                 <div className={cssClass.COLLAPSE_ARROW}>


### PR DESCRIPTION
**Overview:** I'm working with the InfoPanel in SD2 and can't seem to get the defaultOpen prop to work. This PR changes what variable controls the expanded prop in efforts to alleviate the problem I am having.

**Testing:**
Tested manually to ensure there was no regression.

**Roll Out:**
- Before merging:
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
