### PR TITLE
added RootCloseWrapper to floating button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FloatingButton/FloatingButton.tsx
+++ b/src/FloatingButton/FloatingButton.tsx
@@ -2,6 +2,7 @@ import * as _ from "lodash";
 import * as classnames from "classnames";
 import * as PropTypes from "prop-types";
 import * as React from "react";
+import * as RootCloseWrapper from "react-overlays/lib/RootCloseWrapper";
 
 import { Button } from "../Button/Button";
 import FlexBox from "../flex/FlexBox";
@@ -128,6 +129,10 @@ export default class FloatingButton extends React.PureComponent {
     }
   };
 
+  onRootClose = () => {
+    this.setState({ active: false });
+  };
+
   additionalButtonHandler(button) {
     this.setState({ active: false });
     button.onClick();
@@ -155,67 +160,69 @@ export default class FloatingButton extends React.PureComponent {
     };
 
     return (
-      <FlexBox
-        {...additionalProps}
-        className={classnames(
-          cssClass.CONTAINER,
-          cssClass.propStyle(positionX),
-          cssClass.propStyle(positionY),
-          className,
-        )}
-        style={{
-          ...this.horizontalStyle(),
-          ...this.verticalStyle(),
-        }}
-      >
-        <div className={classnames(cssClass.SUB_ELEMENT)}>
-          <Button
-            className={classnames(
-              cssClass.BUTTON,
-              colorGroup && cssClass.propStyle(colorGroup),
-              active && cssClass.propStyle("gray"),
-            )}
-            onClick={this.mainButtonHandler}
-            value={
-              active
-                ? closeLabel || (
-                    <FlexBox alignItems="center">
-                      <Icon
-                        className={cssClass.ICON}
-                        size={iconSizes[size]}
-                        name={Icon.names.CLOSE_FLOATING_BUTTON}
-                      />{" "}
-                      Close
-                    </FlexBox>
-                  )
-                : label
-            }
-            size={size || Button.Size.M}
-          />
-        </div>
-        {additionalButtons &&
-          additionalButtons.map((button, i) => (
-            <div
+      <RootCloseWrapper onRootClose={this.onRootClose}>
+        <FlexBox
+          {...additionalProps}
+          className={classnames(
+            cssClass.CONTAINER,
+            cssClass.propStyle(positionX),
+            cssClass.propStyle(positionY),
+            className,
+          )}
+          style={{
+            ...this.horizontalStyle(),
+            ...this.verticalStyle(),
+          }}
+        >
+          <div className={classnames(cssClass.SUB_ELEMENT)}>
+            <Button
               className={classnames(
-                cssClass.SUB_ELEMENT,
-                !active && cssClass.inactive(positionY),
-                animate && cssClass.ANIMATE,
-                button.className,
+                cssClass.BUTTON,
+                colorGroup && cssClass.propStyle(colorGroup),
+                active && cssClass.propStyle("gray"),
               )}
-              key={i}
-            >
-              <Button
+              onClick={this.mainButtonHandler}
+              value={
+                active
+                  ? closeLabel || (
+                      <FlexBox alignItems="center">
+                        <Icon
+                          className={cssClass.ICON}
+                          size={iconSizes[size]}
+                          name={Icon.names.CLOSE_FLOATING_BUTTON}
+                        />{" "}
+                        Close
+                      </FlexBox>
+                    )
+                  : label
+              }
+              size={size || Button.Size.M}
+            />
+          </div>
+          {additionalButtons &&
+            additionalButtons.map((button, i) => (
+              <div
                 className={classnames(
-                  cssClass.BUTTON,
-                  colorGroup && cssClass.propStyle(colorGroup),
+                  cssClass.SUB_ELEMENT,
+                  !active && cssClass.inactive(positionY),
+                  animate && cssClass.ANIMATE,
+                  button.className,
                 )}
-                onClick={() => this.additionalButtonHandler(button)}
-                value={button.label}
-                size={size || Button.Size.M}
-              />
-            </div>
-          ))}
-      </FlexBox>
+                key={i}
+              >
+                <Button
+                  className={classnames(
+                    cssClass.BUTTON,
+                    colorGroup && cssClass.propStyle(colorGroup),
+                  )}
+                  onClick={() => this.additionalButtonHandler(button)}
+                  value={button.label}
+                  size={size || Button.Size.M}
+                />
+              </div>
+            ))}
+        </FlexBox>
+      </RootCloseWrapper>
     );
   }
 }


### PR DESCRIPTION
**Jira:**

**Overview:**
We want the floating group button menu to close when the use clicks outside the floating button group (or presses `esc`). We use [RootCloseWrapper](https://react-bootstrap.github.io/react-overlays/#root-close-wrapper) (as seen [here](https://github.com/Clever/components/blob/5967a9f8d5f1cfa8d7c7efa1ee739f90ecabd0ae/src/Menu/Menu.tsx#L105)) to achieve this

**Screenshots/GIFs:**
![Screen Recording 2019-07-01 at 11 40 AM](https://user-images.githubusercontent.com/42983512/60459281-92945c00-9bf5-11e9-8c1d-b9495033ce04.gif)


**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
