### PR TITLE
Fix rightButtonDisabled in MultiPanelModal docs

### DIFF
--- a/docs/components/MultiplePanelModalsView.jsx
+++ b/docs/components/MultiplePanelModalsView.jsx
@@ -204,6 +204,14 @@ export default class MultiplePanelModalsView extends React.PureComponent {
               optional: true,
             },
             {
+              name: "rightButtonDisabled",
+              type: "Boolean",
+              description:
+                "Whether the right button is disabled. The parent component should manage any state required to derive this value.",
+              optional: true,
+              defaultValue: false,
+            },
+            {
               name: "height",
               type: "String",
               description:
@@ -285,14 +293,6 @@ export default class MultiplePanelModalsView extends React.PureComponent {
                 "If this is provided, it will be the only function called upon clicking the right button " +
                 "for this panel.",
               optional: true,
-            },
-            {
-              name: "rightButtonDisabled",
-              type: "Boolean",
-              description:
-                "Whether the right button is disabled. The parent component should manage any state required to derive this value.",
-              optional: true,
-              defaultValue: false,
             },
           ]}
         />


### PR DESCRIPTION
**Jira:**
N/A

**Overview:**
For the `MultiplePanelModals` component, the prop `rightButtonDisabled` was being listed as a prop of the components in the `componentArray`, when really it's a top level `MultiplePanelModals` prop. This change fixes that error in the docs.

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [ ] ~Bumped version in `package.json`~
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
