### PR TITLE
Hide docs bundle diffs by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+docs/bundle.js linguist-generated=true
+


### PR DESCRIPTION
**Overview:**
This change marks the docs bundle as a generated file so github will hide diffs from the file by default. 

Here's some relevant documentation.
https://help.github.com/en/github/administering-a-repository/customizing-how-changed-files-appear-on-github
**Screenshots/GIFs:**
### before
![](https://cl.ly/d07b059ca42f/Image%202020-02-07%20at%201.27.49%20PM.png)
### after
![](https://cl.ly/41a65d32894d/Image%202020-02-07%20at%201.24.49%20PM.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
