### PR TITLE
[IL-1191] Firefox ignores padding-bottom when overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.less
+++ b/src/Modal/Modal.less
@@ -73,7 +73,8 @@
 
 .Modal--window--content {
   position: relative;
-  .padding--l;
+  .padding--top--l;
+  .padding--x--l;
   background-color: @neutral_white;
   box-sizing: border-box;
   overflow-y: auto;
@@ -81,6 +82,11 @@
   p {
     .margin--bottom--m;
     .margin--top--none;
+  }
+
+  .Modal--padding--div {
+    //workaround for https://github.com/w3c/csswg-drafts/issues/129
+    height: @size_l;
   }
 }
 

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -100,6 +100,7 @@ export class Modal extends React.Component<Props, State> {
           </header>
           <div style={contentStyle} className="Modal--window--content">
             {this.props.children}
+            <div className="Modal--padding--div" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/IL-1191

**Overview:**
There is inconsistency between browsers in regards with what is scrollable when we have overflow. Chrome & Safari consider padding box to be scrollable but Firefox and IE consider content box to be scrollable. CSS3 says that padding should be included but the browsers haven't fixed that. 
More info on the root problem at 
- https://www.w3.org/TR/css-overflow-3/#scrollable 
- https://github.com/w3c/csswg-drafts/issues/129
Current Status
![firefox-modal-before](https://user-images.githubusercontent.com/18272584/60995507-7be1b980-a307-11e9-9ede-3fff71bd228b.gif)

**Screenshots/GIFs:**
![firefox-modal-after](https://user-images.githubusercontent.com/18272584/60995516-7edcaa00-a307-11e9-9905-a01c9753aaaa.gif)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10
  - [x] Firefox

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
