### PR TITLE
Use react-fontawesome for example Tooltip

### DIFF
--- a/docs/components/TooltipView.jsx
+++ b/docs/components/TooltipView.jsx
@@ -2,6 +2,7 @@ import _ from "lodash";
 import classnames from "classnames";
 import loremIpsum from "lorem-ipsum";
 import React, { Component } from "react";
+import FontAwesome from "react-fontawesome";
 
 import Example, { ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
@@ -36,7 +37,7 @@ export default class TooltipView extends Component {
                   placement={placement}
                   textAlign={textAlign}
                 >
-                  <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
+                  <FontAwesome className={cssClass.TRIGGER} name="question-circle" />
                 </Tooltip>
               </div>
               <div className={cssClass.EXAMPLE}>
@@ -53,7 +54,7 @@ export default class TooltipView extends Component {
                   placement={placement}
                   textAlign={textAlign}
                 >
-                  <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
+                  <FontAwesome className={cssClass.TRIGGER} name="question-circle" />
                 </Tooltip>
               </div>
               <div className={cssClass.EXAMPLE}>
@@ -63,8 +64,9 @@ export default class TooltipView extends Component {
                   placement={placement}
                   textAlign={textAlign}
                 >
-                  <span
-                    className={classnames("fa fa-question-circle", cssClass.TRIGGER)}
+                  <FontAwesome
+                    className={cssClass.TRIGGER}
+                    name="question-circle"
                     ref="focusableTrigger"
                     tabIndex={0}
                   />
@@ -78,7 +80,7 @@ export default class TooltipView extends Component {
                   textAlign={textAlign}
                   clickTrigger
                 >
-                  <span className={classnames("fa fa-question-circle", cssClass.TRIGGER)} />
+                  <FontAwesome className={cssClass.TRIGGER} name="question-circle" />
                 </Tooltip>
               </div>
             </ExampleCode>


### PR DESCRIPTION
**Overview:**
Seems like we prefer using react-fontawesome so our example components should do so too so that new engineers will prefer this convention! 

**Screenshots/GIFs:**
<img width="1202" alt="Screen Shot 2019-05-21 at 5 21 52 PM" src="https://user-images.githubusercontent.com/10870634/58138854-f71ecd00-7bec-11e9-8e7a-51bac7be480f.png">

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Firefox

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
