### PR TITLE
WizardLayout: add fullscreen props and styles

### DIFF
--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -144,6 +144,7 @@ export default class WizardLayoutView extends React.PureComponent {
               stepper={stepper}
               subtitle="Ensure a smooth upcoming school year by following a few easy steps below."
               title="Back to school guide"
+              fullscreen={false}
             />
           </ExampleCode>
           {this._renderConfig()}

--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -144,7 +144,6 @@ export default class WizardLayoutView extends React.PureComponent {
               stepper={stepper}
               subtitle="Ensure a smooth upcoming school year by following a few easy steps below."
               title="Back to school guide"
-              fullscreen={false}
             />
           </ExampleCode>
           {this._renderConfig()}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.13.4",
+  "version": "1.14.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/WizardLayout/WizardLayout.less
+++ b/src/WizardLayout/WizardLayout.less
@@ -6,6 +6,10 @@
   width: 100%;
 }
 
+.WizardLayout--fullscreen {
+  height: 1vh;
+}
+
 .WizardLayout--header {
   background-color: @neutral_white;
   .margin--bottom--none();
@@ -32,6 +36,12 @@
 
 .WizardLayout--body {
   overflow: auto;
+}
+
+.WizardLayout--body--fullscreen {
+  overflow: unset;
+  height: 1vh;
+  flex: 1;
 }
 
 .WizardLayout--helpContainer {
@@ -101,4 +111,11 @@
 
 .Button.WizardLayout--previousButton {
   .margin--right--l();
+}
+
+.WizardLayout--footer--fullscreen {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }

--- a/src/WizardLayout/WizardLayout.less
+++ b/src/WizardLayout/WizardLayout.less
@@ -42,6 +42,7 @@
   overflow: unset;
   height: 1vh;
   flex: 1;
+  margin-bottom: 5.5rem;
 }
 
 .WizardLayout--helpContainer {

--- a/src/WizardLayout/WizardLayout.less
+++ b/src/WizardLayout/WizardLayout.less
@@ -20,7 +20,7 @@
 }
 
 .WizardLayout--headerImg {
-  height: 4rem;
+  height: @size_5xl;
   .self--center();
   .margin--right--m();
 }

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -16,7 +16,7 @@ const SECTION_PROP_TYPE = PropTypes.shape({
 
 const propTypes = {
   className: PropTypes.string,
-  sections: PropTypes.arrayOf(SECTION_PROP_TYPE).isRequired,
+  fullscreen: PropTypes.bool,
   headerImg: PropTypes.element,
   helpContent: PropTypes.node,
   nextStepButtonDisabled: PropTypes.bool,
@@ -27,6 +27,7 @@ const propTypes = {
   onNextStep: PropTypes.func.isRequired,
   onPrevStep: PropTypes.func.isRequired,
   onSaveAndExit: PropTypes.func,
+  sections: PropTypes.arrayOf(SECTION_PROP_TYPE).isRequired,
   stepper: PropTypes.node.isRequired,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
@@ -50,6 +51,10 @@ const cssClass = {
   STEPPER_CONTAINER: "WizardLayout--stepperContainer",
   SECTION_DIVIDER: "WizardLayout--sectionDivider",
   NEXT_BUTTON: "WizardLayout--nextButton",
+
+  CONTAINER_FULLSCREEN: "WizardLayout--fullscreen",
+  BODY_FULLSCREEN: "WizardLayout--body--fullscreen",
+  FOOTER_FULLSCREEN: "WizardLayout--footer--fullscreen",
 };
 
 /**
@@ -74,10 +79,11 @@ export default class WizardLayout extends React.PureComponent {
       stepper,
       subtitle,
       title,
+      fullscreen,
     } = this.props;
 
     return (
-      <FlexBox column grow className={classnames(cssClass.CONTAINER, className)}>
+      <FlexBox column grow className={classnames(cssClass.CONTAINER, className, fullscreen && cssClass.CONTAINER_FULLSCREEN)}>
         <FlexBox className={cssClass.HEADER}>
           {headerImg && <div className={cssClass.HEADER_IMG}>{headerImg}</div>}
           <div>
@@ -85,7 +91,7 @@ export default class WizardLayout extends React.PureComponent {
             <p className={cssClass.HEADER_SUBTITLE}>{subtitle}</p>
           </div>
         </FlexBox>
-        <FlexBox className={cssClass.BODY}>
+        <FlexBox className={classnames(cssClass.BODY, fullscreen && cssClass.BODY_FULLSCREEN)}>
           <FlexBox column className={cssClass.STEPPER_CONTAINER}>
             {stepper}
             <FlexBox grow />
@@ -107,7 +113,7 @@ export default class WizardLayout extends React.PureComponent {
             ))}
           </FlexBox>
         </FlexBox>
-        <FlexBox className={cssClass.FOOTER}>
+        <FlexBox className={classnames(cssClass.FOOTER, fullscreen && cssClass.FOOTER_FULLSCREEN)}>
           {!hideSaveAndExit && onSaveAndExit && (
             <Button type="link" value={"Save & exit"} onClick={() => onSaveAndExit()} />
           )}


### PR DESCRIPTION
**Jira:**

**Overview:**
Wizard layout style was breaking in IE 11 for bespoke fullscreen css. This PR adds a fullscreen prop the 
WizardLayout so the styles are always correct.

**Screenshots/GIFs:**
Tested fullscreen view locally in sd2 by copying over dist.
![image](https://user-images.githubusercontent.com/18291415/58294658-34679400-7d80-11e9-9823-3b4b46cf5826.png)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
