### PR TITLE
Add outline to focused close button in Modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.less
+++ b/src/Modal/Modal.less
@@ -68,6 +68,7 @@
   &:hover,
   &:focus {
     opacity: 1;
+    outline: @borderRadiusM solid @primary_blue_tint_1;
   }
 }
 


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/IL-1286

**Overview:**
Adds stronger visible focus to the close button in the `Modal` component by adding a 3px outline when the button is in focus.

**Screenshots/GIFs:**

<img width="432" alt="Screen Shot 2019-07-15 at 4 43 44 PM" src="https://user-images.githubusercontent.com/10870634/61255998-e20f7780-a71f-11e9-82ed-0c641b9a6315.png">

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] ~~Updated docs~~
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] ~~Deployed updated docs (`make deploy-docs`)~~
