### PR TITLE
Make sidebar and main content scroll separately

### DIFF
--- a/docs/components/Layout.less
+++ b/docs/components/Layout.less
@@ -13,6 +13,7 @@ body {
   min-height: 100vh;
   padding: 0;
   width: 100%;
+  overflow: hidden;
 }
 
 .Dewey--docs {
@@ -28,7 +29,13 @@ body {
 
 .Layout--sideBar {
   .flexShrink(0);
-  height: auto;
+  height: calc(100vh - 3.75rem);
+}
+
+.Layout--viewContainer {
+  height: calc(100vh - 3.75rem);
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
 }
 
 .Layout--mainContainer {

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -76,7 +76,22 @@ render(
         <Route path="compound-form(/*)" component={LayoutCompoundForm} />
         <Route path="ui-text(/*)" component={UITextView} />
       </Route>
-      <Route path="components">
+      <Route
+        path="components"
+        onChange={(prevState, nextState) => {
+          // If the component being rendered has changed, scroll to the top of the view container
+          if (prevState.location.pathname !== nextState.location.pathname) {
+            // HACK: Ideally we find a better way to target the main content view container,
+            // but this is the best approach I could find
+            const viewContainerList = document.getElementsByClassName(
+              prevState.components[0].cssClass.VIEW_CONTAINER,
+            );
+            if (viewContainerList && viewContainerList[0]) {
+              viewContainerList[0].scrollTo(0, 0);
+            }
+          }
+        }}
+      >
         <Route path="alert-box(/*)" component={AlertBoxView} />
         <Route path="button(/*)" component={ButtonView} />
         <Route path="checkbox(/*)" component={CheckboxView} />

--- a/package.json
+++ b/package.json
@@ -107,6 +107,6 @@
     "react-dom": ">=16.0.0 <17.0.0"
   },
   "scripts": {
-    "dev-server": "node_modules/.bin/webpack-dev-server --host 0.0.0.0 --port 5010 --content-base docs/ --inline --watch"
+    "dev-server": "node_modules/.bin/webpack-dev-server"
   }
 }

--- a/src/LeftNav/LeftNav.less
+++ b/src/LeftNav/LeftNav.less
@@ -36,13 +36,12 @@
   overflow: hidden;
 }
 
-.LeftNav--topnav,
-.LeftNav--subnav--content {
-}
-
 .LeftNav--topnav {
   .animateWidth;
   .flexShrink(0);
+  // Only show scrollbar if necessary (looks pretty ugly in the cramped space otherwise)
+  // This prevents using iOS momentum scrolling but that's a worthwhile compromise
+  overflow: auto;
   max-width: @paneWidth;
   width: @paneWidth;
 }
@@ -68,6 +67,8 @@
   .flex--grow;
   height: auto;
   width: 100%;
+  overflow: scroll;
+  -webkit-overflow-scrolling: touch;
 }
 
 .LeftNav--subnav--open {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,4 +46,15 @@ module.exports = {
     ],
   },
   postcss: [autoprefixer({ browsers: "> 1% in US, last 3 versions, ie > 9" })],
+  devServer: {
+    host: "0.0.0.0",
+    port: "5010",
+    contentBase: "docs/",
+    inline: true,
+    watch: true,
+    // The following property is HIGHLY DISCOURAGED in general but can be useful
+    // for viewing the frontend from another device (i.e a phone) by navigating
+    // to <laptop-ip>:<port> from the device.
+    // disableHostCheck: true
+  },
 };


### PR DESCRIPTION
**Overview:**
Pretty self-explanatory from the title and following GIF. Improves UX by not requiring you to scroll around as much to navigate either the sidebar or the main content.

Also included the change for scrolling to top of main content on selected component change because the approach is highly tied to the changes required for the scroll separation.

**Screenshots/GIFs:**

| Desktop | Mobile |
| -------- | ------- |
| ![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8083680/60363261-e3a71480-9997-11e9-9c05-1daf2166f788.gif) | ![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/8083680/60367415-07238c80-99a3-11e9-8e9f-786c1a552aad.gif) |

**Testing:**
* Visually verified correct behavior on desktop.
* On iOS Safari, [there is a known bug/feature](https://medium.com/@susiekim9/how-to-compensate-for-the-ios-viewport-unit-bug-46e78d54af0d) that makes `100vh` layouts act a little wonky in that the bottom toolbar covers some content (shown in gif above). Might not be worthwhile fixing but I'm open to suggestions!

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
