### PR TITLE
Modify box-shadow styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/less/box-shadow.less
+++ b/src/less/box-shadow.less
@@ -20,15 +20,18 @@
 // Convenience mixins
 
 .boxShadow--light {
-  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetS @boxShadowBlurRadiusS @boxShadowDefaultSpread @boxShadowDefaultColor
+  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetS @boxShadowBlurRadiusS
+    @boxShadowDefaultSpread @boxShadowDefaultColor;
 }
 
 .boxShadow--medium {
-  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetM @boxShadowBlurRadiusM @boxShadowDefaultSpread @boxShadowDefaultColor
+  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetM @boxShadowBlurRadiusM
+    @boxShadowDefaultSpread @boxShadowDefaultColor;
 }
 
 .boxShadow--heavy {
-  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetL @boxShadowBlurRadiusL @boxShadowDefaultSpread @boxShadowDefaultColor
+  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetL @boxShadowBlurRadiusL
+    @boxShadowDefaultSpread @boxShadowDefaultColor;
 }
 
 // DEPRECATED - remove once there are no usages of these

--- a/src/less/box-shadow.less
+++ b/src/less/box-shadow.less
@@ -5,15 +5,15 @@
 
 @boxShadowDefaultXOffset: 0;
 
-@boxShadowYOffsetS: @size_4xs;
+@boxShadowYOffsetS: 0.0625rem;
 @boxShadowYOffsetM: 0.1875rem;
 @boxShadowYOffsetL: 0.3125rem;
 
 @boxShadowBlurRadiusS: 0.1875rem;
 @boxShadowBlurRadiusM: 0.375rem;
-@boxShadowBlurRadiusL: @size_s;
+@boxShadowBlurRadiusL: 0.75rem;
 
-@boxShadowDefaultSpread: @size_4xs;
+@boxShadowDefaultSpread: 0.0625rem;
 
 @boxShadowDefaultColor: rgba(71, 76, 94, 0.2);
 
@@ -34,12 +34,13 @@
     @boxShadowDefaultSpread @boxShadowDefaultColor;
 }
 
+.boxShadow(@blurRadius, @color) {
+  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetM @blurRadius
+    @boxShadowDefaultSpread @color;
+}
+
 // DEPRECATED - remove once there are no usages of these
 @boxShadowLightBlack: fade(@neutral_black, 40%);
 @boxShadowMediumBlack: fade(@neutral_black, 50%);
 @boxShadowHeavyBlack: fade(@neutral_black, 70%);
-
-.boxShadow(@blurRadius, @color) {
-  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetM @blurRadius @color;
-}
 // DEPRECATED

--- a/src/less/box-shadow.less
+++ b/src/less/box-shadow.less
@@ -4,30 +4,39 @@
 // Opinionated defaults for box shadows
 
 @boxShadowDefaultXOffset: 0;
-@boxShadowDefaultYOffset: @size_4xs;
 
-@boxShadowLightBlack: fade(@neutral_black, 40%);
-@boxShadowMediumBlack: fade(@neutral_black, 50%);
-@boxShadowHeavyBlack: fade(@neutral_black, 70%);
+@boxShadowYOffsetS: @size_4xs;
+@boxShadowYOffsetM: 0.1875rem;
+@boxShadowYOffsetL: 0.3125rem;
 
-@boxShadowBlurRadiusS: @size_xs;
-@boxShadowBlurRadiusM: @size_s;
-@boxShadowBlurRadiusL: @size_m;
+@boxShadowBlurRadiusS: 0.1875rem;
+@boxShadowBlurRadiusM: 0.375rem;
+@boxShadowBlurRadiusL: @size_s;
 
-.boxShadow(@blurRadius, @color) {
-  box-shadow: @boxShadowDefaultXOffset @boxShadowDefaultYOffset @blurRadius @color;
-}
+@boxShadowDefaultSpread: @size_4xs;
+
+@boxShadowDefaultColor: rgba(71, 76, 94, 0.2);
 
 // Convenience mixins
 
 .boxShadow--light {
-  .boxShadow(@boxShadowBlurRadiusS, @boxShadowLightBlack);
+  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetS @boxShadowBlurRadiusS @boxShadowDefaultSpread @boxShadowDefaultColor
 }
 
 .boxShadow--medium {
-  .boxShadow(@boxShadowBlurRadiusM, @boxShadowMediumBlack);
+  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetM @boxShadowBlurRadiusM @boxShadowDefaultSpread @boxShadowDefaultColor
 }
 
 .boxShadow--heavy {
-  .boxShadow(@boxShadowBlurRadiusL, @boxShadowHeavyBlack);
+  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetL @boxShadowBlurRadiusL @boxShadowDefaultSpread @boxShadowDefaultColor
 }
+
+// DEPRECATED - remove once there are no usages of these
+@boxShadowLightBlack: fade(@neutral_black, 40%);
+@boxShadowMediumBlack: fade(@neutral_black, 50%);
+@boxShadowHeavyBlack: fade(@neutral_black, 70%);
+
+.boxShadow(@blurRadius, @color) {
+  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetM @blurRadius @color;
+}
+// DEPRECATED


### PR DESCRIPTION
**Jira:**
N/A

**Overview:**
Update the box-shadow styles! They're soooo aggressive today. Below are the current styling of:
* `.boxShadow--light`
* `.boxShadow--medium`
* `.boxShadow--heavy`
<img width="628" alt="Screen Shot 2019-05-08 at 6 10 55 PM" src="https://user-images.githubusercontent.com/12655228/57420494-a48cec00-71bc-11e9-9680-d2437f3d8fa6.png">

And with the changes in this PR (new values courtesy of Neil!), here are the same styles:
<img width="639" alt="Screen Shot 2019-05-08 at 6 08 35 PM" src="https://user-images.githubusercontent.com/12655228/57420539-d605b780-71bc-11e9-9dba-dce3c7e2b03e.png">


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
