### PR TITLE
FEE-63 & FEE-155 optional tag in textInput, consistent styles for required tag in textArea and textInput

### DIFF
--- a/docs/components/TextAreaView.jsx
+++ b/docs/components/TextAreaView.jsx
@@ -15,6 +15,7 @@ export default class TextAreaView extends React.Component {
       disabled: false,
       readOnly: false,
       required: false,
+      optional: false,
       inputValue: "",
       autoResize: true,
       placeholder: true,

--- a/docs/components/TextInputView.jsx
+++ b/docs/components/TextInputView.jsx
@@ -18,6 +18,7 @@ export default class TextInputView extends Component {
       inputValue: "",
       obscured: false,
       required: false,
+      optional: false,
       placeholderCaps: false,
       size: FormElementSize.MEDIUM,
     };
@@ -39,6 +40,7 @@ export default class TextInputView extends Component {
                 disabled={this.state.disabled}
                 readOnly={this.state.readOnly}
                 required={this.state.required}
+                optional={this.state.optional}
                 enableShow={this.state.obscured}
                 error={this.state.hasError ? "Invalid password" : null}
                 type={this.state.obscured ? "password" : "text"}
@@ -74,8 +76,18 @@ export default class TextInputView extends Component {
           <label className={cssClass.CONFIG}>
             <input
               type="checkbox"
+              checked={this.state.optional}
+              onChange={({ target }) => this.setState({ optional: target.checked })}
+              disabled={this.state.required}
+            />{" "}
+            Optional
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
               checked={this.state.required}
               onChange={({ target }) => this.setState({ required: target.checked })}
+              disabled={this.state.optional}
             />{" "}
             Required
           </label>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.0.5",
+  "version": "2.1.5",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -1,3 +1,4 @@
+import * as FontAwesome from "react-fontawesome";
 import * as React from "react";
 import * as PropTypes from "prop-types";
 import * as classnames from "classnames";
@@ -116,10 +117,50 @@ export class TextArea extends React.Component<Props, State> {
     this.textAreaEl.current.focus();
   }
 
+  currentErrorMessage() {
+    const { error, value, required } = this.props;
+    const { hasBeenFocused } = this.state;
+
+    let errorMessage = "";
+
+    if (required && hasBeenFocused && !value) {
+      errorMessage = "required";
+    }
+
+    if (error) {
+      errorMessage = error;
+    }
+
+    return errorMessage;
+  }
+
+  renderNote(errorMessage) {
+    const { required, optional } = this.props;
+    let inputNote;
+
+    if (required) {
+      inputNote = <span className="TextArea--required">required</span>;
+    }
+    if (optional) {
+      inputNote = <span className="TextArea--optional">optional</span>;
+    }
+
+    if (errorMessage) {
+      inputNote = (
+        <span className="TextArea--error">
+          <FontAwesome name="exclamation-triangle" /> {errorMessage}
+        </span>
+      );
+    }
+
+    return inputNote;
+  }
+
   render() {
     let wrapperClass = "TextArea";
+    const errorMessage = this.currentErrorMessage();
 
-    if (this.props.error) wrapperClass += " TextArea--hasError";
+    if (errorMessage) wrapperClass += " TextArea--hasError";
 
     if (this.props.readOnly) {
       wrapperClass += " TextArea--readonly";
@@ -135,25 +176,7 @@ export class TextArea extends React.Component<Props, State> {
     }
 
     // note on the upper right corner
-    let inputNote;
-    if (this.props.required) {
-      inputNote = (
-        <span
-          className={`TextArea--${
-            this.state.hasBeenFocused && !this.props.value ? "error" : "required"
-          }`}
-        >
-          required
-        </span>
-      );
-    }
-    if (this.props.optional) {
-      inputNote = <span className="TextArea--optional">optional</span>;
-    }
-
-    if (this.props.error) {
-      inputNote = <span className="TextArea--error">{this.props.error}</span>;
-    }
+    const inputNote = this.renderNote(errorMessage);
 
     const textAreaProps = {
       className: "TextArea--input",

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -72,9 +72,9 @@ export class TextArea extends React.Component<Props, State> {
       throw new Error("You cannot pass both `required` and `optional` on a TextArea.");
     }
 
-    if (["readOnly", "disabled", "inFocus"].filter(x => props[x]).length > 1) {
-      throw new Error(
-        "The readOnly, disabled, and inFocus props on a TextArea are mutually exclusive.",
+    if (props.readOnly && props.disabled) {
+      console.warn(
+        "The readOnly, disabled props on a TextArea are mutually exclusive. If both are passed readOnly is used",
       );
     }
 

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -69,7 +69,7 @@ export class TextArea extends React.Component<Props, State> {
 
   static validateProps(props) {
     if (props.required && props.optional) {
-      throw new Error("You cannot pass both `required` and `optional` on a TextArea.");
+      console.warn("You should not pass both `required` and `optional` on a TextArea.");
     }
 
     if (props.readOnly && props.disabled) {

--- a/src/TextInput/TextInput.less
+++ b/src/TextInput/TextInput.less
@@ -40,6 +40,11 @@
       position: absolute;
       right: @size_l;
     }
+
+    .TextInput--optional {
+      position: absolute;
+      right: @size_l;
+    }
   }
 
   .TextInput--input {

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -21,6 +21,7 @@ export interface Props {
   onKeyPress?: React.KeyboardEventHandler<HTMLInputElement>;
   onFocus?: () => void;
   onBlur?: () => void;
+  optional?: boolean;
   placeholder?: string;
   placeholderCaps?: boolean;
   readOnly?: boolean;
@@ -50,6 +51,7 @@ const propTypes = {
   onKeyPress: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
+  optional: PropTypes.bool,
   placeholder: PropTypes.string,
   placeholderCaps: PropTypes.bool,
   readOnly: PropTypes.bool,
@@ -68,8 +70,22 @@ export class TextInput extends React.Component<Props, State> {
   static propTypes = propTypes;
   static defaultProps = defaultProps;
 
+  static validateProps(props) {
+    if (props.required && props.optional) {
+      throw new Error("You cannot pass both `required` and `optional` on a TextArea.");
+    }
+
+    if (["readOnly", "disabled", "inFocus"].filter(x => props[x]).length > 1) {
+      throw new Error(
+        "The readOnly, disabled, and inFocus props on a TextArea are mutually exclusive.",
+      );
+    }
+
+    return props;
+  }
+
   constructor(props: Props) {
-    super(props);
+    super(TextInput.validateProps(props));
     this.state = { inFocus: false, hasBeenFocused: false, hidden: true };
     this.onFocus = this.onFocus.bind(this);
     this.onBlur = this.onBlur.bind(this);
@@ -123,11 +139,14 @@ export class TextInput extends React.Component<Props, State> {
   }
 
   renderNote(errorMessage) {
-    const { required } = this.props;
+    const { required, optional } = this.props;
     let inputNote;
 
     if (required) {
       inputNote = <span className="TextInput--required">required</span>;
+    }
+    if (optional) {
+      inputNote = <span className="TextInput--optional">optional</span>;
     }
 
     if (errorMessage) {
@@ -148,7 +167,6 @@ export class TextInput extends React.Component<Props, State> {
     // add additional wrapper classes
     if (errorMessage) wrapperClass += " TextInput--hasError";
 
-    // TODO:  throw error for mutually exclusive states
     if (this.props.readOnly) {
       wrapperClass += " TextInput--readonly";
     } else if (this.props.disabled) {

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -75,9 +75,9 @@ export class TextInput extends React.Component<Props, State> {
       throw new Error("You cannot pass both `required` and `optional` on a TextArea.");
     }
 
-    if (["readOnly", "disabled", "inFocus"].filter(x => props[x]).length > 1) {
-      throw new Error(
-        "The readOnly, disabled, and inFocus props on a TextArea are mutually exclusive.",
+    if (props.readOnly && props.disabled) {
+      console.warn(
+        "The readOnly, disabled props on a TextArea are mutually exclusive. If both are passed readOnly is used",
       );
     }
 

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -72,7 +72,7 @@ export class TextInput extends React.Component<Props, State> {
 
   static validateProps(props) {
     if (props.required && props.optional) {
-      throw new Error("You cannot pass both `required` and `optional` on a TextArea.");
+      console.warn("You should not pass both `required` and `optional` on a TextInput.");
     }
 
     if (props.readOnly && props.disabled) {


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FEE-63
https://clever.atlassian.net/browse/FEE-155

**Overview:**
- Added explicit optional label for textInput which already existed in textArea
- Updated textArea so that styles are same as textInput when required tag is passed
<img width="629" alt="Screen Shot 2019-07-10 at 2 45 50 PM" src="https://user-images.githubusercontent.com/18272584/61008909-c114e400-a325-11e9-9e29-1e1a75ddd15d.png">
- Filed a jira https://clever.atlassian.net/browse/FEE-156 to investigate consolidating styles and logic for textArea/Input so that we don't get this inconsistent behavior in future

**Screenshots/GIFs:**
- textInput
<img width="629" alt="Screen Shot 2019-07-10 at 3 17 32 PM" src="https://user-images.githubusercontent.com/18272584/61008933-e0137600-a325-11e9-97e0-55d8d41e2eef.png">
- textArea

![textArea-required](https://user-images.githubusercontent.com/18272584/61009185-ba3aa100-a326-11e9-9bf4-0fbd3b8016dd.gif)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
