### PR TITLE
Fix misnamed WizardLayout prop in docs

### DIFF
--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -309,7 +309,7 @@ export default class WizardLayoutView extends React.PureComponent {
             optional: true,
           },
           {
-            name: "hideOnSaveAndExit",
+            name: "hideSaveAndExit",
             type: "Boolean",
             description: "Optional boolean determining if the save & exit button is hidden",
             optional: true,


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FEE-159

**Overview:**
The docs list the prop as `hideOnSaveAndExit` but the code uses `hideSaveAndExit`. Should update the `WizardLayoutView` to use the latter instead.

**Screenshots/GIFs:**
Just changes text here:
![image](https://user-images.githubusercontent.com/8083680/62157652-836eff80-b2c2-11e9-9b27-888598262444.png)


**Testing:**
Verified visually

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
