### PR TITLE
fix firefox box-shadow bug for text inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput/TextInput.less
+++ b/src/TextInput/TextInput.less
@@ -56,6 +56,7 @@
     min-height: @size_2xl;
     padding-top: @size_s;
     background-color: transparent;
+    box-shadow: none;
   }
 
   &.TextInput--placeholder-shown {


### PR DESCRIPTION
**Jira:** n/a

**Overview:** In firefox TextInputs that have an error have a red boxshadow around them. This should fix that.

**Screenshots/GIFs:**
Before:
![Screen Shot 2019-08-08 at 4 10 38 PM](https://user-images.githubusercontent.com/32712579/62743507-815e1c80-b9f7-11e9-9de3-78e8ae844aa7.png)

After:
![Screen Shot 2019-08-08 at 4 11 04 PM](https://user-images.githubusercontent.com/32712579/62743511-86bb6700-b9f7-11e9-8c55-c6937206a746.png)

**Testing:**
- [X] Unit tests
- Manual tests:
  - [X] Chrome
  - [X] Safari
  - [X] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
