### PR TITLE
[Table] Reset table padding when noDataContent is provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table/Table.less
+++ b/src/Table/Table.less
@@ -18,6 +18,10 @@
   text-align: center;
 }
 
+.Table--no_data_cell_with_content {
+  padding: 0;
+}
+
 .Table--row {
   .border--bottom--s(@neutral_silver);
   transition: background-color @timingImmediately @motionSmooth;

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -97,6 +97,7 @@ export const cssClass = {
   CLICKABLE_ROW: "Table--clickable_row",
   FIXED: "Table--fixed",
   NO_DATA: "Table--no_data_cell",
+  NO_DATA_CONTENT: "Table--no_data_cell_with_content",
   ROW: "Table--row",
   TABLE: "Table",
 };
@@ -399,7 +400,7 @@ export class Table extends React.Component<Props, State> {
           {displayedData.length === 0 ? (
             <tr className={cssClass.ROW}>
               {noDataContent ? (
-                <Cell colSpan={columns.length} noWrap>
+                <Cell className={cssClass.NO_DATA_CONTENT} colSpan={columns.length} noWrap>
                   {noDataContent}
                 </Cell>
               ) : (


### PR DESCRIPTION
**Jira:**
Related to https://clever.atlassian.net/browse/FEE-160

**Overview:**
When the user has set noDataContent we shouldn't force table-cell padding and allow user to override it. Sample use-case in the screenshots

**Screenshots/GIFs:**
Before
![table-with-padding](https://user-images.githubusercontent.com/18272584/62899819-7c59df80-bd0d-11e9-980f-03cca5326551.png)
After
![table-with-no-padding](https://user-images.githubusercontent.com/18272584/62899827-811e9380-bd0d-11e9-8d77-946f3887ed40.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
