### PR TITLE
Bump minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Overview:**
My previous PR version bump got lost with John's change. Bumping minor version here so package changes are actually published to npm.

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
