### PR TITLE
Use <h3>s for <AlertBox> titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AlertBox/AlertBox.less
+++ b/src/AlertBox/AlertBox.less
@@ -6,10 +6,13 @@
   .border--s(transparent);
 }
 
-.AlertBox--title {
-  .text--semi-bold();
-  .text--large();
+h3.AlertBox--title {
+  .margin--none();
   .margin--bottom--s();
+  .padding--none();
+  .text--large();
+  .text--semi-bold();
+  color: @neutral_black;
 }
 
 .AlertBox--header {

--- a/src/AlertBox/AlertBox.tsx
+++ b/src/AlertBox/AlertBox.tsx
@@ -72,7 +72,9 @@ export default class AlertBox extends React.PureComponent<Props> {
             <Icon className={cssClass.ICON} />
           </FlexItem>
           <FlexItem>
-            <div className={cssClass.TITLE}>{title}</div>
+            {/* Use an <h3> for accessibility. Visual headings must be marked as such. The US Gov
+              design system also uses <h3>s for their alert box titles */}
+            <h3 className={cssClass.TITLE}>{title}</h3>
             {children}
           </FlexItem>
           <FlexItem grow>


### PR DESCRIPTION
# Jira 

[IL-1296](https://clever.atlassian.net/browse/IL-1296)

# Overview

We received the following comment about our alert box titles during the recent accessibility audit:

> visual heading is not marked as such

This PR updates Dewey to use `<h3>`s for `<AlertBox>` titles. I followed the example of the US Gov design system, which also uses `<h3>`s for their alert box titles: https://designsystem.digital.gov/components/alert.

# Screenshot

<img width="500" alt="h3" src="https://user-images.githubusercontent.com/12616928/61674039-da634c00-aca6-11e9-8463-7dd672c8742a.png">

# Testing

- [x] Chrome
- [x] Safari
- [x] IE10

# Rollout

- [x] Bumped version in `package.json`
- [ ] Deployed updated docs (`make deploy-docs` after merging)