### PR TITLE
error format when empty required field blurred

### DIFF
--- a/docs/components/TooltipView.jsx
+++ b/docs/components/TooltipView.jsx
@@ -78,9 +78,7 @@ export default class TooltipView extends Component {
                   textAlign={textAlign}
                   clickTrigger
                 >
-                  <span
-                    className={classnames("fa fa-question-circle", cssClass.TRIGGER)}
-                  />
+                  <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
                 </Tooltip>
               </div>
             </ExampleCode>

--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -133,20 +133,14 @@ export default class WizardLayoutView extends React.PureComponent {
               className="Dewey--WizardLayout"
               sections={WizardLayoutContent[currentStep].sections}
               headerImg={showHeaderImg ? headerImg : null}
-              helpContent={
-                customHelpContent ? WizardLayoutContent[currentStep].helpContent : null
-              }
+              helpContent={customHelpContent ? WizardLayoutContent[currentStep].helpContent : null}
               hideSaveAndExit={hideSaveAndExit}
-              nextStepButtonText={
-                WizardLayoutContent[currentStep].nextStepButtonText || null
-              }
+              nextStepButtonText={WizardLayoutContent[currentStep].nextStepButtonText || null}
               onNextStep={_onNextStep}
               onPrevStep={_onPrevStep}
               onSaveAndExit={_onSaveAndExit}
               prevStepButtonDisabled={!WizardLayoutContent[currentStep].prevStep}
-              prevStepButtonText={
-                WizardLayoutContent[currentStep].prevStepButtonText || null
-              }
+              prevStepButtonText={WizardLayoutContent[currentStep].prevStepButtonText || null}
               stepper={stepper}
               subtitle="Ensure a smooth upcoming school year by following a few easy steps below."
               title="Back to school guide"
@@ -183,15 +177,15 @@ export default class WizardLayoutView extends React.PureComponent {
           />{" "}
           Custom help content
         </label>
-       <label className={cssClass.CONFIG}>
-        <input
-          type="checkbox"
-          checked={hideSaveAndExit}
-          className={cssClass.CONFIG_TOGGLE}
-          onChange={e => this.setState({ hideSaveAndExit: e.target.checked })}
-        />{" "}
-        Hide save & exit button
-      </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            checked={hideSaveAndExit}
+            className={cssClass.CONFIG_TOGGLE}
+            onChange={e => this.setState({ hideSaveAndExit: e.target.checked })}
+          />{" "}
+          Hide save & exit button
+        </label>
       </FlexBox>
     );
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/CopyableInput/CopyableInput.jsx
+++ b/src/CopyableInput/CopyableInput.jsx
@@ -78,9 +78,11 @@ export class CopyableInput extends React.Component {
 CopyableInput.propTypes = Object.assign({}, TextInput.propTypes, {
   className: PropTypes.string,
   enableCopy: PropTypes.bool,
+  required: PropTypes.bool,
 });
 
 CopyableInput.defaultProps = {
   enableCopy: true,
+  required: false,
   size: FormElementSize.FULL_WIDTH,
 };

--- a/src/CopyableInput/CopyableInput.jsx
+++ b/src/CopyableInput/CopyableInput.jsx
@@ -50,6 +50,7 @@ export class CopyableInput extends React.Component {
           readOnly={this.props.readOnly}
           label={this.props.label}
           onChange={this.props.onChange}
+          required={this.props.required}
           size={
             FormElementSize.FULL_WIDTH /* Rely on the fact that we're bounding the parent
             container */

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -34,7 +34,7 @@ export default class DateInput extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { inFocus: false };
+    this.state = { inFocus: false, hasBeenFocused: false };
 
     this.isValidDate = this.isValidDate.bind(this);
   }
@@ -57,6 +57,7 @@ export default class DateInput extends React.Component {
   }
 
   render() {
+    console.log(this.props);
     const classes = ["DateInput"];
 
     // add additional wrapper classes
@@ -81,7 +82,15 @@ export default class DateInput extends React.Component {
     // note on the upper right corner
     let inputNote;
     if (this.props.required) {
-      inputNote = <span className="DateInput--required">required</span>;
+      inputNote = (
+        <span
+          className={`DateInput--${
+            this.state.hasBeenFocused && !this.props.value ? "error" : "required"
+          }`}
+        >
+          required
+        </span>
+      );
     }
     if (this.props.error) {
       inputNote = <span className="DateInput--error">{this.props.error}</span>;
@@ -106,7 +115,7 @@ export default class DateInput extends React.Component {
             className="DateTimePicker"
             onChange={this.props.onChange}
             value={this.props.value}
-            onBlur={() => this.setState({ inFocus: false })}
+            onBlur={() => this.setState({ inFocus: false, hasBeenFocused: true })}
             onFocus={() => this.setState({ inFocus: true })}
             isValidDate={this.isValidDate}
             inputProps={{
@@ -126,7 +135,7 @@ export default class DateInput extends React.Component {
             maxDate={this.props.max}
             minDate={this.props.min}
             name={this.props.name}
-            onBlur={() => this.setState({ inFocus: false })}
+            onBlur={() => this.setState({ inFocus: false, hasBeenFocused: true })}
             onFocus={() => this.setState({ inFocus: true })}
             onSelect={this.props.onChange}
             placeholderText={this.props.placeholder}

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -57,7 +57,6 @@ export default class DateInput extends React.Component {
   }
 
   render() {
-    console.log(this.props);
     const classes = ["DateInput"];
 
     // add additional wrapper classes

--- a/src/List/Item.tsx
+++ b/src/List/Item.tsx
@@ -42,7 +42,7 @@ export default class Item extends React.PureComponent {
 }
 
 function DivWrapper(props) {
-  return <div {...props}></div>;
+  return <div {...props} />;
 }
 
 DivWrapper.propTypes = {
@@ -50,7 +50,7 @@ DivWrapper.propTypes = {
 };
 
 function ButtonWrapper(props) {
-  return <button {...props}></button>;
+  return <button {...props} />;
 }
 
 ButtonWrapper.propTypes = {

--- a/src/Select/Select.jsx
+++ b/src/Select/Select.jsx
@@ -9,6 +9,15 @@ import "react-select/dist/react-select.css";
 import "./Select.less";
 import "../less/forms.less";
 
+const cssClass = {
+  CONTAINER: "Select--container",
+  LABEL: "Select--label",
+  LABEL_CONTAINER: "Select--labelContainer",
+  LABEL_HIDDEN: "Select--labelHidden",
+  REACT_SELECT: "Select--ReactSelect",
+  READ_ONLY: "Select--readOnly",
+};
+
 function isLabelHidden(placeholder, value) {
   if (!placeholder) {
     return false;
@@ -149,15 +158,6 @@ export class Select extends React.Component {
     );
   }
 }
-
-const cssClass = {
-  CONTAINER: "Select--container",
-  LABEL: "Select--label",
-  LABEL_CONTAINER: "Select--labelContainer",
-  LABEL_HIDDEN: "Select--labelHidden",
-  REACT_SELECT: "Select--ReactSelect",
-  READ_ONLY: "Select--readOnly",
-};
 
 const selectValuePropType = PropTypes.shape({
   label: PropTypes.string.isRequired,

--- a/src/TextArea/TextArea.jsx
+++ b/src/TextArea/TextArea.jsx
@@ -26,7 +26,7 @@ export class TextArea extends React.Component {
   constructor(props) {
     super(TextArea.validateProps(props));
 
-    this.state = { inFocus: false };
+    this.state = { inFocus: false, hasBeenFocused: false };
     this.onFocus = this.onFocus.bind(this);
     this.onBlur = this.onBlur.bind(this);
   }
@@ -46,7 +46,7 @@ export class TextArea extends React.Component {
   onBlur() {
     const { onBlur } = this.props;
 
-    this.setState({ inFocus: false });
+    this.setState({ inFocus: false, hasBeenFocused: true });
     if (onBlur) {
       onBlur();
     }
@@ -77,7 +77,15 @@ export class TextArea extends React.Component {
     // note on the upper right corner
     let inputNote;
     if (this.props.required) {
-      inputNote = <span className="TextArea--required">required</span>;
+      inputNote = (
+        <span
+          className={`TextArea--${
+            this.state.hasBeenFocused && !this.props.value ? "error" : "required"
+          }`}
+        >
+          required
+        </span>
+      );
     }
     if (this.props.optional) {
       inputNote = <span className="TextArea--optional">optional</span>;

--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -16,7 +16,7 @@ export class TextInput extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { inFocus: false, hidden: true };
+    this.state = { inFocus: false, hasBeenFocused: false, hidden: true };
     this.onFocus = this.onFocus.bind(this);
     this.onBlur = this.onBlur.bind(this);
     this.toggleHidden = this.toggleHidden.bind(this);
@@ -34,7 +34,7 @@ export class TextInput extends React.Component {
   onBlur() {
     const { onBlur } = this.props;
 
-    this.setState({ inFocus: false });
+    this.setState({ inFocus: false, hasBeenFocused: true });
     if (onBlur) {
       onBlur();
     }
@@ -73,7 +73,15 @@ export class TextInput extends React.Component {
     // note on the upper right corner
     let inputNote;
     if (this.props.required) {
-      inputNote = <span className="TextInput--required">required</span>;
+      inputNote = (
+        <span
+          className={`TextInput--${
+            this.state.hasBeenFocused && !this.props.value ? "error" : "required"
+          }`}
+        >
+          required
+        </span>
+      );
     }
     if (this.props.error) {
       inputNote = <span className="TextInput--error">{this.props.error}</span>;

--- a/src/less/box-shadow.less
+++ b/src/less/box-shadow.less
@@ -35,7 +35,8 @@
 }
 
 .boxShadow(@blurRadius, @color) {
-  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetM @blurRadius @boxShadowDefaultSpread @color;
+  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetM @blurRadius
+    @boxShadowDefaultSpread @color;
 }
 
 // DEPRECATED - remove once there are no usages of these

--- a/src/less/box-shadow.less
+++ b/src/less/box-shadow.less
@@ -35,8 +35,7 @@
 }
 
 .boxShadow(@blurRadius, @color) {
-  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetM @blurRadius
-    @boxShadowDefaultSpread @color;
+  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetM @blurRadius @boxShadowDefaultSpread @color;
 }
 
 // DEPRECATED - remove once there are no usages of these


### PR DESCRIPTION
**Overview:**
Previously, "required" inputs would simply place a gray "REQUIRED" label in the field. Logically, this should be a red error font when the user selects the field but provides no input.

**Screenshots/GIFs:**
![Screen Recording 2019-05-17 at 04 48 PM](https://user-images.githubusercontent.com/42983512/58043676-a5921780-7af2-11e9-9a71-14aa7998117a.gif)
![Screen Recording 2019-05-17 at 04 50 PM](https://user-images.githubusercontent.com/42983512/58043677-a5921780-7af2-11e9-8fe5-4851ede94ea0.gif)
![Screen Recording 2019-05-17 at 04 51 PM (1)](https://user-images.githubusercontent.com/42983512/58043678-a5921780-7af2-11e9-8070-c5f3d12ba685.gif)
![Screen Recording 2019-05-17 at 04 51 PM](https://user-images.githubusercontent.com/42983512/58043679-a5921780-7af2-11e9-8bf9-0bf3a3aeaad9.gif)
![Screen Recording 2019-05-17 at 04 52 PM](https://user-images.githubusercontent.com/42983512/58043680-a62aae00-7af2-11e9-8cbf-9b2cd58d14df.gif)


**Testing:**
- [x] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
