### PR TITLE
Exploring @testing-library/react as replacement for enzyme

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "tether": "^1.4.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^8.0.4",
     "@types/classnames": "^2.2.3",
     "@types/jasmine": "^2.6.0",
     "@types/jasmine-enzyme": "^3.6.0",

--- a/src/AlertBox/AlertBox.tsx
+++ b/src/AlertBox/AlertBox.tsx
@@ -66,7 +66,10 @@ export default class AlertBox extends React.PureComponent<Props> {
       return null;
     }
     return (
-      <div className={classnames(`AlertBox--${type}`, cssClass.CONTAINER, className)}>
+      <div
+        data-testid="AlertBoxType"
+        className={classnames(`AlertBox--${type}`, cssClass.CONTAINER, className)}
+      >
         <FlexBox className={cssClass.HEADER}>
           <FlexItem className={cssClass.ICON_CONTAINER}>
             <Icon className={cssClass.ICON} />

--- a/test/AlertBox_test.tsx
+++ b/test/AlertBox_test.tsx
@@ -1,38 +1,40 @@
 import * as _ from "lodash";
 import * as assert from "assert";
 import * as React from "react";
-import { shallow } from "enzyme";
+import { render, cleanup } from "@testing-library/react";
 import { AlertBox } from "../src";
+
+afterEach(cleanup);
 
 describe("AlertBox", () => {
   _.forEach(["warning", "info", "error", "success"], type => {
     it(`renders a <AlertBox> element with class AlertBox--${type}`, () => {
-      const alertBox = shallow(
+      const { getByTestId } = render(
         <AlertBox type={type as any} title="title">
           <p> child </p>
         </AlertBox>,
       );
-      assert.equal(alertBox.find(`.AlertBox--${type}`).length, 1);
+      assert.ok(getByTestId("AlertBoxType").classList.contains(`AlertBox--${type}`));
     });
   });
 
   it("renders a closable box if isClosable and closes on click", () => {
-    const alertBox = shallow(
+    const { getByLabelText, container } = render(
       <AlertBox type="warning" title="title" isClosable>
         <p> child </p>
       </AlertBox>,
     );
-    assert.equal(alertBox.find(".AlertBox--warning").length, 1);
-    alertBox.find(".AlertBox--close").simulate("click");
-    assert.equal(alertBox.find(".AlertBox--warning").length, 0);
+    assert.ok(container.firstChild);
+    getByLabelText("Close").click();
+    assert.ok(container.firstChild == null);
   });
 
   it("applies custom classname", () => {
-    const alertBox = shallow(
+    const { container } = render(
       <AlertBox type="warning" title="title" className="custom">
         <p> child </p>
       </AlertBox>,
     );
-    assert.equal(alertBox.find(".custom").length, 1);
+    assert.ok(container.firstChild && container.firstChild.classList.contains("custom"));
   });
 });


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FEE-132

**Overview:**
Ideally when testing UI components, all that is tested is the component's interface with the user, since that's ultimately what matters. Enzyme's API tends to encourage tests that test the component implementation a bit more than we'd like. We want to look into alternatives that give us more resilient, refactor-friendly tests. One possible alternative is [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro). 

This PR implements react-testing-library in place of Enzyme for a single component, `AlertBox`. The resulting tests are significantly more interface-oriented than the pre-existing implementation-heavy Enzyme API. 

Although this RTL API proved to be better in this particular case, it's tough to conclude from this small example that RTL >> Enzyme in all cases. Tests would need to be written for more complex components to reach a stronger conclusion.

**Screenshots/GIFs:**

**Testing:**
- [x] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
