### PR TITLE
[Select] Override react-select border radius

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select/Select.less
+++ b/src/Select/Select.less
@@ -150,5 +150,9 @@
         background-color: @neutral_off_white;
       }
     }
+
+    .Select-option:last-child {
+      border-radius: unset;
+    }
   }
 }


### PR DESCRIPTION
**Overview:**
This one has always bugged me. The dewey `Select` already has some style overrides to match the style of our other input elements. This change adds another override to the border radius style which is applied to the last menu item.

**Screenshots/GIFs:**
### before
![](https://cl.ly/2354a1f0b476/Image%202020-02-07%20at%2011.39.19%20AM.png)

### after
![](https://cl.ly/c42c846d2a51/Image%202020-02-07%20at%2012.03.02%20PM.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
