### PR TITLE
Fix list props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/List/Item.tsx
+++ b/src/List/Item.tsx
@@ -42,8 +42,7 @@ export default class Item extends React.PureComponent {
 }
 
 function DivWrapper(props) {
-  const { children } = props;
-  return <div>{children}</div>;
+  return <div {...props}></div>;
 }
 
 DivWrapper.propTypes = {
@@ -51,8 +50,7 @@ DivWrapper.propTypes = {
 };
 
 function ButtonWrapper(props) {
-  const { children } = props;
-  return <button>{children}</button>;
+  return <button {...props}></button>;
 }
 
 ButtonWrapper.propTypes = {

--- a/src/List/Item.tsx
+++ b/src/List/Item.tsx
@@ -46,7 +46,7 @@ function DivWrapper(props) {
 }
 
 DivWrapper.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.any.isRequired,
 };
 
 function ButtonWrapper(props) {
@@ -54,5 +54,5 @@ function ButtonWrapper(props) {
 }
 
 ButtonWrapper.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.any.isRequired,
 };


### PR DESCRIPTION
Introduced here:
https://github.com/Clever/components/pull/377
Props are being stripped away from these wrapper components, causing css and click handler problems

before:
![list-item-bug-before](https://user-images.githubusercontent.com/13126257/57888454-11b90680-77e7-11e9-8cf8-20d0ee7d7c50.gif)

after:
![list-item-bug-after](https://user-images.githubusercontent.com/13126257/57888458-14b3f700-77e7-11e9-9066-f8d607be5f2f.gif)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
