### PR TITLE
Fix source paths in docs

### DIFF
--- a/docs/components/AlertBoxView.jsx
+++ b/docs/components/AlertBoxView.jsx
@@ -14,7 +14,7 @@ export default class AlertBoxView extends PureComponent {
     const { type } = this.state;
 
     return (
-      <View title="AlertBox" sourcePath="src/AlertBox/AlertBox.jsx">
+      <View title="AlertBox" sourcePath="src/AlertBox/AlertBox.tsx">
         <p>
           This is a container for prominent page-level messaging. Alerts should communicate a single
           informational message and may contain a text link if there are related actions. Temporary

--- a/docs/components/ButtonView.jsx
+++ b/docs/components/ButtonView.jsx
@@ -14,7 +14,7 @@ export default function ButtonView() {
   const { cssClass } = ButtonView;
 
   return (
-    <View className={cssClass.CONTAINER} title="Button" sourcePath="src/Button/Button.jsx">
+    <View className={cssClass.CONTAINER} title="Button" sourcePath="src/Button/Button.tsx">
       <p>This is a set of button components with various sizes and types.</p>
       <p>
         See also: <Link to="/components/confirmation-button">Confirmation Button</Link>

--- a/docs/components/ConfirmationButtonView.jsx
+++ b/docs/components/ConfirmationButtonView.jsx
@@ -16,7 +16,11 @@ export default class ConfirmationButtonView extends Component {
     const { cssClass } = ConfirmationButtonView;
 
     return (
-      <View className={cssClass.CONTAINER} title="ConfirmationButton" sourcePath="src/ConfirmationButton/ConfirmationButton.tsx">
+      <View
+        className={cssClass.CONTAINER}
+        title="ConfirmationButton"
+        sourcePath="src/ConfirmationButton/ConfirmationButton.tsx"
+      >
         <p>
           This component is a <code>Button</code> that triggers the appearance of a modal with
           "Confirm" and "Cancel" buttons when clicked.

--- a/docs/components/ConfirmationButtonView.jsx
+++ b/docs/components/ConfirmationButtonView.jsx
@@ -16,7 +16,7 @@ export default class ConfirmationButtonView extends Component {
     const { cssClass } = ConfirmationButtonView;
 
     return (
-      <View className={cssClass.CONTAINER} title="ConfirmationButton">
+      <View className={cssClass.CONTAINER} title="ConfirmationButton" sourcePath="src/ConfirmationButton/ConfirmationButton.tsx">
         <p>
           This component is a <code>Button</code> that triggers the appearance of a modal with
           "Confirm" and "Cancel" buttons when clicked.

--- a/docs/components/CopyableInputView.jsx
+++ b/docs/components/CopyableInputView.jsx
@@ -26,7 +26,11 @@ export default class CopyableInputView extends Component {
     const { cssClass } = CopyableInputView;
 
     return (
-      <View className={cssClass.CONTAINER} title="CopyableInput" sourcePath="src/CopyableInput/CopyableInput.tsx">
+      <View
+        className={cssClass.CONTAINER}
+        title="CopyableInput"
+        sourcePath="src/CopyableInput/CopyableInput.tsx"
+      >
         <p>
           This is a special TextInput that allows the user to show/hide the value of the input and
           copy to clipboard. Ideal for passwords and other secret keys.

--- a/docs/components/CopyableInputView.jsx
+++ b/docs/components/CopyableInputView.jsx
@@ -26,7 +26,7 @@ export default class CopyableInputView extends Component {
     const { cssClass } = CopyableInputView;
 
     return (
-      <View className={cssClass.CONTAINER} title="CopyableInput">
+      <View className={cssClass.CONTAINER} title="CopyableInput" sourcePath="src/CopyableInput/CopyableInput.tsx">
         <p>
           This is a special TextInput that allows the user to show/hide the value of the input and
           copy to clipboard. Ideal for passwords and other secret keys.

--- a/docs/components/CountView.jsx
+++ b/docs/components/CountView.jsx
@@ -56,7 +56,7 @@ export default class CountView extends Component {
     const shouldShorten = numberFormat === "short";
 
     return (
-      <View className={cssClass.CONTAINER} title="Count" sourcePath="src/Count/Count.jsx">
+      <View className={cssClass.CONTAINER} title="Count" sourcePath="src/Count/Count.tsx">
         <div className={cssClass.INTRO}>
           <p>Provides a convenient wrapper for displaying counts of things.</p>
           <p>

--- a/docs/components/DateInputView.jsx
+++ b/docs/components/DateInputView.jsx
@@ -26,7 +26,7 @@ export default class DateInputView extends Component {
     const { cssClass } = DateInputView;
 
     return (
-      <View title="DateInput" sourcePath="src/DateInput/DateInput.jsx">
+      <View title="DateInput" sourcePath="src/DateInput/DateInput.tsx">
         <p>DateInput is an input that allows the user to select dates from a DatePicker.</p>
         <Example>
           <ExampleCode>

--- a/docs/components/DatePickerView.jsx
+++ b/docs/components/DatePickerView.jsx
@@ -13,7 +13,7 @@ export default class DatePickerView extends Component {
 
   render() {
     return (
-      <View title="DatePicker" sourcePath="src/DatePicker/DatePicker.jsx">
+      <View title="DatePicker" sourcePath="src/DatePicker/DatePicker.tsx">
         <p>
           DatePickers are cards that can be used to select a date. They're thin wrappers around{" "}
           <a href="https://hacker0x01.github.io/react-datepicker" target="blank">

--- a/docs/components/DollarAmountView.jsx
+++ b/docs/components/DollarAmountView.jsx
@@ -70,7 +70,7 @@ export default class DollarAmountView extends Component {
       <View
         className={cssClass.CONTAINER}
         title="DollarAmount"
-        sourcePath="src/DollarAmount/DollarAmount.jsx"
+        sourcePath="src/DollarAmount/DollarAmount.tsx"
       >
         <div className={cssClass.INTRO}>
           <p>Provides a convenient wrapper for displaying dollar values.</p>

--- a/docs/components/DropdownButtonView.jsx
+++ b/docs/components/DropdownButtonView.jsx
@@ -102,7 +102,7 @@ export default class DropdownButtonView extends Component {
       <View
         className={cssClass.CONTAINER}
         title="DropdownButton"
-        sourcePath="src/DropdownButton/DropdownButton.jsx"
+        sourcePath="src/DropdownButton/DropdownButton.tsx"
       >
         <div className={cssClass.INTRO}>
           <p>

--- a/docs/components/FileInputView.jsx
+++ b/docs/components/FileInputView.jsx
@@ -40,7 +40,7 @@ export default class FileInputView extends React.PureComponent {
 
   render() {
     return (
-      <View className={cssClass.CONTAINER} title="FileInput">
+      <View className={cssClass.CONTAINER} title="FileInput" sourcePath="src/FileInput/FileInput.tsx">
         <p>An input component that allows users to drag and drop (or click and select) files.</p>
         <Example>
           <div>

--- a/docs/components/FileInputView.jsx
+++ b/docs/components/FileInputView.jsx
@@ -40,7 +40,11 @@ export default class FileInputView extends React.PureComponent {
 
   render() {
     return (
-      <View className={cssClass.CONTAINER} title="FileInput" sourcePath="src/FileInput/FileInput.tsx">
+      <View
+        className={cssClass.CONTAINER}
+        title="FileInput"
+        sourcePath="src/FileInput/FileInput.tsx"
+      >
         <p>An input component that allows users to drag and drop (or click and select) files.</p>
         <Example>
           <div>

--- a/docs/components/FlexBoxView.jsx
+++ b/docs/components/FlexBoxView.jsx
@@ -9,7 +9,7 @@ export default class FlexBoxView extends PureComponent {
     const { cssClass } = FlexBoxView;
 
     return (
-      <View className={cssClass.CONTAINER} title="FlexBox">
+      <View className={cssClass.CONTAINER} title="FlexBox" sourcePath="src/flex/FlexBox.tsx">
         <p>
           <code>FlexBox</code> provides a flex-enabled container as a convenience wrapper around the
           clever-components flex CSS classes. A <code>FlexBox</code> may contain any other

--- a/docs/components/GridView.jsx
+++ b/docs/components/GridView.jsx
@@ -33,7 +33,7 @@ export default class GridView extends PureComponent {
     const { cssClass } = GridView;
 
     return (
-      <View className={cssClass.CONTAINER} title="Grid" subtitle="Flexible, 12-Column Grid Layout">
+      <View className={cssClass.CONTAINER} title="Grid" subtitle="Flexible, 12-Column Grid Layout" sourcePath="src/Grid/Grid.tsx">
         <p>12-column grid component for consistent, simple and flexible layouts.</p>
         <p>
           The <code>Grid</code> is a single column of any number of <code>Grid.Rows</code>, which

--- a/docs/components/GridView.jsx
+++ b/docs/components/GridView.jsx
@@ -33,7 +33,12 @@ export default class GridView extends PureComponent {
     const { cssClass } = GridView;
 
     return (
-      <View className={cssClass.CONTAINER} title="Grid" subtitle="Flexible, 12-Column Grid Layout" sourcePath="src/Grid/Grid.tsx">
+      <View
+        className={cssClass.CONTAINER}
+        title="Grid"
+        subtitle="Flexible, 12-Column Grid Layout"
+        sourcePath="src/Grid/Grid.tsx"
+      >
         <p>12-column grid component for consistent, simple and flexible layouts.</p>
         <p>
           The <code>Grid</code> is a single column of any number of <code>Grid.Rows</code>, which

--- a/docs/components/IconView.jsx
+++ b/docs/components/IconView.jsx
@@ -19,7 +19,7 @@ export default class IconView extends PureComponent {
     const { cssClass } = IconView;
 
     return (
-      <View className={cssClass.CONTAINER} title="Icon">
+      <View className={cssClass.CONTAINER} title="Icon" sourcePath="src/Icon/Icon.tsx">
         <p>
           This component gives you access to a library of over 60 bespoke icons designed
           specifically for Clever products. Each icon comes in three sizes.

--- a/docs/components/InfoPanelView.jsx
+++ b/docs/components/InfoPanelView.jsx
@@ -43,7 +43,7 @@ export default class InfoPanelView extends React.Component {
     const { collapsible, footer, hideTitle } = this.state;
 
     return (
-      <View className={cssClass.CONTAINER} title="InfoPanel">
+      <View className={cssClass.CONTAINER} title="InfoPanel" sourcePath="src/InfoPanel/InfoPanel.tsx">
         <Example>
           <ExampleCode>
             <InfoPanel

--- a/docs/components/InfoPanelView.jsx
+++ b/docs/components/InfoPanelView.jsx
@@ -43,7 +43,11 @@ export default class InfoPanelView extends React.Component {
     const { collapsible, footer, hideTitle } = this.state;
 
     return (
-      <View className={cssClass.CONTAINER} title="InfoPanel" sourcePath="src/InfoPanel/InfoPanel.tsx">
+      <View
+        className={cssClass.CONTAINER}
+        title="InfoPanel"
+        sourcePath="src/InfoPanel/InfoPanel.tsx"
+      >
         <Example>
           <ExampleCode>
             <InfoPanel

--- a/docs/components/LabelView.jsx
+++ b/docs/components/LabelView.jsx
@@ -26,7 +26,7 @@ export default class LabelView extends Component {
     const { color, size, tooltipPlacement, tooltipTextAlign } = this.state;
 
     return (
-      <View className={cssClass.CONTAINER} title="Label">
+      <View className={cssClass.CONTAINER} title="Label" sourcePath="src/Label/Label.tsx">
         <p>Labels can be used as easily recognizable indicators of a type, state or status.</p>
         <p>
           They can be particularly useful when displaying a list or table of information as a visual

--- a/docs/components/LeftNavView.jsx
+++ b/docs/components/LeftNavView.jsx
@@ -9,7 +9,7 @@ export default class LeftNavView extends PureComponent {
     const { cssClass } = LeftNavView;
 
     return (
-      <View className={cssClass.CONTAINER} title="LeftNav" sourcePath="src/LeftNav/LeftNav.jsx">
+      <View className={cssClass.CONTAINER} title="LeftNav" sourcePath="src/LeftNav/LeftNav.tsx">
         <p>
           <code>LeftNav</code> is a navigation sidebar component designed to be anchored to the left
           side of the page. It takes as its children a list consisting of top-level links (

--- a/docs/components/ListView.jsx
+++ b/docs/components/ListView.jsx
@@ -128,7 +128,7 @@ export default class ListView extends React.PureComponent {
     const items = Items[itemsKey];
 
     return (
-      <View className={cssClass.CONTAINER} title="List" sourcePath="src/List/List.jsx">
+      <View className={cssClass.CONTAINER} title="List" sourcePath="src/List/List.tsx">
         <div className={cssClass.INTRO}>
           <p>
             Provides a simple view for a list of items with various display configuration options.

--- a/docs/components/LogoView.jsx
+++ b/docs/components/LogoView.jsx
@@ -35,7 +35,7 @@ export default class LogoView extends React.PureComponent {
     const { beta, color, fontSize } = this.state;
 
     return (
-      <View className={cssClass.CONTAINER} title="Logo" sourcePath="src/Logo/Logo.tsx">
+      <View className={cssClass.CONTAINER} title="Logo" sourcePath="src/Logo/index.tsx">
         <header className={cssClass.INTRO}>
           <CodeSample>
             {`

--- a/docs/components/ModalButtonView.jsx
+++ b/docs/components/ModalButtonView.jsx
@@ -17,7 +17,11 @@ export default class ModalButtonView extends Component {
     const { cssClass } = ModalButtonView;
 
     return (
-      <View className={cssClass.CONTAINER} title="ModalButton" sourcePath="src/ModalButton/ModalButton.tsx">
+      <View
+        className={cssClass.CONTAINER}
+        title="ModalButton"
+        sourcePath="src/ModalButton/ModalButton.tsx"
+      >
         <p>
           This component is a <code>Button</code> that triggers the appearance of a modal when
           clicked.

--- a/docs/components/ModalButtonView.jsx
+++ b/docs/components/ModalButtonView.jsx
@@ -17,7 +17,7 @@ export default class ModalButtonView extends Component {
     const { cssClass } = ModalButtonView;
 
     return (
-      <View className={cssClass.CONTAINER} title="ModalButton">
+      <View className={cssClass.CONTAINER} title="ModalButton" sourcePath="src/ModalButton/ModalButton.tsx">
         <p>
           This component is a <code>Button</code> that triggers the appearance of a modal when
           clicked.

--- a/docs/components/ModalView.jsx
+++ b/docs/components/ModalView.jsx
@@ -17,7 +17,7 @@ export default class ModalView extends Component {
     const { cssClass } = ModalView;
 
     return (
-      <View className={cssClass.CONTAINER} title="Modal">
+      <View className={cssClass.CONTAINER} title="Modal" sourcePath="src/Modal/Modal.tsx">
         <p>
           This component wraps your content and displays it in a modal and obscures the underlying
           content.

--- a/docs/components/NumberView.jsx
+++ b/docs/components/NumberView.jsx
@@ -24,7 +24,7 @@ export default class NumberView extends Component {
     const arrow = <span className="fa fa-long-arrow-right" />;
 
     return (
-      <View className={cssClass.CONTAINER} title="Number" sourcePath="src/Number/Number.jsx">
+      <View className={cssClass.CONTAINER} title="Number" sourcePath="src/Number/Number.tsx">
         <p>Provides consistent number formatting for long numbers, with optional shortening.</p>
 
         <Example title="Short numbers are left unchanged:">

--- a/docs/components/RichTextView.jsx
+++ b/docs/components/RichTextView.jsx
@@ -7,7 +7,7 @@ import { RichText } from "src";
 
 export default function DateInputView() {
   return (
-    <View title="RichText" sourcePath="src/RichText/RichText.jsx">
+    <View title="RichText" sourcePath="src/RichText/RichText.tsx">
       <p>
         RichText is a view that improves rendering of raw text - Specifically by linkifying urls and
         not discarding linebreaks.

--- a/docs/components/SegmentedControlView.jsx
+++ b/docs/components/SegmentedControlView.jsx
@@ -16,7 +16,11 @@ export default class SegmentedControlView extends Component {
     const { cssClass } = SegmentedControlView;
 
     return (
-      <View className={cssClass.CONTAINER} title="SegmentedControl" sourcePath="src/SegmentedControl/SegmentedControl.tsx">
+      <View
+        className={cssClass.CONTAINER}
+        title="SegmentedControl"
+        sourcePath="src/SegmentedControl/SegmentedControl.tsx"
+      >
         <p>
           This component is a <code>segmented control</code>. It functions as a variation on
           radiobuttons for when a user needs to select one of a handful of options.

--- a/docs/components/SegmentedControlView.jsx
+++ b/docs/components/SegmentedControlView.jsx
@@ -16,7 +16,7 @@ export default class SegmentedControlView extends Component {
     const { cssClass } = SegmentedControlView;
 
     return (
-      <View className={cssClass.CONTAINER} title="SegmentedControl">
+      <View className={cssClass.CONTAINER} title="SegmentedControl" sourcePath="src/SegmentedControl/SegmentedControl.tsx">
         <p>
           This component is a <code>segmented control</code>. It functions as a variation on
           radiobuttons for when a user needs to select one of a handful of options.

--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -35,7 +35,7 @@ export default class SelectView extends Component {
     const { cssClass } = SelectView;
 
     return (
-      <View className={cssClass.CONTAINER} title="Select">
+      <View className={cssClass.CONTAINER} title="Select" sourcePath="src/Select/Select.tsx">
         <p>
           This component replaces the <code>select</code> input and allows users to select options
           from a list.

--- a/docs/components/TabBarView.jsx
+++ b/docs/components/TabBarView.jsx
@@ -9,7 +9,7 @@ export default class TabBarView extends PureComponent {
     const { cssClass } = TabBarView;
 
     return (
-      <View className={cssClass.CONTAINER} title="TabBar">
+      <View className={cssClass.CONTAINER} title="TabBar" sourcePath="src/TabBar/TabBar.tsx">
         <p>
           <code>TabBar</code> provides a simple horizontal flex-enabled tab bar supporting various
           alignment and sizing options. It requires <code>Tab</code> components as children.

--- a/docs/components/TableView.jsx
+++ b/docs/components/TableView.jsx
@@ -50,7 +50,7 @@ export default class TableView extends PureComponent {
     const { enableDynamicCellClass, enableRowClick, tableData } = this.state;
 
     return (
-      <View className={cssClass.CONTAINER} title="Table">
+      <View className={cssClass.CONTAINER} title="Table" sourcePath="src/Table/Table.tsx">
         <p>
           This table component supports sorting, filtering, and pagination. There is also a lazy
           loading table available for very large sets of data.

--- a/docs/components/TextAreaView.jsx
+++ b/docs/components/TextAreaView.jsx
@@ -26,7 +26,7 @@ export default class TextAreaView extends React.Component {
     const { cssClass } = TextAreaView;
 
     return (
-      <View className={cssClass.CONTAINER} title="TextArea">
+      <View className={cssClass.CONTAINER} title="TextArea" sourcePath="src/TextArea/TextArea.tsx">
         <p>
           This component is a <code>textarea</code> that lets the user input multiple lines of text.
         </p>

--- a/docs/components/TextInputView.jsx
+++ b/docs/components/TextInputView.jsx
@@ -27,7 +27,7 @@ export default class TextInputView extends Component {
     const { cssClass } = TextInputView;
 
     return (
-      <View className={cssClass.CONTAINER} title="TextInput">
+      <View className={cssClass.CONTAINER} title="TextInput" sourcePath="src/TextInput/TextInput.tsx">
         <p>
           This is your standard <code>input type="text"</code> component.
         </p>

--- a/docs/components/TextInputView.jsx
+++ b/docs/components/TextInputView.jsx
@@ -27,7 +27,11 @@ export default class TextInputView extends Component {
     const { cssClass } = TextInputView;
 
     return (
-      <View className={cssClass.CONTAINER} title="TextInput" sourcePath="src/TextInput/TextInput.tsx">
+      <View
+        className={cssClass.CONTAINER}
+        title="TextInput"
+        sourcePath="src/TextInput/TextInput.tsx"
+      >
         <p>
           This is your standard <code>input type="text"</code> component.
         </p>

--- a/docs/components/TooltipView.jsx
+++ b/docs/components/TooltipView.jsx
@@ -26,7 +26,7 @@ export default class TooltipView extends Component {
     const { placement, textAlign } = this.state;
 
     return (
-      <View className={cssClass.CONTAINER} title="Tooltip">
+      <View className={cssClass.CONTAINER} title="Tooltip" sourcePath="src/Tooltip/Tooltip.tsx">
         <Example>
           <div className={cssClass.DEMO_CONTAINER}>
             <ExampleCode>

--- a/docs/components/TooltipView.jsx
+++ b/docs/components/TooltipView.jsx
@@ -65,10 +65,7 @@ export default class TooltipView extends Component {
                   textAlign={textAlign}
                 >
                   <span ref="focusableTrigger" tabIndex={0}>
-                    <FontAwesome
-                      className={cssClass.TRIGGER}
-                      name="question-circle"
-                    />
+                    <FontAwesome className={cssClass.TRIGGER} name="question-circle" />
                   </span>
                 </Tooltip>
               </div>

--- a/docs/components/TopBarView.jsx
+++ b/docs/components/TopBarView.jsx
@@ -50,7 +50,7 @@ export default class TopBarView extends React.PureComponent {
     const page = location.query.page || "portal";
 
     return (
-      <View className={cssClass.CONTAINER} title="TopBar" sourcePath="src/TopBar/TopBar.tsx">
+      <View className={cssClass.CONTAINER} title="TopBar" sourcePath="src/TopBar/index.tsx">
         <header className={cssClass.INTRO}>
           <p>
             Global page-level header component with support for navigation buttons, links and menus.

--- a/docs/components/WizardView.jsx
+++ b/docs/components/WizardView.jsx
@@ -9,7 +9,7 @@ export default class WizardView extends PureComponent {
     const { cssClass } = WizardView;
 
     return (
-      <View className={cssClass.CONTAINER} title="Wizard">
+      <View className={cssClass.CONTAINER} title="Wizard" sourcePath="src/Wizard/Wizard.tsx">
         <p>
           <code>Wizard</code> provides an interface for making guided wizards. A <code>Wizard</code>
           is provided several steps that consist of a <code>Component</code> to render, a validate


### PR DESCRIPTION
**Jira:** N/A

**Overview:** 
Maybe I'm the only one that uses this, but I really like the links in the documentation that go to the code for the component.
![Screen Shot 2019-07-10 at 5 39 03 PM](https://user-images.githubusercontent.com/39533986/61014489-84081c00-a33c-11e9-8822-5b5c67deeb51.png)

Unfortunately, a few URLs are wrong and many components didn't have a URL set at all. This fixes any incorrect URLs and adds them for components missing them!


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [X] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
