### PR TITLE
Add on click copy to copyable input

### DIFF
--- a/docs/components/CopyableInputView.jsx
+++ b/docs/components/CopyableInputView.jsx
@@ -233,6 +233,12 @@ export default class CopyableInputView extends Component {
               optional: true,
               defaultValue: <code>FormElementSize.FULL_WIDTH</code>,
             },
+            {
+              name: "onClickCopy",
+              type: "Function",
+              description: "Called when the user clicks the copy button",
+              optional: true,
+            },
           ]}
           className={cssClass.PROPS}
         />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/CopyableInput/CopyableInput.tsx
+++ b/src/CopyableInput/CopyableInput.tsx
@@ -12,7 +12,7 @@ import "../less/forms.less";
 export interface Props extends TextInputProps {
   className?: string;
   enableCopy?: boolean;
-  onClickCopy?: Function;
+  onClickCopy?: () => void;
 }
 
 interface State {

--- a/src/CopyableInput/CopyableInput.tsx
+++ b/src/CopyableInput/CopyableInput.tsx
@@ -25,6 +25,7 @@ const propTypes = {
   enableCopy: PropTypes.bool,
   required: PropTypes.bool,
   size: PropTypes.string,
+  onClickCopy: PropTypes.func,
 };
 
 const defaultProps = {
@@ -55,7 +56,13 @@ export class CopyableInput extends React.Component<Props, State> {
   }
 
   copyPassword() {
+    const { onClickCopy } = this.props;
+
     this.setState({ copied: true });
+
+    if (onClickCopy) {
+      onClickCopy();
+    }
   }
 
   render() {

--- a/src/CopyableInput/CopyableInput.tsx
+++ b/src/CopyableInput/CopyableInput.tsx
@@ -12,6 +12,7 @@ import "../less/forms.less";
 export interface Props extends TextInputProps {
   className?: string;
   enableCopy?: boolean;
+  onClickCopy?: Function;
 }
 
 interface State {


### PR DESCRIPTION
**Jira:**
Part of: https://clever.atlassian.net/browse/DISC-937

**Overview:**
Adds a `onClickCopy` prop to CopyableInput that is called when the user clicks the copy button.

**Screenshots/GIFs:**
Tested by passing `onClickCopy={() => console.log("HEY HEY HEY")}` to the CopyableInput component:
![copyable-input](https://user-images.githubusercontent.com/47156875/66233510-6f6bc380-e6a0-11e9-88f6-4d079d0088f8.gif)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
