### PR TITLE
Update focus-trap-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "core-js": "^2.4.1",
-    "focus-trap-react": "^3.0.4",
+    "focus-trap-react": "^6.0.0",
     "less": "^3.8.1",
     "lodash": "^4.14.1",
     "moment": "^2.18.1",


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/IL-1300

**Overview:**
Previous versions of `focus-trap-react` had a bug that would prevent focus from switching to a nested iframe. This was fixed in a later version, so upgrading to the latest version resolves this issue.

**Screenshots/GIFs:**
Before:
![2019-05-15 15 08 21](https://user-images.githubusercontent.com/10870634/57813207-24b6d280-7724-11e9-96c2-5c3207300891.gif)

After:
![2019-05-15 15 10 46](https://user-images.githubusercontent.com/10870634/57813215-297b8680-7724-11e9-8971-5bf05505ac01.gif)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [~] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
