### PR TITLE
Fix 'click to focus on tooltip trigger'

### DIFF
--- a/docs/components/TooltipView.jsx
+++ b/docs/components/TooltipView.jsx
@@ -64,12 +64,12 @@ export default class TooltipView extends Component {
                   placement={placement}
                   textAlign={textAlign}
                 >
-                  <FontAwesome
-                    className={cssClass.TRIGGER}
-                    name="question-circle"
-                    ref="focusableTrigger"
-                    tabIndex={0}
-                  />
+                  <span ref="focusableTrigger" tabIndex={0}>
+                    <FontAwesome
+                      className={cssClass.TRIGGER}
+                      name="question-circle"
+                    />
+                  </span>
                 </Tooltip>
               </div>
               <div className={cssClass.EXAMPLE}>


### PR DESCRIPTION
**Overview:**
The `FontAwesome` component from `react-fontawesome` doesn't seem to support the `ref` prop so we have to wrap it in a span to make it focusable on click of a button.

**Screenshots/GIFs:**
![2019-06-06 11 15 55](https://user-images.githubusercontent.com/10870634/59056422-03da2c80-884d-11e9-8ce1-b578692985d5.gif)


**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
~~  - [ ] Bumped version in `package.json`~~
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
