### PR TITLE
Modal FocusTrap - Preventing focus trap error from bubbling 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -74,7 +74,10 @@ export class Modal extends React.Component<Props, State> {
   }
 
   componentDidCatch(error) {
-    if (error && error.message.includes("You can't have a focus-trap without at least one focusable element")) {
+    if (
+      error &&
+      error.message.includes("You can't have a focus-trap without at least one focusable element")
+    ) {
       return;
     }
     throw error;

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -73,6 +73,14 @@ export class Modal extends React.Component<Props, State> {
     this.setState({ windowHeight: window.innerHeight });
   }
 
+  fallbackFocus() {
+    const el = document.activeElement;
+    if (el instanceof HTMLElement) {
+      return el;
+    }
+    return document.body;
+  }
+
   render() {
     // Width should be responsive with window size
     const width = Math.min(window.innerWidth, this.props.width);
@@ -83,6 +91,7 @@ export class Modal extends React.Component<Props, State> {
     };
     // The content is max 90% of the window height less 60px (height of the header)
     const contentStyle = { maxHeight: this.state.windowHeight * 0.9 - 60 };
+    const focusTrapOptions = { fallbackFocus: this.fallbackFocus };
     const modalContent = (
       <div className={classnames("Modal", this.props.className)}>
         <div className="Modal--background" onClick={this.props.closeModal} aria-hidden="true" />
@@ -107,7 +116,7 @@ export class Modal extends React.Component<Props, State> {
     );
     let modal;
     if (this.props.focusLocked) {
-      modal = <FocusTrap>{modalContent}</FocusTrap>;
+      modal = <FocusTrap focusTrapOptions={focusTrapOptions}>{modalContent}</FocusTrap>;
     } else {
       modal = modalContent;
     }

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -73,12 +73,11 @@ export class Modal extends React.Component<Props, State> {
     this.setState({ windowHeight: window.innerHeight });
   }
 
-  fallbackFocus() {
-    const el = document.activeElement;
-    if (el instanceof HTMLElement) {
-      return el;
+  componentDidCatch(error) {
+    if (error && error.message.includes("You can't have a focus-trap without at least one focusable element")) {
+      return;
     }
-    return document.body;
+    throw error;
   }
 
   render() {
@@ -91,7 +90,6 @@ export class Modal extends React.Component<Props, State> {
     };
     // The content is max 90% of the window height less 60px (height of the header)
     const contentStyle = { maxHeight: this.state.windowHeight * 0.9 - 60 };
-    const focusTrapOptions = { fallbackFocus: this.fallbackFocus };
     const modalContent = (
       <div className={classnames("Modal", this.props.className)}>
         <div className="Modal--background" onClick={this.props.closeModal} aria-hidden="true" />
@@ -116,7 +114,7 @@ export class Modal extends React.Component<Props, State> {
     );
     let modal;
     if (this.props.focusLocked) {
-      modal = <FocusTrap focusTrapOptions={focusTrapOptions}>{modalContent}</FocusTrap>;
+      modal = <FocusTrap>{modalContent}</FocusTrap>;
     } else {
       modal = modalContent;
     }


### PR DESCRIPTION
**Jira:**
[FLARE-846](https://clever.atlassian.net/browse/FLARE-846)
**Overview:**
`FocusTrap` throws an error when it can not find an element in their component tree to focus on. This can happen in a Modal when `display` is set to `none`, which caused FLARE-846. There is an open issue in the `focus-trap-react` library `https://github.com/davidtheclark/focus-trap-react/issues/20` however, the library also provides an option where a fallback focus element can be set https://github.com/davidtheclark/focus-trap#focustrap--createfocustrapelement-createoptions ~~which I've used here to fallback on the current focused element, or `document.body`~~

Update: I've used `componentDidCatch` to swallow this specific error

Hiding the modal on small screen sizes was removed here: https://github.com/Clever/launchpad/commit/ed98bb1dbf572ad6f6e7c035ecc569dbdaac86fb
and the bug was mitigated by turning off the feature flag. 

**Screenshots/GIFs:**
Uncaught error thrown by FocusTrap, causes blank screen in portal
![Screen Recording 2019-12-10 at 12 27 PM](https://user-images.githubusercontent.com/6362897/70568672-32fb8e80-1b4d-11ea-98e5-532f922c3fb1.gif)


With a fallback focus element:
![Screen Recording 2019-12-10 at 12 26 PM](https://user-images.githubusercontent.com/6362897/70568688-3bec6000-1b4d-11ea-8f12-0b384f4fdb6e.gif)


**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)

