### PR TITLE
Update RadioGroup docs

### DIFF
--- a/docs/components/RadioGroupView.jsx
+++ b/docs/components/RadioGroupView.jsx
@@ -68,7 +68,7 @@ export default class RadioGroupView extends React.PureComponent {
           </p>
           <CodeSample>
             {`
-              import {Radio, RadioGroup} from "clever-components";
+              import { RadioGroup } from "clever-components";
               // OR
               import RadioGroup from "clever-components/dist/RadioGroup"; // Avoids importing all of clever-components.
             `}


### PR DESCRIPTION
**Overview:**

The Radio component is intended to be an internal component and is not
exported at the top level. Update the docs to reflect this.

**Screenshots/GIFs:**

<img width="489" alt="Screen Shot 2019-10-15 at 2 09 43 PM" src="https://user-images.githubusercontent.com/1817/66870095-8b4f4f00-ef55-11e9-8a11-6b6ff15ebf43.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
