### PR TITLE
[TextInput] fixes show/hide refocus to address toolbar on voiceOver in iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -232,8 +232,9 @@ export class TextInput extends React.Component<Props, State> {
             type="button"
             className="TextInput--link"
             onClick={this.toggleHidden}
-            onMouseDown={() => {
-              // fixes accessibility bug
+            onMouseDown={event => {
+              // This prevents focus from jumping to the address bar or
+              // the first element on voiceover-enabled iOS devices
               event.preventDefault();
               event.stopPropagation();
             }}

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -228,7 +228,16 @@ export class TextInput extends React.Component<Props, State> {
           value={this.props.value as any}
         />
         {this.props.enableShow && (
-          <button type="button" className="TextInput--link" onClick={this.toggleHidden}>
+          <button
+            type="button"
+            className="TextInput--link"
+            onClick={this.toggleHidden}
+            onMouseDown={() => {
+              // fixes accessibility bug
+              event.preventDefault();
+              event.stopPropagation();
+            }}
+          >
             {this.state.hidden ? "Show" : "Hide"}
           </button>
         )}


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/IL-1312

**Overview:**
Voiceover on ipad/iphone changes focus to address bar when clicking on show/hide button with the keyboard open. Accessibility in oauth See gif.
![refocus](https://user-images.githubusercontent.com/18272584/61330768-36c0fa00-a7d5-11e9-8aa2-50a7c9f309b8.gif)

**Screenshots/GIFs:**
![refocus-fixed](https://user-images.githubusercontent.com/18272584/61330796-43dde900-a7d5-11e9-8a91-7eb9209b019c.gif)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10
  - [x] Safari on iPhone

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
