### PR TITLE
Allow passing additional props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -23,6 +23,7 @@ export interface Props {
   stayOpenOnSelect?: boolean;
   trigger: React.ReactElement;
   wrapItems?: boolean;
+  [additionalProp: string]: any;
 }
 
 const Placement = {

--- a/src/Menu/MenuItem.tsx
+++ b/src/Menu/MenuItem.tsx
@@ -19,6 +19,7 @@ export interface Props {
   onMouseEnter?: Function;
   selected?: boolean;
   target?: string;
+  [additionalProp: string]: any;
 }
 
 const propTypes = {

--- a/src/TopBar/TopBarButton.tsx
+++ b/src/TopBar/TopBarButton.tsx
@@ -13,6 +13,7 @@ export interface Props {
   href?: string;
   onClick?: Function;
   round?: boolean;
+  [additionalProp: string]: any;
 }
 
 const propTypes = {

--- a/src/flex/FlexBox.tsx
+++ b/src/flex/FlexBox.tsx
@@ -21,6 +21,7 @@ export interface Props extends FlexItemProps {
   inline?: boolean;
   justify?: Values<typeof Justify>;
   wrap?: boolean;
+  [additionalProp: string]: any;
 }
 
 export const cssClass = {


### PR DESCRIPTION
**Overview:**
There are a number of components that can accept arbitrary props, and it became a problem when we began type checking those files. To prevent TypeScript from complaining about passing arbitrary props, we've added an index type as a catch all: `[additionalProp: string]: any`. We did this for some components, but not all of them. For completeness, let's make the same change for the remaining components. I also need this for something I'm working on so that I can pass an additional prop to a `MenuItem`.

https://github.com/Clever/components/blob/1c7f9e58a2d9618234999018d2b7f41a1a482660/src/Menu/MenuItem.tsx#L79
https://github.com/Clever/components/blob/1c7f9e58a2d9618234999018d2b7f41a1a482660/src/Menu/MenuItem.tsx#L100

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
