### PR TITLE
add customLogo to TopBar component

### DIFF
--- a/docs/components/TopBarView.jsx
+++ b/docs/components/TopBarView.jsx
@@ -189,6 +189,12 @@ export default class TopBarView extends React.PureComponent {
               optional: false,
             },
             {
+              name: "customLogo",
+              type: <code>React.Node</code>,
+              description: "Alternate node to show instead of the Clever logo.",
+              optional: true,
+            },
+            {
               name: "title",
               type: <code>React.Node</code>,
               description: "Title text to show after the Clever logo, if applicable.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.20.2",
+  "version": "2.21.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TopBar/index.tsx
+++ b/src/TopBar/index.tsx
@@ -13,6 +13,7 @@ export interface Props {
   className?: string;
   logoHref: string;
   title?: React.ReactNode;
+  customLogo?: React.ReactNode;
   onLogoClick?: Function;
 }
 
@@ -23,7 +24,7 @@ export class TopBar extends React.PureComponent<Props> {
   static Button = TopBarButton;
 
   render() {
-    const { children, className, title } = this.props;
+    const { children, className, title, customLogo } = this.props;
 
     // If the last element is a "rounded" TopBarButton we need to add some additional padding to the right side.
     // To determine this we need to inspect the children;
@@ -51,7 +52,9 @@ export class TopBar extends React.PureComponent<Props> {
           onClick={this.props.onLogoClick}
           className="dewey-TopBar--logoLink"
         >
-          <Logo className="dewey--TopBar--logo" svgClassName="dewey--TopBar--logo--mobile" />
+          {customLogo || (
+            <Logo className="dewey--TopBar--logo" svgClassName="dewey--TopBar--logo--mobile" />
+          )}
         </TopBarButton>
         {title && (
           <h1 className="dewey--TopBar--title" title={title as any}>


### PR DESCRIPTION
**Jira:** [DISC-1083](https://clever.atlassian.net/browse/DISC-1083)

**Overview:**

Adding a `customLogo` prop to the `TopBar` component, which will allow us to use the Clever Library logo svg instead of the default Clever logo.  Custom logo must handle its own styling, notably for mobile (does not use existing classes).


**Screenshots/GIFs:**

<img width="678" alt="dewey as top bar logo" src="https://user-images.githubusercontent.com/3254910/69742625-f1e99000-10f1-11ea-9302-82d682b3b496.png">


**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10  ⚠️ broken - https://clever.github.io/components/#/intro is a white screen with `Set is not defined` error on master. Should I go through and remove all uses of `Set`?

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
