### PR TITLE
add title to navlink

### DIFF
--- a/docs/LeftNavExample.jsx
+++ b/docs/LeftNavExample.jsx
@@ -48,9 +48,10 @@ export default class LeftNavExample extends React.Component {
     } = this.state;
 
     const icon = name => <Icon name={name} size={Icon.sizes.SMALL} />;
-    const link = (label, iconNode) =>
+    const link = (label, title, iconNode) =>
       <NavLink
         label={label}
+        title={title}
         icon={iconNode}
         selected={selected === label}
         onClick={() => this.setState({selected: label})}
@@ -75,6 +76,7 @@ export default class LeftNavExample extends React.Component {
             >
               <NavLink
                 label="Menu"
+                title="Menu"
                 icon={icon(Icon.names.MENU)}
                 onClick={() => this.setState({collapsed: !collapsed})}
               />
@@ -84,13 +86,18 @@ export default class LeftNavExample extends React.Component {
                 {link("Screwdriver")}
                 {link("Measuring Tape")}
               </NavGroup>
-              <NavGroup label="Juggling Props" id="Juggling Props" icon={icon(Icon.names.JUGGLER)}>
+              <NavGroup label="Juggling Props"
+                title="JugglingProps"
+                id="Juggling Props"
+                icon={icon(Icon.names.JUGGLER)}
+              >
                 {link("Balls")}
                 {link("Clubs")}
                 {link("Rings")}
               </NavGroup>
               <NavGroup
                 label="Really really ridiculously long label"
+                title="Really long title"
                 id="verbose"
                 icon={icon(Icon.names.PEN)}
               >

--- a/docs/components/LeftNavView.jsx
+++ b/docs/components/LeftNavView.jsx
@@ -100,6 +100,11 @@ export default class LeftNavView extends PureComponent {
               type: "String",
               description: "The label to render as the link text",
             },
+            {
+              name: "title",
+              type: "String",
+              description: "The string to render as the link title",
+            },
           ]}
           className={cssClass.PROPS}
           title="NavGroup"
