### PR TITLE
[Table] Pass noDataContent which will display in case no data in table

### DIFF
--- a/docs/components/TableView.jsx
+++ b/docs/components/TableView.jsx
@@ -296,6 +296,14 @@ export default class TableView extends PureComponent {
                 "`lazy`.",
               optional: true,
             },
+            {
+              name: "noDataContent",
+              type: "React Node",
+              description:
+                "If `data` is empty then we render noDataContent below the table body. " +
+                'If noDataContent is not passed we add a row spaning all columns that says "NO DATA"',
+              optional: true,
+            },
           ]}
           title="Table"
         />

--- a/docs/components/TableView.jsx
+++ b/docs/components/TableView.jsx
@@ -300,8 +300,8 @@ export default class TableView extends PureComponent {
               name: "noDataContent",
               type: "React Node",
               description:
-                "If `data` is empty then we render noDataContent below the table body. " +
-                'If noDataContent is not passed we add a row spaning all columns that says "NO DATA"',
+                "If `data` is empty then we render noDataContent in a row spanning all columns. " +
+                'If noDataContent is not passed we add a row spanning all columns that says "NO DATA"',
               optional: true,
             },
           ]}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -387,60 +387,59 @@ export class Table extends React.Component<Props, State> {
     const disableSort = numPages <= 1 && displayedData.length <= 1;
 
     return (
-      <>
-        <table className={classnames(cssClass.TABLE, fixed && cssClass.FIXED, className)}>
-          <Header
-            disableSort={disableSort}
-            onSortChange={columnID => this._toggleSort(columnID)}
-            sortState={sortState}
-          >
-            {columns}
-          </Header>
-          <tbody className={cssClass.BODY}>
-            {displayedData.length === 0 && !noDataContent ? (
-              <tr className={cssClass.ROW}>
+      <table className={classnames(cssClass.TABLE, fixed && cssClass.FIXED, className)}>
+        <Header
+          disableSort={disableSort}
+          onSortChange={columnID => this._toggleSort(columnID)}
+          sortState={sortState}
+        >
+          {columns}
+        </Header>
+        <tbody className={cssClass.BODY}>
+          {displayedData.length === 0 ? (
+            <tr className={cssClass.ROW}>
+              {noDataContent ? (
+                <Cell colSpan={columns.length} noWrap>
+                  {noDataContent}
+                </Cell>
+              ) : (
                 <Cell className={cssClass.NO_DATA} colSpan={columns.length} noWrap>
                   {!pageLoading && "NO DATA"}
                 </Cell>
+              )}
+            </tr>
+          ) : (
+            displayedData.map(rowData => (
+              <tr
+                className={classnames(
+                  cssClass.ROW,
+                  onRowClick && cssClass.CLICKABLE_ROW,
+                  rowClassNameFn && rowClassNameFn(rowData),
+                )}
+                key={rowIDFn(rowData)}
+                onClick={e => onRowClick && onRowClick(e, rowIDFn(rowData), rowData)}
+              >
+                {columns.map(({ props: col }: { props: any }) => (
+                  <Cell className={getCellClassName(col, rowData)} key={col.id} noWrap={col.noWrap}>
+                    {col.cell.renderer(rowData)}
+                  </Cell>
+                ))}
               </tr>
-            ) : (
-              displayedData.map(rowData => (
-                <tr
-                  className={classnames(
-                    cssClass.ROW,
-                    onRowClick && cssClass.CLICKABLE_ROW,
-                    rowClassNameFn && rowClassNameFn(rowData),
-                  )}
-                  key={rowIDFn(rowData)}
-                  onClick={e => onRowClick && onRowClick(e, rowIDFn(rowData), rowData)}
-                >
-                  {columns.map(({ props: col }: { props: any }) => (
-                    <Cell
-                      className={getCellClassName(col, rowData)}
-                      key={col.id}
-                      noWrap={col.noWrap}
-                    >
-                      {col.cell.renderer(rowData)}
-                    </Cell>
-                  ))}
-                </tr>
-              ))
-            )}
-          </tbody>
-          {paginated && (
-            <Footer
-              currentPage={displayedPage}
-              onPageChange={newPage => this.setCurrentPage(newPage)}
-              numColumns={columns.length}
-              numPages={numPages}
-              showLastPage={!lazy}
-              isLoading={pageLoading}
-              lengthUnknown={lazy && numRows == null && !allLoaded}
-            />
+            ))
           )}
-        </table>
-        {displayedData.length === 0 && noDataContent}
-      </>
+        </tbody>
+        {paginated && (
+          <Footer
+            currentPage={displayedPage}
+            onPageChange={newPage => this.setCurrentPage(newPage)}
+            numColumns={columns.length}
+            numPages={numPages}
+            showLastPage={!lazy}
+            isLoading={pageLoading}
+            lengthUnknown={lazy && numRows == null && !allLoaded}
+          />
+        )}
+      </table>
     );
   }
 }


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FEE-160

**Overview:**
Today if the data array is empty we show a row spanning all the columns with the text "No Data". It would be nice to allow users of the component to pass some value to override that.
Need this for https://clever.invisionapp.com/share/GDT1UXD9W4R

**Screenshots/GIFs:**
Before and when noDataContent is not passed:
![table-no-data](https://user-images.githubusercontent.com/18272584/62811223-ccd70000-bab5-11e9-8d10-5a7d298d98e7.png)

When noDataContent is set to `<div> This is a test </div>`
![table-no-data-content](https://user-images.githubusercontent.com/18272584/62811286-f42dcd00-bab5-11e9-9885-54389597e486.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
