### PR TITLE
TopBar tweaks

### DIFF
--- a/docs/components/TopBarView.jsx
+++ b/docs/components/TopBarView.jsx
@@ -7,9 +7,8 @@ import FontAwesome from "react-fontawesome";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import { FlexBox, FlexItem, ItemAlign, TextInput } from "src";
+import { FlexBox, FlexItem, ItemAlign, TextInput, Menu } from "src";
 import { TopBar } from "src/TopBar";
-import Menu from "src/Menu";
 
 import "./TopBarView.less";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Menu/MenuItem.less
+++ b/src/Menu/MenuItem.less
@@ -19,6 +19,7 @@ button.Menu--MenuItem--default {
   display: block;
   transition: all @timingPromptly ease-out;
   width: 100%;
+  text-decoration: none;
 
   &:focus,
   &:hover {

--- a/src/TopBar/index.less
+++ b/src/TopBar/index.less
@@ -5,13 +5,16 @@
   height: @topBarHeight;
   min-width: 0;
   transition: all @timingPromptly ease-out;
-  .padding--left--2xs;
-  .padding--right--s;
+  .padding--x--2xs;
   background-image: linear-gradient(90deg, #3980e6 0%, #3965e6 50%, #394de5 100%);
 
   /* stylelint-disable unit-whitelist */
   box-shadow: 0 1px 6px 2px rgba(33, 70, 189, 0.25);
   /* stylelint-enable unit-whitelist */
+
+  &.dewey--TopBar--rightPadding {
+    .padding--right--s;
+  }
 }
 
 .dewey--TopBar--logo {

--- a/src/TopBar/index.tsx
+++ b/src/TopBar/index.tsx
@@ -7,6 +7,7 @@ import { FlexBox, Justify } from "../flex";
 import { TopBarButton } from "./TopBarButton";
 
 import "./index.less";
+import Menu from "../Menu";
 
 const propTypes = {
   children: PropTypes.node,
@@ -26,8 +27,27 @@ export class TopBar extends React.PureComponent {
   render() {
     const { children, className, title } = this.props;
 
+    // If the last element is a "rounded" TopBarButton we need to add some additional padding to the right side.
+    // To determine this we need to inspect the children;
+    let needsRightPadding = false;
+    const childrenArray = React.Children.toArray(children);
+    if (childrenArray.length) {
+      const lastItem = childrenArray[childrenArray.length - 1];
+      const lastTrigger = lastItem.type === Menu ? lastItem.props.trigger : lastItem;
+      if (lastTrigger && lastTrigger.type === TopBarButton && lastTrigger.props.round) {
+        needsRightPadding = true;
+      }
+    }
+
     return (
-      <FlexBox alignItems="center" className={classnames("dewey--TopBar", className)}>
+      <FlexBox
+        alignItems="center"
+        className={classnames(
+          "dewey--TopBar",
+          className,
+          needsRightPadding && "dewey--TopBar--rightPadding",
+        )}
+      >
         <TopBarButton href={this.props.logoHref} className="dewey-TopBar--logoLink">
           <Logo className="dewey--TopBar--logo" />
         </TopBarButton>

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ export { BetaTag };
 import Menu from "./Menu";
 export { Menu };
 
-import TopBar from "./TopBar";
+import { TopBar } from "./TopBar";
 export { TopBar };
 
 import TextTruncate from "./TextTruncate";


### PR DESCRIPTION
Some tweaks to the TopBar I noticed we needed from launchpad.

- Export the (now) named export correctly.
- Don't underline links in the `Menu`
- Change the right padding depending on if the last item is a `round` button or not. I'd love to do this with CSS but sadly you can't since they get nested inside of menus so `:last-child` doesn't work. 

You can see the difference on the docs page if you look at where the hover state ends
![](https://cl.ly/6cd5c3096dab/Screen%20Recording%202019-05-02%20at%2003.11%20PM.gif)