### PR TITLE
Export ToastNotificationData

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ToastStack/ToastStack.tsx
+++ b/src/ToastStack/ToastStack.tsx
@@ -10,19 +10,21 @@ import { ToastNotificationType, ToastType } from "./ToastType";
 
 import "./ToastStack.less";
 
+export interface ToastNotificationData {
+  action?: ActionProps;
+  content: React.ReactNode;
+  durationMS?: number;
+  id: number;
+  showCloseButton?: boolean;
+  type: ToastNotificationType;
+}
+
 export interface Props {
   className?: string;
   clearNotification: (id: number) => void;
   defaultNotificationDurationMS?: number;
   notificationClassName?: string;
-  notifications?: {
-    action?: ActionProps;
-    content: React.ReactNode;
-    durationMS?: number;
-    id: number;
-    showCloseButton?: boolean;
-    type: ToastNotificationType;
-  }[];
+  notifications?: ToastNotificationData[];
 }
 
 const propTypes = {

--- a/src/ToastStack/index.ts
+++ b/src/ToastStack/index.ts
@@ -1,5 +1,5 @@
-import { ToastStack } from "./ToastStack";
+import { ToastStack, ToastNotificationData } from "./ToastStack";
 import { ToastType } from "./ToastType";
 
-export { ToastStack, ToastType };
+export { ToastStack, ToastType, ToastNotificationData };
 export default ToastStack;


### PR DESCRIPTION
**Jira:** N/A

**Overview:** Launchpad currently doesn't use any types for `pushNotification` which makes it a bit annoying and unsafe to use. This just exports the type of a notification so that Launchpad can use this type.

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [X] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
