### PR TITLE
tied icon size to button size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FloatingButton/FloatingButton.less
+++ b/src/FloatingButton/FloatingButton.less
@@ -44,6 +44,9 @@ button.FloatingButton--button {
 
 .FloatingButton--icon {
   .margin--right--xs();
+  & > svg {
+    vertical-align: top;
+  }
 }
 
 .FloatingButton--inactive--bottom {

--- a/src/FloatingButton/FloatingButton.less
+++ b/src/FloatingButton/FloatingButton.less
@@ -44,6 +44,7 @@ button.FloatingButton--button {
 
 .FloatingButton--icon {
   .margin--right--xs();
+
   & > svg {
     vertical-align: top;
   }

--- a/src/FloatingButton/FloatingButton.tsx
+++ b/src/FloatingButton/FloatingButton.tsx
@@ -141,6 +141,12 @@ export default class FloatingButton extends React.PureComponent {
     } = this.props;
     const { active } = this.state;
 
+    const iconSizes = {
+      [Button.Size.S]: Icon.sizes.XXS,
+      [Button.Size.M]: Icon.sizes.XS,
+      [Button.Size.L]: Icon.sizes.XS,
+    };
+
     return (
       <FlexBox
         className={classnames(
@@ -168,7 +174,7 @@ export default class FloatingButton extends React.PureComponent {
                     <FlexBox alignItems="center">
                       <Icon
                         className={cssClass.ICON}
-                        size={Icon.sizes.XS}
+                        size={iconSizes[size]}
                         name={Icon.names.CLOSE_FLOATING_BUTTON}
                       />{" "}
                       Close


### PR DESCRIPTION
**Jira:**

**Overview:**
bug caused weird sizing on non-regular size buttons

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
