### PR TITLE
z-index for pendo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.less
+++ b/src/Modal/Modal.less
@@ -1,7 +1,8 @@
 @import (reference) "../less/index.less";
 
 .Modal {
-  .zIndex--5;
+  // make modal z-index greater than z-index used by pendo.
+  z-index: 10000000000;
   position: fixed;
 }
 


### PR DESCRIPTION
**Jira:**

**Overview:**
Make the z-index of the modal much greater than the z-index used by pendo modals so that this modal is always on top.

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
