### PR TITLE
Wizard docs

### DIFF
--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -291,6 +291,7 @@ export default class WizardLayoutView extends React.PureComponent {
             type: "Boolean",
             description: "Applies styles needed for fullscreen display.",
             optional: true,
+            defaultValue: "false",
           },
         ]}
         className={cssClass.PROPS}

--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -286,6 +286,12 @@ export default class WizardLayoutView extends React.PureComponent {
             type: "String",
             description: "Title string to be displayed in the header.",
           },
+          {
+            name: "fullscreen",
+            type: "Boolean",
+            description: "Applies styles needed for fullscreen display.",
+            optional: true,
+          },
         ]}
         className={cssClass.PROPS}
       />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Jira:**

**Overview:**
Document the fullscreen prop from the WizardLayout component.

**Screenshots/GIFs:**
![image](https://user-images.githubusercontent.com/18291415/58646928-4e8efe00-82bb-11e9-917a-d837ddd4de25.png)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
