### PR TITLE
Setting flex-shrink to zero for form error icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FormError/FormError.less
+++ b/src/FormError/FormError.less
@@ -19,6 +19,7 @@
 .FormError--icon {
   height: 1.25em; // Match font line height to center with first line of text.
   width: 0.875em; // Match font size at a ratio of 14px:16px.
+  .flexShrink(0)
 }
 
 .FormError--ErrorIcon--path {


### PR DESCRIPTION
**Jira:**

**Overview:**
Multiline messages in FormError were causing the alert icon to shrink.

(was affecting https://github.com/Clever/apps-dashboard/pull/1944)

**Screenshots/GIFs:**

Before:
![Screen Shot 2019-07-10 at 10 46 31 AM](https://user-images.githubusercontent.com/50889175/60992040-8ea4c000-a300-11e9-874d-98d85de09292.png)

After:
![Screen Shot 2019-07-10 at 10 46 49 AM](https://user-images.githubusercontent.com/50889175/60992085-aaa86180-a300-11e9-963f-1db233ff0fca.png)


**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
