### PR TITLE
Dewey front page: fixing links

### DIFF
--- a/docs/components/ComponentBox.jsx
+++ b/docs/components/ComponentBox.jsx
@@ -19,7 +19,7 @@ export default class ComponentBox extends React.Component {
       <FlexBox column className={cssClass.COMPONENTBOX_CONTAINER}>
         <div>
           <h3 className={cssClass.COMPONENTBOX_TITLE}>
-            <a href={`/#/components/${componentLink}`}>{componentName}</a>
+            <a href={`#/components/${componentLink}`}>{componentName}</a>
           </h3>
           <img
             className={cssClass.COMPONENTBOX_IMG}


### PR DESCRIPTION
**Overview:**
Links were broken, switching from absolute path to relative path.

**Roll Out:**
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
