### PR TITLE
[IL-1158] Fix extra spacing in textarea in readonly mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextArea/TextArea.less
+++ b/src/TextArea/TextArea.less
@@ -47,7 +47,6 @@
   .text--medium;
   display: block;
   width: 100%;
-  min-height: @size_2xl;
   border: none;
   .margin--top--l;
 
@@ -68,6 +67,7 @@
   .TextArea--input {
     .text--small;
     color: @neutral_dark_gray;
+    min-height: @size_2xl;
   }
 }
 

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -173,8 +173,9 @@ export class TextArea extends React.Component<Props, State> {
       rows: this.props.rows,
     };
 
+    // Don't increment rows in readOnly so that there is no extra spacing.
     let rows = this.props.rows;
-    if (this.props.placeholder) {
+    if ((this.props.placeholder || this.props.autoResize) && !this.props.readOnly) {
       // Need to add another row for autoGrow since it seems to collapse in a way that conflicts with the placeholder
       // margin
       rows = this.props.rows + 1;
@@ -182,7 +183,6 @@ export class TextArea extends React.Component<Props, State> {
 
     let textarea = <textarea {...textAreaProps} rows={rows} />;
     if (this.props.autoResize) {
-      rows = this.props.rows + 1;
       textarea = <TextareaAutosize {...textAreaProps} rows={rows} />;
     }
 


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/IL-1158
**Overview:**
When using TextArea with only 1 row of text we have a spacing issue. It is apparent when used with other components like TextInput. Example below: Announcement Body is TextArea. 
![Screen Shot 2019-03-28 at 11 14 02 AM](https://user-images.githubusercontent.com/18272584/60911325-bda32f00-a237-11e9-965b-a98dc35ee800.png)

**Screenshots/GIFs:**
![IL-1158](https://user-images.githubusercontent.com/18272584/60912132-8a619f80-a239-11e9-81ca-1d94e9749498.gif)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
