### PR TITLE
[FileInput] fix default prop name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FileInput/FileInput.tsx
+++ b/src/FileInput/FileInput.tsx
@@ -115,7 +115,7 @@ const propTypes = {
 const defaultProps = {
   iconOnly: false,
   className: "",
-  formElementSize: FormElementSize.FULL_WIDTH,
+  size: FormElementSize.FULL_WIDTH,
 };
 
 export class FileInput extends React.Component<Props, State> {


### PR DESCRIPTION
**Overview:**
`FileInput` accepts a `size` prop like the other input components. There's small mistake in the component's `defaultProps` that lists `formElementSize` as a prop instead of `size`. 

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
