### PR TITLE
fixed menu item select bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -137,6 +137,7 @@ export default class Menu extends React.PureComponent {
                   {UntypedReact.cloneElement(menuItem, {
                     focused: this._isFocused(menuItem, i),
                     onClick: e => this._handleItemClick(menuItem, e),
+                    onMouseEnter: e => this._handleItemMouseEnter(menuItem, i, e),
                   })}
                 </li>
               ))}
@@ -169,6 +170,12 @@ export default class Menu extends React.PureComponent {
     }
 
     menuItem.props.onClick(e);
+  };
+
+  _handleItemMouseEnter = (menuItem, i, e) => {
+    this.setState({ focusIndex: i });
+
+    menuItem.props.onMouseEnter(e);
   };
 
   _handleFocusOut = e => {

--- a/src/Menu/MenuItem.less
+++ b/src/Menu/MenuItem.less
@@ -21,8 +21,7 @@ button.Menu--MenuItem--default {
   width: 100%;
   text-decoration: none;
 
-  &:focus,
-  &:hover {
+  &:focus {
     background-color: fade(@primary_blue_tint_2, 10%);
     box-shadow: inset @borderWidthL 0 fade(@primary_blue_tint_2, 50%);
     // box-shadow: inset @borderWidthL 0 @primary_blue_tint_2;
@@ -41,8 +40,7 @@ button.Menu--MenuItem--default {
   box-shadow: inset @borderWidthL 0 @primary_blue;
   color: @primary_blue_shade_2;
 
-  &:focus,
-  &:hover {
+  &:focus {
     box-shadow: inset @borderWidthL 0 @primary_blue;
     color: @primary_blue_shade_2;
   }

--- a/src/Menu/MenuItem.tsx
+++ b/src/Menu/MenuItem.tsx
@@ -16,12 +16,14 @@ const propTypes = {
   href: PropTypes.string,
   onBlur: PropTypes.func,
   onClick: PropTypes.func,
+  onMouseEnter: PropTypes.func,
   selected: PropTypes.bool,
   target: PropTypes.string,
 };
 
 const defaultProps = {
   onClick: _.noop,
+  onMouseEnter: _.noop,
 };
 
 const cssClass = {
@@ -56,6 +58,7 @@ export default class MenuItem extends React.PureComponent {
       href,
       onBlur,
       onClick,
+      onMouseEnter,
       selected,
       target,
     } = this.props;
@@ -92,6 +95,7 @@ export default class MenuItem extends React.PureComponent {
         onBlur={onBlur}
         onClick={onClick}
         onMouseDown={onMouseDown}
+        onMouseEnter={onMouseEnter}
         role="menuitem"
         tabIndex={-1}
         target={target}


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/DISC-455

**Overview:**
The first menu item was always highlighted when using the mouse to hover over buttons because the focusIndex state param was only modified on arrow key press. Now mouse enter triggers the focus change and hover styling is removed

**Screenshots/GIFs:**
Before:
![Screen Recording 2019-05-09 at 01 40 PM](https://user-images.githubusercontent.com/42983512/57485276-25e98a80-7260-11e9-8d6c-7f4132d92800.gif)


After:
![Screen Recording 2019-05-09 at 01 12 PM](https://user-images.githubusercontent.com/42983512/57483923-a4442d80-725c-11e9-82ae-569749520dba.gif)


**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
