### PR TITLE
Small type tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",
@@ -17,18 +17,22 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "@types/classnames": "^2.2.3",
     "core-js": "^2.4.1",
     "focus-trap-react": "^6.0.0",
     "less": "^3.8.1",
     "lodash": "^4.14.1",
+    "@types/lodash": "^4.14.74",
     "moment": "^2.18.1",
     "numeral": "^2.0.4",
     "prop-types": "^15.5.10",
+    "@types/prop-types": "^15.5.1",
     "react-accessible-accordion": "^1.0.2",
     "react-autosize-textarea": "^7.0.0",
     "react-bootstrap": "0.32.1",
     "react-copy-to-clipboard": "^4.3.1",
     "react-datepicker": "~1.6.0",
+    "@types/react-datepicker": "^1.8.0",
     "react-datetime": "^2.14.0",
     "react-dropzone": "^3.11.0",
     "react-fontawesome": "^1.6.1",
@@ -41,16 +45,8 @@
     "tether": "^1.4.0"
   },
   "devDependencies": {
-    "@types/classnames": "^2.2.3",
-    "@types/jasmine": "^2.6.0",
-    "@types/jasmine-enzyme": "^3.6.0",
     "@types/jest": "^20.0.8",
     "@types/jest-matchers": "^20.0.0",
-    "@types/lodash": "^4.14.74",
-    "@types/node": "^10.14.8",
-    "@types/prop-types": "^15.5.1",
-    "@types/react": "^16.8.20",
-    "@types/react-datepicker": "^1.8.0",
     "@typescript-eslint/eslint-plugin": "^1.9.0",
     "@typescript-eslint/parser": "^1.9.0",
     "autoprefixer": "^6.5.3",
@@ -92,6 +88,7 @@
     "prettier": "1.16.4",
     "prismjs": "^1.5.1",
     "react": "^16.8.6",
+    "@types/react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router": "^3.0.0",
     "sinon": "^1.17.3",
@@ -104,6 +101,7 @@
     "webpack-dev-server": "^1.16.1"
   },
   "peer-dependencies": {
+    "@types/react": ">=16.0.0 <17.0.0",
     "react": ">=16.0.0 <17.0.0",
     "react-dom": ">=16.0.0 <17.0.0"
   },

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -19,6 +19,13 @@ export interface SortState {
   direction?: "asc" | "desc";
 }
 
+// Webpack will inject process.env in so declare it here so we can use it to decide to log or not
+declare var process: {
+  env: {
+      NODE_ENV: string
+  }
+};
+
 export interface Props {
   children?: ChildrenOf<typeof Column>;
   className?: string;

--- a/src/TopBar/index.tsx
+++ b/src/TopBar/index.tsx
@@ -1,5 +1,4 @@
 import * as classnames from "classnames";
-import * as PropTypes from "prop-types";
 import * as React from "react";
 
 import Logo from "../Logo";
@@ -13,24 +12,14 @@ export interface Props {
   children?: React.ReactNode;
   className?: string;
   logoHref: string;
-  title: React.ReactNode;
+  title?: React.ReactNode;
   onLogoClick?: Function;
 }
-
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  logoHref: PropTypes.string.isRequired,
-  title: PropTypes.node,
-  onLogoClick: PropTypes.func,
-};
 
 /**
  * Global page-level header component.
  */
 export class TopBar extends React.PureComponent<Props> {
-  static propTypes = propTypes;
-
   static Button = TopBarButton;
 
   render() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "noUnusedLocals": true,
     "noImplicitAny": false,
     "target": "es5",
-    "types": ["jest", "node"]
+    "types": ["jest"]
   },
   "exclude": ["./dist", "./node_modules"]
 }


### PR DESCRIPTION
Small type fixes

- Move the type requirements in package.json to live next to the module requirements so consumers will install types too (needed especially for react-datepicker)
- Removes `@types/node` and hardcodes `process.env` where we use it. 
- Removes some unused types. 
- Makes `title` on `Topbar` optional to match propTypes/implementation 
- Removes propTypes from `TopBar`