### PR TITLE
Add a visual indicator on error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/script/test_server.sh
+++ b/script/test_server.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+./node_modules/.bin/jest --config ./jestconfig.json --watch

--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -1,3 +1,4 @@
+import FontAwesome from "react-fontawesome";
 import React from "react";
 import * as PropTypes from "prop-types";
 import classnames from "classnames";
@@ -48,11 +49,48 @@ export class TextInput extends React.Component {
     this.setState({ hidden: !this.state.hidden });
   }
 
+  currentErrorMessage() {
+    const { error, value } = this.props;
+    const { hasBeenFocused } = this.state;
+
+    let errorMessage = "";
+
+    if (hasBeenFocused && !value) {
+      errorMessage = "required";
+    }
+
+    if (error) {
+      errorMessage = error;
+    }
+
+    return errorMessage;
+  }
+
+  renderNote(errorMessage) {
+    const { required } = this.props;
+    let inputNote;
+
+    if (required) {
+      inputNote = <span className="TextInput--required">required</span>;
+    }
+
+    if (errorMessage) {
+      inputNote = (
+        <span className="TextInput--error">
+          <FontAwesome name="exclamation-triangle" /> {errorMessage}
+        </span>
+      );
+    }
+
+    return inputNote;
+  }
+
   render() {
     let wrapperClass = "TextInput";
+    const errorMessage = this.currentErrorMessage();
 
     // add additional wrapper classes
-    if (this.props.error) wrapperClass += " TextInput--hasError";
+    if (errorMessage) wrapperClass += " TextInput--hasError";
 
     // TODO:  throw error for mutually exclusive states
     if (this.props.readOnly) {
@@ -71,21 +109,7 @@ export class TextInput extends React.Component {
     }
 
     // note on the upper right corner
-    let inputNote;
-    if (this.props.required) {
-      inputNote = (
-        <span
-          className={`TextInput--${
-            this.state.hasBeenFocused && !this.props.value ? "error" : "required"
-          }`}
-        >
-          required
-        </span>
-      );
-    }
-    if (this.props.error) {
-      inputNote = <span className="TextInput--error">{this.props.error}</span>;
-    }
+    const inputNote = this.renderNote(errorMessage);
 
     let type;
     if (this.props.type === "password") {

--- a/test/TextInput_test.jsx
+++ b/test/TextInput_test.jsx
@@ -58,7 +58,7 @@ describe("TextInput", () => {
 
     // check the span element with error message
     assert.equal(textInput.find("span").length, 1);
-    assert.equal(textInput.find("span").text(), "This is an error");
+    assert.equal(textInput.find("span").text(), "<FontAwesome /> This is an error");
     assert(textInput.find("span").hasClass("TextInput--error"));
   });
 


### PR DESCRIPTION
**Jira:**

[[IL-1288] components - Add visual indicator for TextInput errors](https://clever.atlassian.net/browse/IL-1288)

**Overview:**

Currently, there is no visual indication that an error has occurred between the word "required" being displayed in black text color and then "required" showing in a red text color.

This adds a visual indication that an error has occurred along with the explanatory text.

**Screenshots/GIFs:**

### Before

![text-input-required](https://user-images.githubusercontent.com/1817/58735157-672c1080-83ae-11e9-9156-2a8b3505ace9.gif)

### After

![text-input-required-visual](https://user-images.githubusercontent.com/1817/58735163-6b582e00-83ae-11e9-9275-7c82dbcb55a4.gif)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
