### PR TITLE
Add onFocus and isLoading props to Select

### DIFF
--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -240,6 +240,13 @@ export default class SelectView extends Component {
               optional: true,
             },
             {
+              name: "isLoading",
+              type: "Boolean",
+              description: "Whether to force displaying the loading spinner. Shouldn't be used and has no effect when 'lazy' is enabled since it handles loading on its own.",
+              defaultValue: "False",
+              optional: true,
+            },
+            {
               name: "filterOptions",
               type: "Function",
               description:
@@ -259,6 +266,12 @@ export default class SelectView extends Component {
               type: "Boolean",
               description: "Whether multiple options may be selected",
               defaultValue: "False",
+              optional: true,
+            },
+            {
+              name: "onFocus",
+              type: "() => void",
+              description: "Called when the component is focused",
               optional: true,
             },
             {

--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -242,7 +242,8 @@ export default class SelectView extends Component {
             {
               name: "isLoading",
               type: "Boolean",
-              description: "Whether to force displaying the loading spinner. Shouldn't be used and has no effect when 'lazy' is enabled since it handles loading on its own.",
+              description:
+                "Whether to force displaying the loading spinner. Shouldn't be used and has no effect when 'lazy' is enabled since it handles loading on its own.",
               defaultValue: "False",
               optional: true,
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.17.1",
+  "version": "2.18.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -21,6 +21,8 @@ export interface Props {
   disabled?: boolean;
   label?: string;
   multi?: boolean;
+  onFocus?: () => void;
+  isLoading?: boolean;
   onChange?: Function;
   optionRenderer?: Function;
   options?: SelectValueType[];
@@ -131,6 +133,8 @@ export class Select extends React.Component<Props, State> {
       disabled,
       label,
       multi,
+      onFocus,
+      isLoading,
       onChange,
       optionRenderer,
       options,
@@ -158,10 +162,13 @@ export class Select extends React.Component<Props, State> {
       }
     } else {
       if (options) {
-        console.warn('Select: prop "options" may not be set if not "lazy"');
+        console.warn('Select: prop "options" may not be set if "lazy"');
       }
       if (!loadOptions) {
-        console.warn('Select: prop "loadOptions" must be set if not "lazy"');
+        console.warn('Select: prop "loadOptions" must be set if "lazy"');
+      }
+      if (isLoading) {
+        console.warn('Select: prop "isLoading" may not be set if "lazy"');
       }
     }
 
@@ -217,9 +224,11 @@ export class Select extends React.Component<Props, State> {
             name={name}
             onBlur={() => this.setState({ hasBeenFocused: true })}
             onChange={onChange}
+            onFocus={onFocus}
             optionRenderer={optionRenderer}
             options={options}
             loadOptions={loadOptions}
+            isLoading={isLoading}
             filterOptions={filterOptions}
             placeholder={placeholder}
             searchable={searchable}

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -58,6 +58,8 @@ const propTypes = {
   disabled: PropTypes.bool,
   label: PropTypes.string,
   multi: PropTypes.bool,
+  onFocus: PropTypes.func,
+  isLoading: PropTypes.bool,
   onChange: PropTypes.func,
   optionRenderer: PropTypes.func,
   options: PropTypes.arrayOf(selectValuePropType),


### PR DESCRIPTION
**Overview:** This PR adds onFocus and isLoading props to the Select component, which will be used for the same school teacher modal which needs to manually control the loading state and make a data fetch when focused on. For context, we essentially want to simulate the `lazy` behavior, but trigger the fetch on click instead of on mount. Since this isn't supported by React Select, we'll need to handle this manually.

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [X] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [X] Updated docs
  - [X] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
