### PR TITLE
Bump minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Jira:**
N/A

**Overview:**
Bumping minor version since my pr (https://github.com/Clever/components/pull/442) and luba's pr (https://github.com/Clever/components/pull/441) had the same version (2.14.0). Bumping to 2.16.0 rather than 2.15.0 since git says tag 'v2.15.0' already exists.

**Screenshots/GIFs:**
N/A

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
