### PR TITLE
allow the select menu to stay open after selecting an item

### DIFF
--- a/docs/components/SelectView.jsx
+++ b/docs/components/SelectView.jsx
@@ -16,6 +16,7 @@ export default class SelectView extends Component {
       clearable: false,
       disabled: false,
       multi: false,
+      closeMenuOnSelect: true,
       readOnly: false,
       searchable: false,
       creatable: false,
@@ -55,6 +56,7 @@ export default class SelectView extends Component {
                 lazy={this.state.lazy}
                 creatablePromptFn={label => `Add new option: ${label}`}
                 multi={this.state.multi}
+                closeMenuOnSelect={this.state.closeMenuOnSelect}
                 readOnly={this.state.readOnly}
                 required={this.state.required}
                 error={this.state.error}
@@ -141,6 +143,14 @@ export default class SelectView extends Component {
               }}
             />{" "}
             Multi
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={this.state.closeMenuOnSelect}
+              onChange={({ target }) => this.setState({ closeMenuOnSelect: target.checked })}
+            />{" "}
+            closeMenuOnSelect
           </label>
           <label className={cssClass.CONFIG}>
             <input
@@ -267,6 +277,13 @@ export default class SelectView extends Component {
               type: "Boolean",
               description: "Whether multiple options may be selected",
               defaultValue: "False",
+              optional: true,
+            },
+            {
+              name: "closeMenuOnSelect",
+              type: "Boolean",
+              description: "Close the select menu when the user selects an option",
+              defaultValue: "True",
               optional: true,
             },
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-fontawesome": "^1.6.1",
     "react-linkify": "^0.2.1",
     "react-overlays": "^0.8.3",
-    "react-select": "^1.2.1",
+    "react-select": "~1.2.1",
     "react-sticky": "^6.0.1",
     "react-transition-group": "~1.2.0",
     "short-number": "^1.0.6",

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -40,6 +40,7 @@ export interface Props {
   className?: string;
   error?: string;
   size?: Size;
+  closeMenuOnSelect?: boolean;
 }
 
 interface State {
@@ -82,6 +83,7 @@ const propTypes = {
   className: PropTypes.string,
   error: PropTypes.string,
   size: PropTypes.oneOf(Object.values(FormElementSize)),
+  closeMenuOnSelect: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -89,6 +91,7 @@ const defaultProps = {
   placeholder: "",
   searchable: false,
   creatable: false,
+  closeMenuOnSelect: true,
   size: FormElementSize.FULL_WIDTH,
 };
 
@@ -154,6 +157,7 @@ export class Select extends React.Component<Props, State> {
       className,
       error,
       size,
+      closeMenuOnSelect,
     } = this.props;
     if (!lazy) {
       if (!options) {
@@ -235,6 +239,7 @@ export class Select extends React.Component<Props, State> {
             placeholder={placeholder}
             searchable={searchable}
             noResultsText={noResultsText}
+            closeOnSelect={closeMenuOnSelect}
             value={value}
             {...overrideProps}
           />


### PR DESCRIPTION
**Overview:**
This change introduces an optional prop for the `Select` component called `dontCloseMenuOnSelect` which will prevent the menu from closing each time an item is selected. This behavior is especially helpful when used in combination with `multi` as it's much quicker to select multiple values if the menu stays open.

`Select` uses react-select v1 under the hood which has a prop called `closeOnSelect` (`closeOnMenuSelect in v2/3) which is defaults to true. Instead of `dontCloseMenuOnSelect`, we could mirror react-select and use a prop which defaults to true and call it something like `closeOnMenuSelect`. I'd be interested in hearing any opinions on that.

`closeOnSelect` doesn't seem to work in react-select v1.3, so I locked it to the version in the package.json
https://github.com/JedWatson/react-select/issues/3443

**Screenshots/GIFs:**
### before
![](https://cl.ly/c846db066ec4/Screen%20Recording%202020-02-07%20at%2002.11%20AM.gif)

### after
![](https://cl.ly/d76f5ea05af6/Screen%20Recording%202020-02-07%20at%2002.12%20AM.gif)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
