### PR TITLE
fix type errors

### DIFF
--- a/src/LeftNav/LeftNav.tsx
+++ b/src/LeftNav/LeftNav.tsx
@@ -13,7 +13,7 @@ import { ChildrenOf } from "../utils/types";
 import "./LeftNav.less";
 
 export interface Props {
-  children?: ChildrenOf<typeof NavLink | typeof NavGroup>;
+  children?: LeftNavChildren;
   className?: string;
   closeSubNavOnBlur?: boolean;
   collapseOnSubNavOpen?: boolean;
@@ -26,6 +26,8 @@ export interface Props {
 interface State {
   openNavGroup: string;
 }
+
+type LeftNavChildren = ChildrenOf<typeof NavLink | typeof NavGroup>;
 
 const propTypes = {
   children: MorePropTypes.oneOrManyOf(
@@ -79,8 +81,8 @@ export class LeftNav extends React.PureComponent<Props, State> {
     this.state = { openNavGroup: selectedNavGroup ? selectedNavGroup.props.id : null };
   }
 
-  _getNonEmptyChildren(children) {
-    return _.compact(React.Children.toArray(children));
+  _getNonEmptyChildren(children: LeftNavChildren) {
+    return _.compact(React.Children.toArray(children)) as React.ReactElement[];
   }
 
   render() {
@@ -128,7 +130,7 @@ export class LeftNav extends React.PureComponent<Props, State> {
     });
 
     // Find the open NavGroup so that we can render its children NavLinks in the drawer
-    const openChild = _.find(this._getNonEmptyChildren(navItems), item => item.props._open);
+    const openChild: any = _.find(this._getNonEmptyChildren(navItems), item => item.props._open);
 
     return (
       <RootCloseWrapper onRootClose={() => this._onRootClose()}>

--- a/src/LeftNav/NavGroup.tsx
+++ b/src/LeftNav/NavGroup.tsx
@@ -66,7 +66,7 @@ export class NavGroup extends React.PureComponent<Props> {
     } = this.props;
 
     const childSelected = !!_.find(
-      React.Children.toArray(children as React.ReactElement<NavLinkProps>),
+      React.Children.toArray(children) as React.ReactElement<NavLinkProps>[],
       item => item.props.selected,
     );
 

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -4,15 +4,14 @@ import * as PropTypes from "prop-types";
 import * as React from "react";
 import * as RootCloseWrapper from "react-overlays/lib/RootCloseWrapper";
 
-import MenuItem, { cssClass as menuItemCss } from "./MenuItem";
+import MenuItem, { cssClass as menuItemCss, Props as MenuItemProps } from "./MenuItem";
 import MorePropTypes from "../utils/MorePropTypes";
-import { Values } from "../utils/types";
+import { ChildrenOf, Values } from "../utils/types";
 
 import "./Menu.less";
 
 export interface Props {
-  // TODO: fiigure out how to type this.
-  children?: any;
+  children?: ChildrenOf<typeof MenuItem>;
   className?: string;
   maxHeight?: string | number;
   maxWidth?: string | number;
@@ -316,7 +315,9 @@ export default class Menu extends React.PureComponent<Props> {
   };
 
   _getMenuItems() {
-    return React.Children.toArray(this.props.children).filter(i => !!i);
+    return (React.Children.toArray(this.props.children) as React.ReactElement<
+      MenuItemProps
+    >[]).filter(i => !!i);
   }
 
   _isFocused(menuItem, itemIndex) {

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -5,7 +5,7 @@ import * as PropTypes from "prop-types";
 
 import * as tablePropTypes from "./tablePropTypes";
 import Cell from "./Cell";
-import Column from "./Column";
+import { Column, Props as ColumnProps } from "./Column";
 import Footer from "./Footer";
 import Header from "./Header";
 import MorePropTypes from "../utils/MorePropTypes";
@@ -260,7 +260,7 @@ export class Table extends React.Component<Props, State> {
 
   _getColumn(columnID) {
     return _.find(
-      React.Children.toArray(this.props.children as React.ReactElement),
+      React.Children.toArray(this.props.children) as React.ReactElement<ColumnProps>[],
       column => column.props.id === columnID,
     );
   }

--- a/src/TopBar/index.tsx
+++ b/src/TopBar/index.tsx
@@ -29,7 +29,7 @@ export class TopBar extends React.PureComponent<Props> {
     // If the last element is a "rounded" TopBarButton we need to add some additional padding to the right side.
     // To determine this we need to inspect the children;
     let needsRightPadding = false;
-    const childrenArray = React.Children.toArray(children as any);
+    const childrenArray = React.Children.toArray(children) as React.ReactElement[];
     if (childrenArray.length) {
       const lastItem = childrenArray[childrenArray.length - 1];
       const lastTrigger = lastItem.type === Menu ? lastItem.props.trigger : lastItem;


### PR DESCRIPTION
**Overview:**
This fixes some new compiler errors so the next unsuspecting person who develops in this repo (me) can get it to build. I'm not sure if they're caused by stricter react types, or a smarter TypeScript compiler. It's notoriously hard to type react children. I tried to fix most of the errors without resorting to `any`.

This change only adds type annotations, so doesn't affect the outputted JavaScript.

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
