### PR TITLE
Number component tests for falsy input

### DIFF
--- a/jestconfig.json
+++ b/jestconfig.json
@@ -1,6 +1,6 @@
 {
   "automock": false,
-  "testRegex": ".+_test\\.(j|t)sx?$",
+  "testRegex": ".+_test\\.tsx?$",
   "testPathIgnorePatterns": [
     "/.*\/bin/",
     "/.*\/node_modules/"
@@ -21,7 +21,7 @@
   ],
   "setupTestFrameworkScriptFile": "./node_modules/jest-enzyme/lib/index.js",
   "transform": {
-    ".*(js|jsx|ts|tsx)$": "./jest_preprocessor.js"
+    ".*tsx?$": "./jest_preprocessor.js"
   },
   "verbose": true
 }

--- a/test/Number_test.tsx
+++ b/test/Number_test.tsx
@@ -35,4 +35,13 @@ describe("Number", () => {
     assert.throws(() => shallow(<Number>nope</Number>));
     assert.throws(() => Number.format("nope", true));
   });
+
+  it.only("renders 0 when children is falsy", () => {
+    assert.equal("0", mount(<Number />).text());
+    assert.equal("0", mount(<Number>{}</Number>).text());
+    assert.equal("0", mount(<Number>{""}</Number>).text());
+    assert.equal("0", mount(<Number>0</Number>).text());
+    assert.equal("0", mount(<Number>{null}</Number>).text());
+    assert.equal("0", mount(<Number>{undefined}</Number>).text());
+  });
 });


### PR DESCRIPTION
**Overview:**
This change adds some tests to cover the case when the `Number` component is passed falsy values as `children`. The component should handle any of those cases by rendering 0. There was a recent issue https://github.com/Clever/components/pull/410 where the component stopped defaulting to 0, and these tests will catch that.

**Testing:**
- [x] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
