### PR TITLE
Add focus outlines to AlertBox close button and linkPlain Buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.6.0",
+  "version": "2.5.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AlertBox/AlertBox.less
+++ b/src/AlertBox/AlertBox.less
@@ -76,4 +76,7 @@
   &:hover {
     opacity: 1;
   }
+  &:focus {
+    outline: @borderRadiusM solid @primary_blue_tint_2;
+  }
 }

--- a/src/AlertBox/AlertBox.less
+++ b/src/AlertBox/AlertBox.less
@@ -76,6 +76,7 @@
   &:hover {
     opacity: 1;
   }
+
   &:focus {
     outline: @borderRadiusM solid @primary_blue_tint_2;
   }

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -135,9 +135,12 @@ button {
     color: @primary_blue;
 
     &:hover,
-    &:focus,
     &:active {
       color: @primary_blue_shade_2;
+    }
+    &:focus {
+      outline: @borderRadiusM solid fade(@primary_blue_tint_2, 50%);
+      transition: none;
     }
   }
 

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -138,6 +138,7 @@ button {
     &:active {
       color: @primary_blue_shade_2;
     }
+
     &:focus {
       outline: @borderRadiusM solid fade(@primary_blue_tint_2, 50%);
       transition: none;


### PR DESCRIPTION
**Jira:** https://clever.atlassian.net/browse/IL-1291

**Overview:** Adds outlines for the focus state of the AlertBox's close button and linkPlain buttons. Screenshots show these new focus states.

**Screenshots/GIFs:**
![image](https://user-images.githubusercontent.com/39533986/61673416-4c866180-aca4-11e9-90af-8b335efa3799.png)
![image](https://user-images.githubusercontent.com/39533986/61673421-5019e880-aca4-11e9-9e5b-30d76fc42dfe.png)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [X] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [X] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
