### PR TITLE
TextInputs announce errors and set aria flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -159,6 +159,7 @@ export class TextArea extends React.Component<Props, State> {
   render() {
     let wrapperClass = "TextArea";
     const errorMessage = this.currentErrorMessage();
+    const valid = errorMessage === "";
 
     if (errorMessage) wrapperClass += " TextArea--hasError";
 
@@ -179,6 +180,7 @@ export class TextArea extends React.Component<Props, State> {
     const inputNote = this.renderNote(errorMessage);
 
     const textAreaProps = {
+      ["aria-invalid"]: !valid,
       className: "TextArea--input",
       disabled: this.props.disabled,
       maxLength: this.props.maxLength,
@@ -221,7 +223,7 @@ export class TextArea extends React.Component<Props, State> {
           <label className="TextArea--label" htmlFor={this.props.name}>
             {this.props.label}
           </label>
-          {inputNote}
+          <span aria-live="polite">{inputNote}</span>
         </div>
         {textarea}
       </div>

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -117,7 +117,7 @@ export class TextArea extends React.Component<Props, State> {
     this.textAreaEl.current.focus();
   }
 
-  currentErrorMessage() {
+  currentErrorMessage(): string {
     const { error, value, required } = this.props;
     const { hasBeenFocused } = this.state;
 

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -121,7 +121,7 @@ export class TextInput extends React.Component<Props, State> {
     this.setState({ hidden: !this.state.hidden });
   }
 
-  currentErrorMessage() {
+  currentErrorMessage(): string {
     const { error, value, required } = this.props;
     const { hasBeenFocused } = this.state;
 

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -163,6 +163,7 @@ export class TextInput extends React.Component<Props, State> {
   render() {
     let wrapperClass = "TextInput";
     const errorMessage = this.currentErrorMessage();
+    const valid = errorMessage === "";
 
     // add additional wrapper classes
     if (errorMessage) wrapperClass += " TextInput--hasError";
@@ -208,7 +209,7 @@ export class TextInput extends React.Component<Props, State> {
           <label className="TextInput--label" htmlFor={this.props.name}>
             {this.props.label}
           </label>
-          {inputNote}
+          <span aria-live="polite">{inputNote}</span>
         </div>
         <input
           {...additionalProps}
@@ -226,6 +227,7 @@ export class TextInput extends React.Component<Props, State> {
           required={this.props.required}
           type={type}
           value={this.props.value as any}
+          aria-invalid={!valid}
         />
         {this.props.enableShow && (
           <button

--- a/test/TextInput_test.tsx
+++ b/test/TextInput_test.tsx
@@ -63,9 +63,11 @@ describe("TextInput", () => {
     assert(textInput.hasClass("TextInput--hasError"));
 
     // check the span element with error message
-    assert.equal(textInput.find("span").length, 1);
-    assert.equal(textInput.find("span").text(), "<FontAwesome /> This is an error");
-    assert(textInput.find("span").hasClass("TextInput--error"));
+    assert.equal(textInput.find("span.TextInput--error").length, 1);
+    assert.equal(
+      textInput.find('span[aria-live="polite"]').text(),
+      "<FontAwesome /> This is an error",
+    );
   });
 
   it("properly renders a <TextInput> with a required flag", () => {
@@ -76,9 +78,8 @@ describe("TextInput", () => {
     assert.equal(textInput.find("input[value='TextInputValue']").length, 1);
 
     // check the span element with required indicator
-    assert.equal(textInput.find("span").length, 1);
-    assert.equal(textInput.find("span").text(), "required");
-    assert(textInput.find("span").hasClass("TextInput--required"));
+    assert.equal(textInput.find("span.TextInput--required").length, 1, textInput.html());
+    assert.equal(textInput.find('span[aria-live="polite"]').text(), "required");
   });
 
   it("properly renders a <TextInput> as readonly", () => {


### PR DESCRIPTION
**Jira:**

[[IL-1287] Make TextInput error messages screen readable](https://clever.atlassian.net/browse/IL-1287)

**Overview:**

Aria attributes can be set on the client side or on the server side.
If they are set by the client, we need to notify screen readers that
something has been changed and needs to be announced. So we need an
`aria-live` tag on first render. If the contents of this `aria-live`
element change, the screen reader will be notified.


**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
