### PR TITLE
Fix menu clicking behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "react-dropzone": "^3.11.0",
     "react-fontawesome": "^1.6.1",
     "react-linkify": "^0.2.1",
-    "react-onclickoutside": "^5.11.1",
     "react-overlays": "^0.8.3",
     "react-select": "^1.2.1",
     "react-sticky": "^6.0.1",

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -2,6 +2,7 @@ import * as _ from "lodash";
 import * as classnames from "classnames";
 import * as PropTypes from "prop-types";
 import * as React from "react";
+import * as RootCloseWrapper from "react-overlays/lib/RootCloseWrapper";
 
 import MenuItem from "./MenuItem";
 import MorePropTypes from "../utils/MorePropTypes";
@@ -101,46 +102,48 @@ export default class Menu extends React.PureComponent {
     const additionalProps = _.omit(this.props, Object.keys(propTypes));
 
     return (
-      <div
-        {...additionalProps}
-        className={classnames(cssClass.CONTAINER, className)}
-        onKeyDown={this._handleKeyDown}
-        onKeyUp={this._handleKeyUp}
-        onBlur={this._handleFocusOut}
-      >
-        {UntypedReact.cloneElement(trigger, {
-          "aria-controls": this.IDs.DROPDOWN,
-          "aria-expanded": open,
-          "aria-haspopup": true,
-          className: classnames(cssClass.TRIGGER, trigger.props.className),
-          id: this.IDs.TRIGGER,
-          onClick: this._handleTriggerClick,
-          ref: this._handleTriggerRef,
-          role: "button",
-        })}
-        {open && (
-          <ul
-            aria-labelled-by={this.IDs.TRIGGER}
-            className={classnames(
-              cssClass.DROPDOWN,
-              cssClass.placement(placement),
-              wrapItems && cssClass.WRAP,
-            )}
-            id={this.IDs.DROPDOWN}
-            role="menu"
-            style={{ maxHeight, maxWidth, minWidth }}
-          >
-            {this._getMenuItems().map((menuItem, i) => (
-              <li className={cssClass.ITEM_WRAPPER} key={i} role="none">
-                {UntypedReact.cloneElement(menuItem, {
-                  focused: this._isFocused(menuItem, i),
-                  onClick: e => this._handleItemClick(menuItem, e),
-                })}
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+      <RootCloseWrapper onRootClose={() => this._setDropdownOpen(false)}>
+        <div
+          {...additionalProps}
+          className={classnames(cssClass.CONTAINER, className)}
+          onKeyDown={this._handleKeyDown}
+          onKeyUp={this._handleKeyUp}
+          onBlur={this._handleFocusOut}
+        >
+          {UntypedReact.cloneElement(trigger, {
+            "aria-controls": this.IDs.DROPDOWN,
+            "aria-expanded": open,
+            "aria-haspopup": true,
+            className: classnames(cssClass.TRIGGER, trigger.props.className),
+            id: this.IDs.TRIGGER,
+            onClick: this._handleTriggerClick,
+            ref: this._handleTriggerRef,
+            role: "button",
+          })}
+          {open && (
+            <ul
+              aria-labelled-by={this.IDs.TRIGGER}
+              className={classnames(
+                cssClass.DROPDOWN,
+                cssClass.placement(placement),
+                wrapItems && cssClass.WRAP,
+              )}
+              id={this.IDs.DROPDOWN}
+              role="menu"
+              style={{ maxHeight, maxWidth, minWidth }}
+            >
+              {this._getMenuItems().map((menuItem, i) => (
+                <li className={cssClass.ITEM_WRAPPER} key={i} role="none">
+                  {UntypedReact.cloneElement(menuItem, {
+                    focused: this._isFocused(menuItem, i),
+                    onClick: e => this._handleItemClick(menuItem, e),
+                  })}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </RootCloseWrapper>
     );
   }
 

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -2,7 +2,6 @@ import * as _ from "lodash";
 import * as classnames from "classnames";
 import * as PropTypes from "prop-types";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 import MenuItem from "./MenuItem";
 import MorePropTypes from "../utils/MorePropTypes";
@@ -91,19 +90,6 @@ export default class Menu extends React.PureComponent {
   _containerEl;
   _triggerRef;
 
-  componentDidMount() {
-    this._containerEl = ReactDOM.findDOMNode(this);
-    if (this._containerEl) {
-      this._containerEl.addEventListener("focusout", this._handleFocusOut);
-    }
-  }
-
-  componentWillUnmount() {
-    if (this._containerEl) {
-      this._containerEl.removeEventListener("focusout", this._handleFocusOut);
-    }
-  }
-
   state = {
     focusIndex: 0,
     open: false,
@@ -120,6 +106,7 @@ export default class Menu extends React.PureComponent {
         className={classnames(cssClass.CONTAINER, className)}
         onKeyDown={this._handleKeyDown}
         onKeyUp={this._handleKeyUp}
+        onBlur={this._handleFocusOut}
       >
         {UntypedReact.cloneElement(trigger, {
           "aria-controls": this.IDs.DROPDOWN,
@@ -183,14 +170,15 @@ export default class Menu extends React.PureComponent {
 
   _handleFocusOut = e => {
     const nextElement = e.relatedTarget;
-    if (
-      nextElement &&
+    if (!nextElement) {
+      return;
+    } else if (
       nextElement.classList.contains(MenuItem.cssClass.CONTAINER) &&
       nextElement.parentNode.parentNode.id === this.IDs.DROPDOWN
     ) {
       return;
     }
-    if (nextElement && nextElement.id === this.IDs.TRIGGER) {
+    if (nextElement.id === this.IDs.TRIGGER) {
       return;
     }
 


### PR DESCRIPTION
The menu misbehaved when you clicked the trigger. 

![](https://cl.ly/37c115e2e58b/Screen%252520Recording%2525202019-04-30%252520at%25252005.34%252520PM.gif)

This was because it was triggering the `focusOut` event, which was closing it, and then the click event was re-opening it. This makes it so we only trigger on `focusOut` when another element is being focused. This preserves the a11y behavior while fixing the clicking issue. 

I also removed some hacky reactDOM usage in favor of just using the built in `onBlur`. All the a11y stuff continues to work with these changes and the UX is certainly better with a mouse. 

![](https://cl.ly/2130bb1641d8/Screen%20Recording%202019-04-30%20at%2006.07%20PM.gif)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10