### PR TITLE
Create a custom route for fullscreen WizardLayout

### DIFF
--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { Link } from "react-router";
 import * as PropTypes from "prop-types";
 
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import { WizardLayout, FlexBox, ItemAlign, Stepper } from "src";
+import { Button, WizardLayout, FlexBox, ItemAlign, Stepper } from "src";
 import { WizardLayoutContent } from "./WizardLayoutContent";
 
 import "./WizardLayoutView.less";
@@ -167,6 +168,13 @@ export default class WizardLayoutView extends React.PureComponent {
             {WizardLayoutToRender}
           </ExampleCode>
           {this._renderConfig()}
+          <Button
+            type="secondary"
+            size="regular"
+            // Intentionally not using Button's href prop because this link is internal and should
+            // be handled by react-router's <Link />, not an <a />
+            value={<Link to="/fullscreen-wizard-layout">View fullscreen (separate page)</Link>}
+          />
         </Example>
 
         {this._renderProps()}

--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -41,7 +41,6 @@ export default class WizardLayoutView extends React.PureComponent {
       goals: false,
     },
     hideSaveAndExit: false,
-    fullscreen: false,
   };
 
   render() {
@@ -176,7 +175,7 @@ export default class WizardLayoutView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { showHeaderImg, customHelpContent, hideSaveAndExit, fullscreen } = this.state;
+    const { showHeaderImg, customHelpContent, hideSaveAndExit } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>

--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as PropTypes from "prop-types";
 
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
@@ -18,7 +19,16 @@ const cssClass = {
   PROPS: "WizardLayoutView--props",
 };
 
+const propTypes = {
+  fullscreen: PropTypes.bool,
+};
+const defaultProps = {
+  fullscreen: false,
+};
+
 export default class WizardLayoutView extends React.PureComponent {
+  static propTypes = propTypes;
+  static defaultProps = defaultProps;
   static cssClass = cssClass;
 
   state = {
@@ -31,9 +41,11 @@ export default class WizardLayoutView extends React.PureComponent {
       goals: false,
     },
     hideSaveAndExit: false,
+    fullscreen: false,
   };
 
   render() {
+    const { fullscreen } = this.props;
     const { currentStep, showHeaderImg, customHelpContent, hideSaveAndExit } = this.state;
 
     const stepperSteps = [
@@ -104,6 +116,30 @@ export default class WizardLayoutView extends React.PureComponent {
       <img className="WizardLayoutView--headerImg" src="./assets/img/deweyFox.svg" />
     );
 
+    const WizardLayoutToRender = (
+      <WizardLayout
+        className="Dewey--WizardLayout"
+        fullscreen={fullscreen}
+        sections={WizardLayoutContent[currentStep].sections}
+        headerImg={showHeaderImg ? headerImg : null}
+        helpContent={customHelpContent ? WizardLayoutContent[currentStep].helpContent : null}
+        hideSaveAndExit={hideSaveAndExit}
+        nextStepButtonText={WizardLayoutContent[currentStep].nextStepButtonText || null}
+        onNextStep={_onNextStep}
+        onPrevStep={_onPrevStep}
+        onSaveAndExit={_onSaveAndExit}
+        prevStepButtonDisabled={!WizardLayoutContent[currentStep].prevStep}
+        prevStepButtonText={WizardLayoutContent[currentStep].prevStepButtonText || null}
+        stepper={stepper}
+        subtitle="Ensure a smooth upcoming school year by following a few easy steps below."
+        title="Back to school guide"
+      />
+    );
+
+    if (fullscreen) {
+      return WizardLayoutToRender;
+    }
+
     return (
       <View
         className={cssClass.CONTAINER}
@@ -129,22 +165,7 @@ export default class WizardLayoutView extends React.PureComponent {
 
         <Example title="Basic Usage:">
           <ExampleCode style={{ display: "flex", height: "35rem" }}>
-            <WizardLayout
-              className="Dewey--WizardLayout"
-              sections={WizardLayoutContent[currentStep].sections}
-              headerImg={showHeaderImg ? headerImg : null}
-              helpContent={customHelpContent ? WizardLayoutContent[currentStep].helpContent : null}
-              hideSaveAndExit={hideSaveAndExit}
-              nextStepButtonText={WizardLayoutContent[currentStep].nextStepButtonText || null}
-              onNextStep={_onNextStep}
-              onPrevStep={_onPrevStep}
-              onSaveAndExit={_onSaveAndExit}
-              prevStepButtonDisabled={!WizardLayoutContent[currentStep].prevStep}
-              prevStepButtonText={WizardLayoutContent[currentStep].prevStepButtonText || null}
-              stepper={stepper}
-              subtitle="Ensure a smooth upcoming school year by following a few easy steps below."
-              title="Back to school guide"
-            />
+            {WizardLayoutToRender}
           </ExampleCode>
           {this._renderConfig()}
         </Example>
@@ -155,7 +176,7 @@ export default class WizardLayoutView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { showHeaderImg, customHelpContent, hideSaveAndExit } = this.state;
+    const { showHeaderImg, customHelpContent, hideSaveAndExit, fullscreen } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -64,6 +64,7 @@ import WizardView from "./components/WizardView";
 
 render(
   <Router history={hashHistory}>
+    <Route path="/fullscreen-wizard-layout" component={() => <WizardLayoutView fullscreen />} />
     <Route path="/" component={Layout}>
       <IndexRedirect to="/intro" />
       <Route path="intro(/*)" component={IntroView} />


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FEE-142

**Overview:**
The `WizardLayout` component is difficult to test with its `fullscreen` prop applied. When rendered in the `WizardLayoutView` in the docs, it tries to take the full screen while the Dewey `Layout` is also trying to use the full screen. There's some conversation around this (and this temp solution) in the comments in the JIRA ticket linked above.

This PR creates a new route `/#/fullscreen-wizard-layout` for the purpose of testing the `WizardLayout` in fullscreen mode. This route renders nothing other than the `WizardLayout` and can be accessed via a button below the config checkboxes (demoed in gif below)

Furthermore, the gif shows that the `WizardLayout` styles are broken and could definitely use a good demo page like this one for debugging it.

**Screenshots/GIFs:**
![2019-07-02 16 28 16](https://user-images.githubusercontent.com/8083680/60553075-8936ec80-9ce6-11e9-96e2-1fc40fafb024.gif)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
