### PR TITLE
Lowercase placeholders on all input components

### DIFF
--- a/docs/components/TextInputView.jsx
+++ b/docs/components/TextInputView.jsx
@@ -18,7 +18,7 @@ export default class TextInputView extends Component {
       inputValue: "",
       obscured: false,
       required: false,
-      placeholderCaps: true,
+      placeholderCaps: false,
       size: FormElementSize.MEDIUM,
     };
   }
@@ -194,7 +194,7 @@ export default class TextInputView extends Component {
               name: "placeholderCaps",
               type: "Bool",
               description: "Determines if placeholder value is capitalized or not",
-              defaultValue: "true",
+              defaultValue: "false",
               optional: true,
             },
             {

--- a/src/DateInput/DateInput.less
+++ b/src/DateInput/DateInput.less
@@ -71,7 +71,6 @@
 
     .DateInput--input {
       .text--small;
-      .text--caps;
       .padding--top--xs;
       line-height: @size_2xl;
       min-height: @size_2xl;

--- a/src/Select/Select.less
+++ b/src/Select/Select.less
@@ -113,7 +113,6 @@
       .padding--top--xs;
       .text--small;
       line-height: @size_2xl;
-      text-transform: uppercase;
     }
 
     .Select-input,

--- a/src/TextArea/TextArea.less
+++ b/src/TextArea/TextArea.less
@@ -67,7 +67,6 @@
 
   .TextArea--input {
     .text--small;
-    .text--caps;
     color: @neutral_dark_gray;
   }
 }

--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -11,7 +11,7 @@ import "../less/forms.less";
 
 export class TextInput extends React.Component {
   static defaultProps = {
-    placeholderCaps: true,
+    placeholderCaps: false,
     size: FormElementSize.FULL_WIDTH,
   };
 

--- a/test/TextInput_test.jsx
+++ b/test/TextInput_test.jsx
@@ -36,7 +36,7 @@ describe("TextInput", () => {
     assert.equal(textInput.find("input[type='text']").length, 1);
     assert.equal(textInput.find("input[name='TextInputPlaceholder']").length, 1);
     assert.equal(textInput.find("input[placeholder='PlaceholderText']").length, 1);
-    assert(textInput.hasClass("TextInput--placeholder-shown"));
+    assert(textInput.hasClass("TextInput--placeholder-shown-no-caps"));
 
     // make sure it also works when value is not passed
     const textInput2 = shallow(
@@ -45,7 +45,7 @@ describe("TextInput", () => {
     assert.equal(textInput2.find("input[type='text']").length, 1);
     assert.equal(textInput2.find("input[name='TextInputPlaceholder']").length, 1);
     assert.equal(textInput2.find("input[placeholder='PlaceholderText']").length, 1);
-    assert(textInput2.hasClass("TextInput--placeholder-shown"));
+    assert(textInput2.hasClass("TextInput--placeholder-shown-no-caps"));
   });
 
   it("properly renders a <TextInput> with an error", () => {


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FEE-151

**Overview:**
Placeholder text should not be all caps on input components.

Affects the following components:

* `TextInput`
* `DateInput`
* `Select`
* `CopyableInput`
* `TextArea`

**Screenshots/GIFs:**
For example,
![image](https://user-images.githubusercontent.com/8083680/60458667-164d4900-9bf4-11e9-8cfe-9c665537054e.png)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
