### PR TITLE
enforce prettier formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ WEBPACK := node_modules/webpack/bin/webpack.js
 .PHONY: gen-border-styles gen-border-radius-styles deploy-docs generate gen-colors
 
 GREEN_CHECK_MARK := " \033[0;32m✓\033[0m"
+RED_CROSS_MARK := "❌"
+
+RED := "\033[0;31m"
+ENDCOLOR := "\033[0m"
 
 format-all:
 	@./node_modules/.bin/prettier --write $(FORMATTED_FILES)
@@ -30,7 +34,7 @@ format:
 
 format-check:
 	@./node_modules/.bin/prettier -l $(FORMATTED_FILES) || \
-	(echo "\033[0;31m**** Prettier errors in the above files! Run 'make format-all' to fix! ****\033[0m" && false)
+	(echo -e $(RED_CROSS_MARK) $(RED) Prettier diffs in the above files! Run 'make format' to fix! $(ENDCOLOR) && false)
 
 # Clean up build artifacts
 clean:
@@ -92,7 +96,9 @@ lint:
 		echo -e "\033[0;32m✓ No new lint errors found.\033[0m\n"; \
 	fi
 
-test: lint
+test: format-check lint unit-test
+
+unit-test:
 	@echo "Running unit tests..."
 	NODE_ENV=test $(JEST)
 

--- a/bin/NewComponent.tsx
+++ b/bin/NewComponent.tsx
@@ -8,7 +8,7 @@ import "./NewComponent.less";
 export interface Props {
   children: React.ReactNode;
   className?: string;
-  onPerformAction: (arg?: string) => any
+  onPerformAction: (arg?: string) => any;
 }
 
 // TODO: Uncomment if this component is stateful, and pass State to PureComponent. Remove otherwise.
