### PR TITLE
Responsive width on modals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -44,9 +44,11 @@ export class Modal extends React.Component {
   }
 
   render() {
+    // Width should be responsive with window size
+    const width = Math.min(window.innerWidth, this.props.width);
     const windowStyle = {
-      width: `${this.props.width}px`,
-      marginLeft: `-${this.props.width / 2}px`,
+      width: `${width}px`,
+      marginLeft: `-${width / 2}px`,
     };
     // The content is max 90% of the window height less 60px (height of the header)
     const contentStyle = { maxHeight: this.state.windowHeight * 0.9 - 60 };


### PR DESCRIPTION
**Overview:**
Some repos use this [logic](https://github.com/Clever/launchpad/blob/8ba337258052233de175776e996f8331d7b5a3c6/shared_components/Header/ResetADPasswordModal.tsx#L72) to make modal sizing more responsive to window sizes. This change bakes in that logic directly into the modal component.

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
