### PR TITLE
Adding a darker box shadow to the FloatingButton

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FloatingButton/FloatingButton.less
+++ b/src/FloatingButton/FloatingButton.less
@@ -38,7 +38,7 @@
 }
 
 button.FloatingButton--button {
-  .boxShadow--heavy();
+  .boxShadow--heavyDark();
   border-radius: 500rem;
 }
 

--- a/src/less/box-shadow.less
+++ b/src/less/box-shadow.less
@@ -16,6 +16,7 @@
 @boxShadowDefaultSpread: 0.0625rem;
 
 @boxShadowDefaultColor: rgba(71, 76, 94, 0.2);
+@boxShadowDarkColor: rgba(71, 76, 94, 0.5);
 
 // Convenience mixins
 
@@ -32,6 +33,11 @@
 .boxShadow--heavy {
   box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetL @boxShadowBlurRadiusL
     @boxShadowDefaultSpread @boxShadowDefaultColor;
+}
+
+.boxShadow--heavyDark {
+  box-shadow: @boxShadowDefaultXOffset @boxShadowYOffsetL @boxShadowBlurRadiusL
+    @boxShadowDefaultSpread @boxShadowDarkColor;
 }
 
 .boxShadow(@blurRadius, @color) {


### PR DESCRIPTION
**Jira:**
N/A

**Overview:**
So that it stands out better over busy content, like app icons

**Screenshots/GIFs:**
Before:
![image](https://user-images.githubusercontent.com/1316859/61966640-f5281000-af87-11e9-9147-7883d0feda2c.png)

After:
![image](https://user-images.githubusercontent.com/1316859/61966688-1ab51980-af88-11e9-8cc7-0398c939158e.png)

**Testing:**
- [ ] Unit tests - N/A
- Manual tests:
  - [X] Chrome
  - [X] Safari
  - [X] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs - N/A
  - [X] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)