### PR TITLE
Text input focus handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -16,9 +16,9 @@ export interface Props {
   maxLength?: number;
   minLength?: number;
   name: string;
-  onBlur?: () => void;
+  onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
   onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
-  onFocus?: () => void;
+  onFocus?: React.FocusEventHandler<HTMLTextAreaElement>;
   optional?: boolean;
   placeholder?: string;
   readOnly?: boolean;
@@ -85,8 +85,6 @@ export class TextArea extends React.Component<Props, State> {
     super(TextArea.validateProps(props));
 
     this.state = { inFocus: false, hasBeenFocused: false };
-    this.onFocus = this.onFocus.bind(this);
-    this.onBlur = this.onBlur.bind(this);
   }
 
   // eslint-disable-next-line react/sort-comp
@@ -95,23 +93,23 @@ export class TextArea extends React.Component<Props, State> {
   /* Insert any additional lifecycle methods,
      event handlers, and helper methods here */
 
-  onFocus() {
+  onFocus: React.FocusEventHandler<HTMLTextAreaElement> = e => {
     const { onFocus } = this.props;
 
     this.setState({ inFocus: true });
     if (onFocus) {
-      onFocus();
+      onFocus(e);
     }
-  }
+  };
 
-  onBlur() {
+  onBlur: React.FocusEventHandler<HTMLTextAreaElement> = e => {
     const { onBlur } = this.props;
 
     this.setState({ inFocus: false, hasBeenFocused: true });
     if (onBlur) {
-      onBlur();
+      onBlur(e);
     }
-  }
+  };
 
   focus() {
     this.textAreaEl.current.focus();

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -19,8 +19,8 @@ export interface Props {
   name: string;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
   onKeyPress?: React.KeyboardEventHandler<HTMLInputElement>;
-  onFocus?: () => void;
-  onBlur?: () => void;
+  onFocus?: React.FocusEventHandler<HTMLInputElement>;
+  onBlur?: React.FocusEventHandler<HTMLInputElement>;
   optional?: boolean;
   placeholder?: string;
   placeholderCaps?: boolean;
@@ -87,39 +87,36 @@ export class TextInput extends React.Component<Props, State> {
   constructor(props: Props) {
     super(TextInput.validateProps(props));
     this.state = { inFocus: false, hasBeenFocused: false, hidden: true };
-    this.onFocus = this.onFocus.bind(this);
-    this.onBlur = this.onBlur.bind(this);
-    this.toggleHidden = this.toggleHidden.bind(this);
   }
 
   // eslint-disable-next-line react/sort-comp
   private input = React.createRef<HTMLInputElement>();
 
-  onFocus() {
+  onFocus: React.FocusEventHandler<HTMLInputElement> = e => {
     const { onFocus } = this.props;
 
     this.setState({ inFocus: true });
     if (onFocus) {
-      onFocus();
+      onFocus(e);
     }
-  }
+  };
 
-  onBlur() {
+  onBlur: React.FocusEventHandler<HTMLInputElement> = e => {
     const { onBlur } = this.props;
 
     this.setState({ inFocus: false, hasBeenFocused: true });
     if (onBlur) {
-      onBlur();
+      onBlur(e);
     }
-  }
+  };
 
   focus() {
     this.input.current.focus();
   }
 
-  toggleHidden() {
+  toggleHidden = () => {
     this.setState({ hidden: !this.state.hidden });
-  }
+  };
 
   currentErrorMessage(): string {
     const { error, value, required } = this.props;


### PR DESCRIPTION
**Overview:**
This change makes the focus event available as the argument in `TextInput` and `TextArea`'s `onBlur` and `onFocus` props.

Now we can do this:
```TSX
<TextInput
    onBlur={e => console.log(e.target.value)}
/>
```

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