@@ -16,7 +16,6 @@ export interface Props {
 //   sampleState1: boolean;
 //   sampleState2: string;
 // }
-
 
 export const cssClass = {
   CONTAINER: "NewComponent",

--- a/bin/componentUtils.ts
+++ b/bin/componentUtils.ts
@@ -28,10 +28,7 @@ export function createNewComponent(componentName) {
   const componentIndexFilePath = `${srcDirPath}/index.ts`;
   fs.writeFileSync(
     componentIndexFilePath,
-    [
-      `export { ${componentName} } from "./${componentName}";`,
-      "",
-    ].join("\n"),
+    [`export { ${componentName} } from "./${componentName}";`, ""].join("\n"),
   );
 
   process.stdout.write("Updating src/index.ts...");

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "lorem-ipsum": "^1.0.3",
     "mocha": "^2.4.5",
     "postcss-loader": "^1.1.1",
-    "prettier": "1.16.4",
+    "prettier": "1.18.2",
     "prismjs": "^1.5.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/src/ConfirmationButton/ConfirmationButton.tsx
+++ b/src/ConfirmationButton/ConfirmationButton.tsx
@@ -69,11 +69,11 @@ export class ConfirmationButton extends React.Component<Props> {
     const wrapperClass = "ConfirmationButton--dialog-buttons";
 
     return (
-      <ModalButton {...modalButtonProps as ModalButtonProps} ref={this.modalButton}>
+      <ModalButton {...(modalButtonProps as ModalButtonProps)} ref={this.modalButton}>
         {this.props.children}
         <div className={classnames(wrapperClass, this.props.className)}>
           <Button type="link" value="Cancel" onClick={this.handleCancel} />
-          <Button {...confirmButtonProps as ButtonProps} onClick={this.handleConfirm} />
+          <Button {...(confirmButtonProps as ButtonProps)} onClick={this.handleConfirm} />
         </div>
       </ModalButton>
     );

--- a/src/FormError/FormError.less
+++ b/src/FormError/FormError.less
@@ -19,7 +19,7 @@
 .FormError--icon {
   height: 1.25em; // Match font line height to center with first line of text.
   width: 0.875em; // Match font size at a ratio of 14px:16px.
-  .flexShrink(0)
+  .flexShrink(0);
 }
 
 .FormError--ErrorIcon--path {

--- a/src/ModalButton/ModalButton.tsx
+++ b/src/ModalButton/ModalButton.tsx
@@ -66,7 +66,7 @@ export class ModalButton extends React.Component<Props, State> {
     return (
       <div className={classnames("ModalButton", this.props.className)}>
         <Button
-          {...buttonProps as ButtonProps}
+          {...(buttonProps as ButtonProps)}
           onClick={e => {
             if (this.props.onClick) this.props.onClick(e);
             this.showModal();
@@ -74,7 +74,7 @@ export class ModalButton extends React.Component<Props, State> {
         />
         {this.state.showingModal ? (
           <Modal
-            {...modalProps as ModalProps}
+            {...(modalProps as ModalProps)}
             closeModal={() => {
               if (this.props.onClose) this.props.onClose();
               this.hideModal();

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -22,8 +22,8 @@ export interface SortState {
 // Webpack will inject process.env in so declare it here so we can use it to decide to log or not
 declare var process: {
   env: {
-      NODE_ENV: string
-  }
+    NODE_ENV: string;
+  };
 };
 
 export interface Props {

--- a/src/TopBar/index.tsx
+++ b/src/TopBar/index.tsx
@@ -46,7 +46,11 @@ export class TopBar extends React.PureComponent<Props> {
           needsRightPadding && "dewey--TopBar--rightPadding",
         )}
       >
-        <TopBarButton href={this.props.logoHref} onClick={this.props.onLogoClick} className="dewey-TopBar--logoLink">
+        <TopBarButton
+          href={this.props.logoHref}
+          onClick={this.props.onLogoClick}
+          className="dewey-TopBar--logoLink"
+        >
           <Logo className="dewey--TopBar--logo" />
         </TopBarButton>
         {title && (

--- a/src/WizardLayout/WizardLayout.less
+++ b/src/WizardLayout/WizardLayout.less
@@ -122,8 +122,7 @@
 }
 
 // Hack for IE only styles
-@media screen and (-ms-high-contrast: active),
-(-ms-high-contrast: none) {
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
   .WizardLayout--fullscreen {
     min-height: 100vh;
   }

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -107,7 +107,15 @@ export default class WizardLayout extends React.PureComponent<Props> {
     } = this.props;
 
     return (
-      <FlexBox column grow className={classnames(cssClass.CONTAINER, className, fullscreen && cssClass.CONTAINER_FULLSCREEN)}>
+      <FlexBox
+        column
+        grow
+        className={classnames(
+          cssClass.CONTAINER,
+          className,
+          fullscreen && cssClass.CONTAINER_FULLSCREEN,
+        )}
+      >
         <FlexBox className={cssClass.HEADER}>
           {headerImg && <div className={cssClass.HEADER_IMG}>{headerImg}</div>}
           <div>

--- a/src/less/box-shadow.less
+++ b/src/less/box-shadow.less
@@ -35,8 +35,7 @@
 }
 
 .boxShadow(@blurRadius, @color) {
-  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetM @blurRadius
-    @boxShadowDefaultSpread @color;
+  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetM @blurRadius @boxShadowDefaultSpread @color;
 }
 
 // DEPRECATED - remove once there are no usages of these

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -11,7 +11,6 @@ module.exports = {
       },
     ],
     "max-empty-lines": 2,
-    "max-line-length": 100,
     "max-nesting-depth": [
       2,
       {


### PR DESCRIPTION
**Overview:**
This change adds the format check to the build process to fail builds with unformatted code. `make test` is called in circle, and that performs the format check, linting, and unit tests. I created a separate make target for the unit tests for convenience. 

I bumped prettier to the latest version and formatted all the files.

Prettier made one of the lines in https://gist.github.com/vratiu/9780109 101 characters, so I deleted the styleint rule.

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
