### PR TITLE
actually default number to 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Number/Number.tsx
+++ b/src/Number/Number.tsx
@@ -28,7 +28,7 @@ export default class Number extends React.PureComponent<Props> {
   static propTypes = propTypes;
 
   static format(num: number | string, short = false) {
-    const rawNumber = parseInt(`${num}` || "0", 10);
+    const rawNumber = parseInt(`${num || 0}`, 10);
 
     if (isNaN(rawNumber)) {
       throw new Error("A number is required.");

--- a/src/Number/Number.tsx
+++ b/src/Number/Number.tsx
@@ -27,8 +27,8 @@ export const cssClass = {
 export default class Number extends React.PureComponent<Props> {
   static propTypes = propTypes;
 
-  static format(number: number | string, short = false) {
-    const rawNumber = parseInt(`${number}` || "0", 10);
+  static format(num: number | string, short = false) {
+    const rawNumber = parseInt(`${num}` || "0", 10);
 
     if (isNaN(rawNumber)) {
       throw new Error("A number is required.");


### PR DESCRIPTION
**Overview:**

~`children` should be a required prop since the component calls `format` with the value of `children` unconditionally and throws an error if the argument can't be parsed as a number.
https://github.com/Clever/components/blob/23109d4b3401bd61d6065efbc93d87b6c1d0ca95/src/Number/Number.tsx#L45~

Edit: Let's go back to the pre v2 behavior and allow `children` to be optional. If the prop is omitted, it will default to 0. I broke this behavior in https://github.com/Clever/components/pull/394#discussion_r298411466. If only we were using the `strict` compiler option... 

I also changed a variable name to avoid colliding with the `number` reserved keyword.

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
