### PR TITLE
first sort direction table prop

### DIFF
--- a/docs/components/TableView.jsx
+++ b/docs/components/TableView.jsx
@@ -7,7 +7,7 @@ import React, { PureComponent } from "react";
 import Example, { ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import { Button, ModalButton, Table, TextInput } from "src";
+import { Button, ModalButton, Table, TextInput, SegmentedControl } from "src";
 
 import "./TableView.less";
 
@@ -19,6 +19,7 @@ export default class TableView extends PureComponent {
       enableRowClick: true,
       enableRowMouseOver: false,
       tableFilter: "",
+      firstSortDirection: Table.sortDirection.ASCENDING,
     };
   }
 
@@ -48,7 +49,13 @@ export default class TableView extends PureComponent {
 
   render() {
     const { cssClass } = TableView;
-    const { enableDynamicCellClass, enableRowClick, enableRowMouseOver, tableData } = this.state;
+    const {
+      enableDynamicCellClass,
+      enableRowClick,
+      enableRowMouseOver,
+      tableData,
+      firstSortDirection,
+    } = this.state;
 
     return (
       <View className={cssClass.CONTAINER} title="Table" sourcePath="src/Table/Table.tsx">
@@ -90,6 +97,7 @@ export default class TableView extends PureComponent {
                 }
                 initialPage={24}
                 initialSortState={{ columnID: "name", direction: Table.sortDirection.ASCENDING }}
+                firstSortDirection={firstSortDirection}
                 ref="table"
                 onPageChange={page => console.log("Table page changed:", page)}
                 onSortChange={sortState => console.log("Table sort changed:", sortState)}
@@ -197,6 +205,18 @@ export default class TableView extends PureComponent {
             />{" "}
             Dynamic cell class names
           </label>
+          <label className={cssClass.CONFIG}>
+            First Sort Direction:
+            <SegmentedControl
+              className={cssClass.CONFIG_OPTIONS}
+              defaultValue={firstSortDirection}
+              onSelect={value => this.setState({ firstSortDirection: value })}
+              options={[
+                { content: "ASCENDING", value: Table.sortDirection.ASCENDING },
+                { content: "DESCENDING", value: Table.sortDirection.DESCENDING },
+              ]}
+            />
+          </label>
         </Example>
 
         <PropDocumentation
@@ -244,6 +264,12 @@ export default class TableView extends PureComponent {
               name: "initialSortState",
               type: "{columnID: String, direction: Table.sortDirection}",
               description: "The initial sort state of the table",
+              optional: true,
+            },
+            {
+              name: "firstSortDirection",
+              type: "Table.sortDirection",
+              description: "Direction to sort table on initial click",
               optional: true,
             },
             {
@@ -417,6 +443,7 @@ export default class TableView extends PureComponent {
               await new Promise(resolve => setTimeout(resolve, 1000));
               return tableData.slice(start, start + pageSize);
             }}
+            firstSortDirection={Table.sortDirection.DESCENDING}
             numRows={tableData.length}
             onPageChange={page => console.log("Table page changed:", page)}
             onSortChange={sortState => console.log("Table sort changed:", sortState)}
@@ -476,5 +503,6 @@ export default class TableView extends PureComponent {
 
 TableView.cssClass = {
   CONFIG: "TableView--config",
+  CONFIG_OPTIONS: "TableView--configOptions",
   CONTAINER: "TableView",
 };

--- a/docs/components/TableView.less
+++ b/docs/components/TableView.less
@@ -3,11 +3,16 @@
 .TableView--config {
   .margin--y--s;
   .margin--left--none;
-  .margin--right--xs;
+  .margin--right--l;
   .text--small;
   cursor: pointer;
   display: inline-block;
   text-transform: uppercase;
+}
+
+.TableView--configOptions {
+  .margin--left--2xs;
+  display: inline-block;
 }
 
 .TableView--status {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -14,9 +14,11 @@ import { ChildrenOf } from "../utils/types";
 
 import "./Table.less";
 
+export type SortDirection = "asc" | "desc";
+
 export interface SortState {
   columnID?: string;
-  direction?: "asc" | "desc";
+  direction?: SortDirection;
 }
 
 // Webpack will inject process.env in so declare it here so we can use it to decide to log or not
@@ -34,6 +36,7 @@ export interface Props {
   fixed?: boolean;
   initialPage?: number;
   initialSortState?: SortState;
+  firstSortDirection?: SortDirection;
   onPageChange?: Function;
   onRowClick?: Function;
   onRowMouseOver?: (e: any, rowID: any, rowData: any) => void;
@@ -71,6 +74,7 @@ const propTypes = {
   fixed: PropTypes.bool,
   initialPage: tablePropTypes.pageNumber,
   initialSortState: tablePropTypes.sortState,
+  firstSortDirection: tablePropTypes.sortDirection,
   onPageChange: PropTypes.func,
   onRowClick: PropTypes.func,
   onRowMouseOver: PropTypes.func,
@@ -92,6 +96,7 @@ const defaultProps = {
   onPageChange: () => {},
   onSortChange: () => {},
   pageSize: DEFAULT_PAGE_SIZE,
+  firstSortDirection: sortDirection.ASCENDING,
 };
 
 export const cssClass = {
@@ -265,7 +270,7 @@ export class Table extends React.Component<Props, State> {
 
     const newSortState: SortState = {
       columnID,
-      direction: sortDirection.ASCENDING,
+      direction: this.props.firstSortDirection,
     };
 
     if (oldSortState && oldSortState.columnID === columnID) {


### PR DESCRIPTION
I had a hard time finding an appropriate name for this prop. Help me!
(I didn't use `initial` because that tends to be a key word in react for initializing state from props)

![table-first-sort-direction](https://user-images.githubusercontent.com/13126257/64281360-d6faeb80-cf07-11e9-8d23-f5106d2e3bcf.gif)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
