### PR TITLE
collapse FloatingButton after clicking any of its 'additional buttons'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FloatingButton/FloatingButton.tsx
+++ b/src/FloatingButton/FloatingButton.tsx
@@ -127,6 +127,11 @@ export default class FloatingButton extends React.PureComponent {
     }
   };
 
+  additionalButtonHandler(button) {
+    this.setState({ active: false });
+    button.onClick();
+  }
+
   render() {
     const {
       additionalButtons,
@@ -201,7 +206,7 @@ export default class FloatingButton extends React.PureComponent {
                   cssClass.BUTTON,
                   colorGroup && cssClass.propStyle(colorGroup),
                 )}
-                onClick={button.onClick}
+                onClick={() => this.additionalButtonHandler(button)}
                 value={button.label}
                 size={size || Button.Size.M}
               />


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/DISC-556

**Overview:**
FloatingButton should collapse back to just the main button after any of the sub-buttons are clicked.

**Screenshots/GIFs:**
![Screen Recording 2019-06-18 at 01 51 PM](https://user-images.githubusercontent.com/50673502/59719024-4518f780-91d0-11e9-860f-c5d5969eb4a2.gif)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