@@ -123,6 +128,11 @@ export default class LeftNavView extends PureComponent {
               name: "label",
               type: "String",
               description: "The label to render as the link text",
+            },
+            {
+              name: "title",
+              type: "String",
+              description: "The string to render as the link title",
             },
             {
               name: "onClick",

--- a/docs/components/SideBar/SideBar.jsx
+++ b/docs/components/SideBar/SideBar.jsx
@@ -113,7 +113,7 @@ export default class SideBar extends React.Component {
           {this._renderLink("/components/wizard", "Wizard")}
           {this._renderLink("/components/wizard-layout", "WizardLayout")}
         </NavGroup>
-        <NavGroup id="less" label="LESS" icon={faIcon("css3")}>
+        <NavGroup id="less" label="LESS" title="LESS" icon={faIcon("css3")}>
           {this._renderLink("/less/less-style-guide", "Style Guide")}
           {this._renderLink("/less/spacing", "Spacing")}
         </NavGroup>

--- a/src/LeftNav/NavGroup.jsx
+++ b/src/LeftNav/NavGroup.jsx
@@ -24,6 +24,7 @@ export class NavGroup extends React.PureComponent {
       className,
       icon,
       label,
+      title,
     } = this.props;
 
     const childSelected = !!_.find(React.Children.toArray(children), item => item.props.selected);
@@ -33,6 +34,7 @@ export class NavGroup extends React.PureComponent {
         className={classnames(cssClass.CONTAINER, _open && cssClass.OPEN, className)}
         icon={icon}
         label={label}
+        title={title}
         onClick={_onClick}
         selected={_withActiveNavGroups && childSelected}
         _collapsed={_collapsed}
@@ -49,6 +51,7 @@ NavGroup.propTypes = {
   icon: PropTypes.node.isRequired,
   id: PropTypes.string.isRequired,
   label: PropTypes.node.isRequired,
+  title: PropTypes.string,
 
   // Internal use only:
   _collapsed: PropTypes.bool,

--- a/src/LeftNav/NavLink.jsx
+++ b/src/LeftNav/NavLink.jsx
@@ -22,6 +22,7 @@ export class NavLink extends React.PureComponent {
       label,
       onClick,
       selected,
+      title,
       ...additionalProps,
     } = this.props;
 
@@ -54,7 +55,7 @@ export class NavLink extends React.PureComponent {
             </div>
           )}
           <div className={cssClass.LABEL_CONTAINER}>
-            <div className={cssClass.LABEL} title={label}>{label}</div>
+            <div className={cssClass.LABEL} title={title ? title : label}>{label}</div>
           </div>
           {_withArrow && (
             <div className={cssClass.ARROW_CONTAINER}>

--- a/src/LeftNav/NavLink.jsx
+++ b/src/LeftNav/NavLink.jsx
@@ -55,7 +55,7 @@ export class NavLink extends React.PureComponent {
             </div>
           )}
           <div className={cssClass.LABEL_CONTAINER}>
-            <div className={cssClass.LABEL} title={title? title : JSON.stringify(label)}>{label}</div>
+            <div className={cssClass.LABEL} title={"bla" || title}>{label}</div>
           </div>
           {_withArrow && (
             <div className={cssClass.ARROW_CONTAINER}>
@@ -86,6 +86,7 @@ NavLink.propTypes = {
   label: PropTypes.node,
   onClick: PropTypes.func,
   selected: PropTypes.bool,
+  title: PropTypes.string,
 
   // Internal use only:
   _collapsed: PropTypes.bool,

--- a/src/LeftNav/NavLink.jsx
+++ b/src/LeftNav/NavLink.jsx
@@ -55,7 +55,7 @@ export class NavLink extends React.PureComponent {
             </div>
           )}
           <div className={cssClass.LABEL_CONTAINER}>
-            <div className={cssClass.LABEL} title={title}>{label}</div>
+            <div className={cssClass.LABEL} title={title? title : JSON.stringify(label)}>{label}</div>
           </div>
           {_withArrow && (
             <div className={cssClass.ARROW_CONTAINER}>

--- a/src/LeftNav/NavLink.jsx
+++ b/src/LeftNav/NavLink.jsx
@@ -55,7 +55,7 @@ export class NavLink extends React.PureComponent {
             </div>
           )}
           <div className={cssClass.LABEL_CONTAINER}>
-            <div className={cssClass.LABEL} title={title ? title : label}>{label}</div>
+            <div className={cssClass.LABEL} title={title}>{label}</div>
           </div>
           {_withArrow && (
             <div className={cssClass.ARROW_CONTAINER}>

--- a/test/LeftNav_test.jsx
+++ b/test/LeftNav_test.jsx
@@ -24,8 +24,8 @@ describe("LeftNav", function LeftNavTest() {
       </NavGroup>
       <NavLink label="topLink2" icon={fakeIcon} />
       <NavGroup label="group2" id="group2" icon={fakeIcon}>
-        <NavLink label="subLink21" />
-        <NavLink label="subLink22" />
+        <NavLink label="subLink21" title="subLink21" />
+        <NavLink label="subLink22" title="sb22" />
       </NavGroup>
     </LeftNav>
   );
@@ -67,6 +67,7 @@ describe("LeftNav", function LeftNavTest() {
       const link = group.get(0);
       assert.equal(group.type(), NavLink);
       assert.equal(link.props.label, "group1");
+      assert.equal(link.props.title, "group1");
       assert.equal(link.props.icon, fakeIcon);
       assert(!group.children().find(NavLink).exists());
     });
@@ -86,7 +87,9 @@ describe("LeftNav", function LeftNavTest() {
       assert(subnav.exists());
       assert.equal(subnav.children().length, 2);
       assert.equal(subnav.childAt(0).prop("label"), "subLink11");
+      assert.equal(subnav.childAt(0).prop("title"), "subLink11");
       assert.equal(subnav.childAt(1).prop("label"), "subLink12");
+      assert.equal(subnav.childAt(0).prop("title"), "subLink12");
     });
   });
 
@@ -133,7 +136,9 @@ describe("LeftNav", function LeftNavTest() {
       assert(subnav.exists());
       assert.equal(subnav.children().length, 2);
       assert.equal(subnav.childAt(0).prop("label"), "subLink21");
+      assert.equal(subnav.childAt(0).prop("title"), "subLink21");
       assert.equal(subnav.childAt(1).prop("label"), "subLink22");
+      assert.equal(subnav.childAt(1).prop("title"), "sb22");
     });
   });
 
@@ -170,6 +175,7 @@ describe("LeftNav", function LeftNavTest() {
       assert(subnav.exists());
       assert.equal(subnav.children().length, 1);
       assert.equal(subnav.childAt(0).prop("label"), "subLink11");
+      assert.equal(subnav.childAt(0).prop("title"), "subLink11");
     });
 
     it("renders the NavLink with the 'selected' class", () => {
@@ -186,6 +192,7 @@ describe("LeftNav", function LeftNavTest() {
       assert(subnav.exists());
       assert.equal(subnav.children().length, 1);
       assert.equal(subnav.childAt(0).prop("label"), "subLink21");
+      assert.equal(subnav.childAt(0).prop("title"), "subLink21");
     });
   });
 


### PR DESCRIPTION
**Jira:**

**Overview:**
Adding `title` attribute to`NavLink`. It is currently set to label's value. Since label is an object, the title gets set to `[object Object]`. This PR will allow us to set the title explicitly or default to none.

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
