### PR TITLE
add sticky mixin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.20.1",
+  "version": "2.20.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/less/position.less
+++ b/src/less/position.less
@@ -1,0 +1,6 @@
+// IE supports neither of these two rules. Only use when stickiness is non-critical
+// or IE is not supported
+.position--sticky {
+  position: -webkit-sticky;
+  position: sticky;
+}

--- a/src/less/utilities.less
+++ b/src/less/utilities.less
@@ -12,6 +12,7 @@
 @import "./forms";
 @import "./grid";
 @import "./layout";
+@import "./position";
 @import "./resets";
 @import "./sizing";
 @import "./spacing";


### PR DESCRIPTION
**Jira:**
N/A

**Overview:**
There are many [instances](https://github.com/search?q=org%3AClever+position%3A+sticky&unscoped_q=position%3A+sticky&type=Code) where we apply both `position: -webkit-sticky;` and `position: sticky;` to achieve stickiness across our supported browsers, but it's easy to forget one. This PR simply puts both styles in a single mixin that we can call by convention

**Screenshots/GIFs:**

**Testing:**
- [x] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
