### PR TITLE
add additional props to floating button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FloatingButton/FloatingButton.tsx
+++ b/src/FloatingButton/FloatingButton.tsx
@@ -1,3 +1,4 @@
+import * as _ from "lodash";
 import * as classnames from "classnames";
 import * as PropTypes from "prop-types";
 import * as React from "react";
@@ -145,6 +146,7 @@ export default class FloatingButton extends React.PureComponent {
       size,
     } = this.props;
     const { active } = this.state;
+    const additionalProps = _.omit(this.props, Object.keys(propTypes));
 
     const iconSizes = {
       [Button.Size.S]: Icon.sizes.XXS,
@@ -154,6 +156,7 @@ export default class FloatingButton extends React.PureComponent {
 
     return (
       <FlexBox
+        {...additionalProps}
         className={classnames(
           cssClass.CONTAINER,
           cssClass.propStyle(positionX),


### PR DESCRIPTION
**Jira:**

**Overview:**
proximate goal is to add an id to a floating button, but in general it seems good practice to be able to add props like id and key without specifying them

**Screenshots/GIFs:**

**Testing:**
none

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
