### PR TITLE
[WizardLayout] hideable back button

### DIFF
--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -41,12 +41,19 @@ export default class WizardLayoutView extends React.PureComponent {
       singleSignOn: false,
       goals: false,
     },
+    hidePreviousStepButton: false,
     hideSaveAndExit: false,
   };
 
   render() {
     const { fullscreen } = this.props;
-    const { currentStep, showHeaderImg, customHelpContent, hideSaveAndExit } = this.state;
+    const {
+      currentStep,
+      showHeaderImg,
+      customHelpContent,
+      hidePreviousStepButton,
+      hideSaveAndExit,
+    } = this.state;
 
     const stepperSteps = [
       {
@@ -124,6 +131,7 @@ export default class WizardLayoutView extends React.PureComponent {
         sections={WizardLayoutContent[currentStep].sections}
         headerImg={showHeaderImg ? headerImg : null}
         helpContent={customHelpContent ? WizardLayoutContent[currentStep].helpContent : null}
+        hidePreviousStepButton={hidePreviousStepButton}
         hideSaveAndExit={hideSaveAndExit}
         nextStepButtonText={WizardLayoutContent[currentStep].nextStepButtonText || null}
         onNextStep={_onNextStep}
@@ -184,7 +192,12 @@ export default class WizardLayoutView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { showHeaderImg, customHelpContent, hideSaveAndExit } = this.state;
+    const {
+      showHeaderImg,
+      customHelpContent,
+      hidePreviousStepButton,
+      hideSaveAndExit,
+    } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -205,6 +218,15 @@ export default class WizardLayoutView extends React.PureComponent {
             onChange={e => this.setState({ customHelpContent: e.target.checked })}
           />{" "}
           Custom help content
+        </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            checked={hidePreviousStepButton}
+            className={cssClass.CONFIG_TOGGLE}
+            onChange={e => this.setState({ hidePreviousStepButton: e.target.checked })}
+          />{" "}
+          Hide previous step button
         </label>
         <label className={cssClass.CONFIG}>
           <input
@@ -279,6 +301,12 @@ export default class WizardLayoutView extends React.PureComponent {
             name: "onPrevStep",
             type: "Function",
             description: "Called when user clicks on 'Previous step' button.",
+          },
+          {
+            name: "hidePreviousStepButton",
+            type: "Boolean",
+            description: "Optional boolean determining if the previous step button is hidden",
+            optional: true,
           },
           {
             name: "hideOnSaveAndExit",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -15,6 +15,7 @@ export interface Props {
   fullscreen?: boolean;
   headerImg?: any;
   helpContent?: React.ReactNode;
+  hidePreviousStepButton?: boolean;
   hideSaveAndExit?: boolean;
   nextStepButtonDisabled?: boolean;
   nextStepButtonText?: string;
@@ -40,6 +41,7 @@ const propTypes = {
   fullscreen: PropTypes.bool,
   headerImg: PropTypes.element,
   helpContent: PropTypes.node,
+  hidePreviousStepButton: PropTypes.bool,
   nextStepButtonDisabled: PropTypes.bool,
   nextStepButtonText: PropTypes.string,
   prevStepButtonDisabled: PropTypes.bool,
@@ -93,6 +95,7 @@ export default class WizardLayout extends React.PureComponent<Props> {
       helpContent,
       nextStepButtonDisabled,
       nextStepButtonText,
+      hidePreviousStepButton,
       hideSaveAndExit,
       onSaveAndExit,
       prevStepButtonDisabled,
@@ -144,13 +147,15 @@ export default class WizardLayout extends React.PureComponent<Props> {
           )}
           {/* spacer for the buttons */}
           <FlexBox grow />
-          <Button
-            type="link"
-            value={prevStepButtonText || "Previous step"}
-            className={cssClass.PREVIOUS_BUTTON}
-            onClick={this._onPrevStep}
-            disabled={prevStepButtonDisabled}
-          />
+          {!hidePreviousStepButton && (
+            <Button
+              type="link"
+              value={prevStepButtonText || "Previous step"}
+              className={cssClass.PREVIOUS_BUTTON}
+              onClick={this._onPrevStep}
+              disabled={prevStepButtonDisabled}
+            />
+          )}
           <Button
             type="primary"
             value={nextStepButtonText || "Next step"}


### PR DESCRIPTION
**Overview:**
Sometimes the Wizard doesn't need to show the previous button. For example on the first step, there isn't anything to go back to. This change allows hiding of the previous step button.

**Screenshots/GIFs:**
![](https://cl.ly/7206bdd4c8ae/Screen%20Recording%202019-07-18%20at%2007.22%20PM.gif)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
