### PR TITLE
[WizardLayout] customizable exit button text

### DIFF
--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -119,6 +119,7 @@ export default class WizardLayoutView extends React.PureComponent {
     const WizardLayoutToRender = (
       <WizardLayout
         className="Dewey--WizardLayout"
+        exitButtonText={WizardLayoutContent[currentStep].exitButtonText || null}
         fullscreen={fullscreen}
         sections={WizardLayoutContent[currentStep].sections}
         headerImg={showHeaderImg ? headerImg : null}
@@ -227,6 +228,13 @@ export default class WizardLayoutView extends React.PureComponent {
             name: "className",
             type: "String",
             description: "Custom CSS class to be added to the component.",
+            optional: true,
+          },
+          {
+            name: "exitButtonText",
+            type: "String",
+            description: "Optional exit button text",
+            defaultValue: "Save & exit",
             optional: true,
           },
           {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -10,6 +10,7 @@ import "./WizardLayout.less";
 
 export interface Props {
   className?: string;
+  exitButtonText?: string;
   sections: any[];
   fullscreen?: boolean;
   headerImg?: any;
@@ -35,6 +36,7 @@ const SECTION_PROP_TYPE = PropTypes.shape({
 
 const propTypes = {
   className: PropTypes.string,
+  exitButtonText: PropTypes.string,
   fullscreen: PropTypes.bool,
   headerImg: PropTypes.element,
   helpContent: PropTypes.node,
@@ -85,6 +87,7 @@ export default class WizardLayout extends React.PureComponent<Props> {
   render() {
     const {
       className,
+      exitButtonText,
       sections,
       headerImg,
       helpContent,
@@ -133,7 +136,11 @@ export default class WizardLayout extends React.PureComponent<Props> {
         </FlexBox>
         <FlexBox className={classnames(cssClass.FOOTER, fullscreen && cssClass.FOOTER_FULLSCREEN)}>
           {!hideSaveAndExit && onSaveAndExit && (
-            <Button type="link" value={"Save & exit"} onClick={() => onSaveAndExit()} />
+            <Button
+              type="link"
+              value={exitButtonText || "Save & exit"}
+              onClick={() => onSaveAndExit()}
+            />
           )}
           {/* spacer for the buttons */}
           <FlexBox grow />


### PR DESCRIPTION
**Overview:**
This change adds a new prop to customize the exit button text for the WizardLayout component. It is very similar to the existing props used to customize the next and previous buttons.

**Screenshots/GIFs:**
<img width="1897" alt="Screen Shot 2019-07-16 at 7 37 36 PM" src="https://user-images.githubusercontent.com/32328921/61343024-34749500-a801-11e9-9678-8bb787718d03.png">


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
