### PR TITLE
Add showStepNumber prop

### DIFF
--- a/docs/components/MultiplePanelModalsView.jsx
+++ b/docs/components/MultiplePanelModalsView.jsx
@@ -34,10 +34,11 @@ export default class MultiplePanelModalsView extends React.PureComponent {
     height: "150px",
     startingPanel: "0",
     isModalOpen: false,
+    showStepNumber: false,
   };
 
   render() {
-    const { rightButtonDisabled, height, startingPanel } = this.state;
+    const { rightButtonDisabled, height, startingPanel, showStepNumber } = this.state;
 
     return (
       <View
@@ -84,12 +85,14 @@ export default class MultiplePanelModalsView extends React.PureComponent {
                     panel: panel1,
                     title: "Page1",
                     panelClassName: "FirstClass",
+                    width: 500,
                     overrideOnClickLeftButton: () => this.setState({ isModalOpen: false }),
                   },
                   {
                     panel: panel2,
                     title: "Page2",
                     panelClassName: "secondClass",
+                    width: 500,
                     leftButtonName: "override the name back",
                     rightButtonType: "destructive",
                     overrideOnClickRightButton: () =>
@@ -98,6 +101,7 @@ export default class MultiplePanelModalsView extends React.PureComponent {
                   {
                     panel: panel3,
                     title: "Page3",
+                    width: 500,
                   },
                 ]}
                 defaultOnClickLeftButton={() => console.log("GoingBackwards")}
@@ -105,6 +109,7 @@ export default class MultiplePanelModalsView extends React.PureComponent {
                 rightButtonDisabled={rightButtonDisabled}
                 height={height}
                 startingPanel={parseInt(startingPanel, 10)}
+                showStepNumber={showStepNumber}
               />
             )}
           </ExampleCode>
@@ -117,7 +122,7 @@ export default class MultiplePanelModalsView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { rightButtonDisabled, height, startingPanel } = this.state;
+    const { rightButtonDisabled, height, startingPanel, showStepNumber } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -154,6 +159,15 @@ export default class MultiplePanelModalsView extends React.PureComponent {
             onSelect={value => this.setState({ rightButtonDisabled: value })}
             options={[{ content: "True", value: true }, { content: "False", value: false }]}
             value={rightButtonDisabled}
+          />
+        </div>
+        <div className={cssClass.CONFIG}>
+          Show step number:
+          <SegmentedControl
+            className={cssClass.CONFIG_OPTIONS}
+            onSelect={value => this.setState({ showStepNumber: value })}
+            options={[{ content: "True", value: true }, { content: "False", value: false }]}
+            value={showStepNumber}
           />
         </div>
       </FlexBox>

--- a/docs/components/MultiplePanelModalsView.less
+++ b/docs/components/MultiplePanelModalsView.less
@@ -42,3 +42,7 @@ label.MultiplePanelModalsView--config {
 .MultiplePanelModalsView--props {
   .margin--top--l;
 }
+
+.MultiplePanelModals--stepNumber {
+  .margin--right--m();
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.26.1",
+  "version": "2.27.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MultiplePanelModals/MultiplePanelModals.tsx
+++ b/src/MultiplePanelModals/MultiplePanelModals.tsx
@@ -14,6 +14,7 @@ export interface Props {
   height?: string | number;
   rightButtonDisabled?: boolean;
   startingPanel?: number;
+  showStepNumber?: boolean;
 }
 
 interface State {
@@ -29,6 +30,7 @@ const propTypes = {
   height: PropTypes.string,
   rightButtonDisabled: PropTypes.bool,
   startingPanel: PropTypes.number,
+  showStepNumber: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -36,12 +38,14 @@ const defaultProps = {
   rightButtonDisabled: false,
   defaultOnClickLeftButton: () => {},
   defaultOnClickRightButton: () => {},
+  showStepNumber: false,
 };
 
 export const Classes = {
   CONTAINER: "MultiplePanelModals",
   FIRST_BUTTON: "MultiplePanelModals--later",
   SECOND_BUTTON: "MultiplePanelModals--next",
+  STEP_NUMBER: "MultiplePanelModals--stepNumber",
 };
 
 export class MultiplePanelModals extends React.Component<Props, State> {
@@ -62,9 +66,11 @@ export class MultiplePanelModals extends React.Component<Props, State> {
       defaultOnClickRightButton,
       height,
       rightButtonDisabled,
+      showStepNumber,
     } = this.props;
-    const isFirstPanel = this.state.currentPanel === 0;
-    const isLastPanel = this.state.currentPanel + 1 === componentArray.length;
+    const { currentPanel } = this.state;
+    const isFirstPanel = currentPanel === 0;
+    const isLastPanel = currentPanel + 1 === componentArray.length;
 
     if (this.state.currentPanel >= componentArray.length) {
       return <div />;
@@ -112,6 +118,8 @@ export class MultiplePanelModals extends React.Component<Props, State> {
       rightButtonOnClick = overrideOnClickRightButton;
     }
 
+    const totalPanels = componentArray.length;
+
     return (
       <div className={classnames(Classes.CONTAINER, className)}>
         <Modal
@@ -123,6 +131,7 @@ export class MultiplePanelModals extends React.Component<Props, State> {
         >
           <div style={{ height }}>{panel}</div>
           <footer>
+            {showStepNumber && <span className={Classes.STEP_NUMBER}>{`Step ${currentPanel + 1} of ${totalPanels}`}</span>}
             <Button
               value={leftButtonValue}
               className={Classes.FIRST_BUTTON}

--- a/src/MultiplePanelModals/MultiplePanelModals.tsx
+++ b/src/MultiplePanelModals/MultiplePanelModals.tsx
@@ -131,7 +131,10 @@ export class MultiplePanelModals extends React.Component<Props, State> {
         >
           <div style={{ height }}>{panel}</div>
           <footer>
-            {showStepNumber && <span className={Classes.STEP_NUMBER}>{`Step ${currentPanel + 1} of ${totalPanels}`}</span>}
+            {showStepNumber && (
+              <span className={Classes.STEP_NUMBER}>{`Step ${currentPanel +
+                1} of ${totalPanels}`}</span>
+            )}
             <Button
               value={leftButtonValue}
               className={Classes.FIRST_BUTTON}


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/SSOAP-2198

**Overview:**
We want to expose a way to show steps in the `MultiplePanelModals` component. There is now a boolean prop to turn on a "Step X of N" field in the footer of the modal.

**Screenshots/GIFs:**
<img width="529" alt="Screen Shot 2020-02-13 at 5 46 34 PM" src="https://user-images.githubusercontent.com/12655228/74494080-ce301d80-4e88-11ea-86aa-a49482905e17.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
