### PR TITLE
Add optional Navlink title

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/LeftNav/NavGroup.tsx
+++ b/src/LeftNav/NavGroup.tsx
@@ -15,6 +15,7 @@ export interface Props {
   icon: React.ReactElement;
   id: string;
   label: React.ReactNode;
+  title?: string;
 
   // Internal use only: (TODO: Remove?)
   _collapsed?: boolean;
@@ -30,6 +31,7 @@ const propTypes = {
   icon: PropTypes.element.isRequired,
   id: PropTypes.string.isRequired,
   label: PropTypes.node.isRequired,
+  title: PropTypes.string,
 
   // Internal use only:
   _collapsed: PropTypes.bool,
@@ -60,6 +62,7 @@ export class NavGroup extends React.PureComponent<Props> {
       className,
       icon,
       label,
+      title,
     } = this.props;
 
     const childSelected = !!_.find(
@@ -72,6 +75,7 @@ export class NavGroup extends React.PureComponent<Props> {
         className={classnames(cssClass.CONTAINER, _open && cssClass.OPEN, className)}
         icon={icon}
         label={label}
+        title={(title || label) as string}
         onClick={_onClick}
         selected={_withActiveNavGroups && childSelected}
         _collapsed={_collapsed}

--- a/src/LeftNav/NavLink.tsx
+++ b/src/LeftNav/NavLink.tsx
@@ -15,6 +15,7 @@ export interface Props {
   href?: string;
   icon?: React.ReactElement;
   label?: React.ReactNode;
+  title?: string;
   onClick?: React.MouseEventHandler;
   selected?: boolean;
 
@@ -30,6 +31,7 @@ const propTypes = {
   href: PropTypes.string,
   icon: PropTypes.element,
   label: PropTypes.node,
+  title: PropTypes.string,
   onClick: PropTypes.func,
   selected: PropTypes.bool,
 
@@ -66,6 +68,7 @@ export class NavLink extends React.PureComponent<Props> {
       href,
       icon,
       label,
+      title,
       onClick,
       selected,
       ...additionalProps
@@ -100,7 +103,7 @@ export class NavLink extends React.PureComponent<Props> {
             </div>
           )}
           <div className={cssClass.LABEL_CONTAINER}>
-            <div className={cssClass.LABEL} title={label as any}>
+            <div className={cssClass.LABEL} title={(title || label) as any}>
               {label}
             </div>
           </div>


### PR DESCRIPTION
When `label` is a react element (`node` prop type), the `title` prop renders as `[Object object]`. So add an optional `title` prop to accomodate this

![Untitled](https://user-images.githubusercontent.com/13126257/62109133-86d19f00-b260-11e9-9890-37c6834ffaa5.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
