### PR TITLE
Copyable input: Explicit padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/CopyableInput/CopyableInput.less
+++ b/src/CopyableInput/CopyableInput.less
@@ -27,6 +27,7 @@
     background: none;
     color: @primary_blue;
     font-size: @type_small;
+    padding: @size_4xs @size_xs @size_3xs;
     .border--right--s(@neutral_silver);
     .shade(border-right-color, @neutral_silver, 1);
 


### PR DESCRIPTION
**Jira:**

**Overview:**
Copyable input link padding was inherited from global `button` styles. This PR makes padding explicit setting the values to approximate chrome's default button padding.

**Screenshots/GIFs:**
example of broken usage when global `button` padding is set to 0:
![image](https://user-images.githubusercontent.com/18291415/67230574-5e39eb00-f3f2-11e9-9c91-4a86212cd084.png)

chrome button padding:
![image](https://user-images.githubusercontent.com/18291415/67230678-8de8f300-f3f2-11e9-8db8-59c1548abdf3.png)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
