### PR TITLE
MultipleModalPanels button types

### DIFF
--- a/docs/components/MultiplePanelModalsView.jsx
+++ b/docs/components/MultiplePanelModalsView.jsx
@@ -91,6 +91,7 @@ export default class MultiplePanelModalsView extends React.PureComponent {
                     title: "Page2",
                     panelClassName: "secondClass",
                     leftButtonName: "override the name back",
+                    rightButtonType: "destructive",
                     overrideOnClickRightButton: () =>
                       console.log("new action after clicking button 2 on the second page"),
                   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MultiplePanelModals/MultiplePanelModals.tsx
+++ b/src/MultiplePanelModals/MultiplePanelModals.tsx
@@ -77,8 +77,10 @@ export class MultiplePanelModals extends React.Component<Props, State> {
       width,
       panel,
       leftButtonName,
+      leftButtonType,
       overrideOnClickLeftButton,
       rightButtonName,
+      rightButtonType,
       overrideOnClickRightButton,
     } = componentArray[this.state.currentPanel];
 
@@ -124,7 +126,7 @@ export class MultiplePanelModals extends React.Component<Props, State> {
             <Button
               value={leftButtonValue}
               className={Classes.FIRST_BUTTON}
-              type="link"
+              type={leftButtonType || "link"}
               onClick={() => {
                 if (!isFirstPanel) {
                   this.setState({ currentPanel: this.state.currentPanel - 1 });
@@ -135,7 +137,7 @@ export class MultiplePanelModals extends React.Component<Props, State> {
             <Button
               value={rightButtonValue}
               className={Classes.SECOND_BUTTON}
-              type="primary"
+              type={rightButtonType || "primary"}
               onClick={() => {
                 rightButtonOnClick();
                 if (isLastPanel) {


### PR DESCRIPTION
**Overview:**
Adds support for overriding default modal button types.

**Screenshots/GIFs:**
![Screen Shot 2019-09-04 at 4 51 54 PM](https://user-images.githubusercontent.com/39101659/64301531-56061900-cf34-11e9-9a65-31ed17b3555e.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
