### PR TITLE
IL-2104 - CopyableInput: accessibility & positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/CopyableInput/CopyableInput.less
+++ b/src/CopyableInput/CopyableInput.less
@@ -9,6 +9,7 @@
   .flexbox();
   background: @neutral_white;
   width: 100%;
+  position: relative;
 
   .TextInput {
     border: none;
@@ -17,10 +18,13 @@
 }
 
 .CopyableInput--links {
-  margin: auto @size_s;
+  margin: auto @size_xs;
   white-space: nowrap;
   background: white;
   .flexShrink(0);
+  position: absolute;
+  right: 0;
+  top: 40%;
 
   .CopyableInput--link {
     border: 0;

--- a/src/CopyableInput/CopyableInput.tsx
+++ b/src/CopyableInput/CopyableInput.tsx
@@ -93,13 +93,18 @@ export class CopyableInput extends React.Component<Props, State> {
         />
         <div className="CopyableInput--links">
           {this.props.enableShow && (
-            <button type="button" className="CopyableInput--link" onClick={this.toggleHidden}>
+            <button
+              type="button"
+              className="CopyableInput--link"
+              onClick={this.toggleHidden}
+              aria-live="polite"
+            >
               {this.state.hidden ? "Show" : "Hide"}
             </button>
           )}
           {this.props.enableCopy && (
             <CopyToClipboard text={this.props.value || ""} onCopy={this.copyPassword}>
-              <button type="button" className="CopyableInput--link">
+              <button type="button" className="CopyableInput--link" aria-live="polite">
                 {this.state.copied ? "Copied!" : "Copy"}
               </button>
             </CopyToClipboard>


### PR DESCRIPTION
**Jira:**

[IL-2104](https://clever.atlassian.net/browse/IL-2104)

**Overview:**

CopyableInput: Add `aria-live polite` tags for accessibility, and fix awkward positioning of _REQUIRED_ text vis-a-vis _Show|Copy_ toggles so that it parallels how TextInput handles it.

**Screenshots/GIFs:**

TextInput, for reference:
<img width="332" alt="Screen Shot 2020-01-10 at 12 16 06 PM" src="https://user-images.githubusercontent.com/57963785/72287656-48f0e900-35fc-11ea-865f-777a23517fc2.png">

OLD CopyableInput:
<img width="339" alt="Screen Shot 2020-01-10 at 12 16 13 PM" src="https://user-images.githubusercontent.com/57963785/72287657-48f0e900-35fc-11ea-97af-1634c343555d.png">

NEW CopyableInput:
<img width="345" alt="Screen Shot 2020-01-13 at 11 35 22 AM" src="https://user-images.githubusercontent.com/57963785/72287673-4f7f6080-35fc-11ea-8acd-54bc8b38ce73.png">

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
