### PR TITLE
TextInputs do not display required error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -50,12 +50,12 @@ export class TextInput extends React.Component {
   }
 
   currentErrorMessage() {
-    const { error, value } = this.props;
+    const { error, value, required } = this.props;
     const { hasBeenFocused } = this.state;
 
     let errorMessage = "";
 
-    if (hasBeenFocused && !value) {
+    if (required && hasBeenFocused && !value) {
       errorMessage = "required";
     }
 

--- a/test/TextInput_test.jsx
+++ b/test/TextInput_test.jsx
@@ -5,6 +5,12 @@ import { shallow } from "enzyme";
 import { TextInput } from "../src";
 
 describe("TextInput", () => {
+  let required;
+
+  beforeEach(() => {
+    required = false;
+  });
+
   it("renders a <TextInput> element properly with name and default type", () => {
     const textInput = shallow(<TextInput name="TextInputName" />);
     assert.equal(textInput.find("input[type='text']").length, 1);
@@ -114,4 +120,72 @@ describe("TextInput", () => {
     assert.equal(textInput.find("input[type='password']").length, 0);
     assert.equal(textInput.find("input[type='text']").length, 1);
   });
+
+  describe("When the input is filled out", () => {
+    it("does not display an error message", () => {
+      const component = shallowComponent();
+      setValue(component, "jish");
+      const errors = component.find(".TextInput--error");
+
+      assert.equal(errors.length, 0, "There is no error");
+    });
+  });
+
+  describe("When the input is left blank", () => {
+    it("does not display an error message", () => {
+      const component = shallowComponent();
+      setValue(component, "");
+      const errors = component.find(".TextInput--error");
+
+      assert.equal(errors.length, 0, "There is no error");
+    });
+  });
+
+  describe("Given the TextInput is required", () => {
+    beforeEach(() => {
+      required = true;
+    });
+
+    it("displays a required note", () => {
+      const component = shallowComponent();
+      const requiredNote = component.find(".TextInput--required");
+
+      assert.equal(requiredNote.length, 1, "It displays a required note");
+      assert.equal(requiredNote.text(), "required");
+    });
+
+    describe("When the input is filled out", () => {
+      it("does not display an error message", () => {
+        const component = shallowComponent();
+        setValue(component, "jish");
+        const errors = component.find(".TextInput--error");
+
+        assert.equal(errors.length, 0, "There is no error");
+      });
+    });
+
+    describe("When the input is left blank", () => {
+      it("displays an error message", () => {
+        const component = shallowComponent();
+        setValue(component, "");
+        const errors = component.find(".TextInput--error");
+
+        assert.equal(errors.length, 1, "There is an error");
+      });
+    });
+  });
+
+  function setValue(component, newValue) {
+    const input = component.find("input");
+
+    input.simulate("focus");
+    component.setProps({ value: newValue });
+    input.simulate("blur");
+
+    return component;
+  }
+
+  function shallowComponent() {
+    return shallow(<TextInput name="username" required={required} />);
+  }
 });


### PR DESCRIPTION
**Overview:**

We enhanced TextInputs to display an error message if they are
required and the user skips over the field without filling out a
value.

During these enhancements, we added this behavior in always.
Currently, if any TextInput is focused and then blurred without
entering a value, it will display an error message.

We only want this behavior if the TextInput is marked as required.

**Screenshots/GIFs:**

### Before

An error message is displayed on blur, even if the field is not marked as required:

![not-required-displays-error](https://user-images.githubusercontent.com/1817/60619452-90fd9c00-9d8d-11e9-89d5-cb3f4bb174fc.gif)

### After

An error message is not displayed on blur if the field is not required:

![not-required-no-error](https://user-images.githubusercontent.com/1817/60619461-978c1380-9d8d-11e9-9b7e-c89b8b3dc743.gif)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Firefox

**Roll Out:**
- Before merging:
  - [ ] ~Updated docs~
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] ~Deployed updated docs (`make deploy-docs`)~
