### PR TITLE
Moved stepNumber styling to be tied to MultiplePanelModals

### DIFF
--- a/docs/components/MultiplePanelModalsView.less
+++ b/docs/components/MultiplePanelModalsView.less
@@ -42,7 +42,3 @@ label.MultiplePanelModalsView--config {
 .MultiplePanelModalsView--props {
   .margin--top--l;
 }
-
-.MultiplePanelModals--stepNumber {
-  .margin--right--m();
-}

--- a/src/MultiplePanelModals/MultiplePanelModals.less
+++ b/src/MultiplePanelModals/MultiplePanelModals.less
@@ -1,0 +1,5 @@
+@import (reference) "~src/less/utilities";
+
+.MultiplePanelModals--stepNumber {
+  .margin--right--m();
+}

--- a/src/MultiplePanelModals/MultiplePanelModals.tsx
+++ b/src/MultiplePanelModals/MultiplePanelModals.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import * as PropTypes from "prop-types";
-import * as classnames from "classnames";
 
 import { Button } from "../Button/Button";
 import { Modal, Props as ModalProps } from "../Modal/Modal";
+import "./MultiplePanelModals.less";
 
 export interface Props {
   className?: string;
@@ -42,9 +42,6 @@ const defaultProps = {
 };
 
 export const Classes = {
-  CONTAINER: "MultiplePanelModals",
-  FIRST_BUTTON: "MultiplePanelModals--later",
-  SECOND_BUTTON: "MultiplePanelModals--next",
   STEP_NUMBER: "MultiplePanelModals--stepNumber",
 };
 
@@ -121,7 +118,7 @@ export class MultiplePanelModals extends React.Component<Props, State> {
     const totalPanels = componentArray.length;
 
     return (
-      <div className={classnames(Classes.CONTAINER, className)}>
+      <div className={className}>
         <Modal
           className={panelClassName}
           focusLocked={focusLocked}
@@ -137,7 +134,6 @@ export class MultiplePanelModals extends React.Component<Props, State> {
             )}
             <Button
               value={leftButtonValue}
-              className={Classes.FIRST_BUTTON}
               type={leftButtonType || "link"}
               onClick={() => {
                 if (!isFirstPanel) {
@@ -148,7 +144,6 @@ export class MultiplePanelModals extends React.Component<Props, State> {
             />
             <Button
               value={rightButtonValue}
-              className={Classes.SECOND_BUTTON}
               type={rightButtonType || "primary"}
               onClick={() => {
                 rightButtonOnClick();

--- a/test/MultiplePanelModals_test.tsx
+++ b/test/MultiplePanelModals_test.tsx
@@ -16,7 +16,6 @@ describe("MultiplePanelModals", () => {
       />,
     );
 
-    expect(myComponent.props().className).toMatch("MultiplePanelModals");
     expect(myComponent).toIncludeText("<Modal />");
     expect(myComponent.props().children.props.title).toMatch("page1");
   });
@@ -51,7 +50,6 @@ describe("MultiplePanelModals", () => {
         className="my--custom--class"
       />,
     );
-    expect(myComponent.props().className).toMatch("MultiplePanelModals");
     expect(myComponent.props().className).toMatch("my--custom--class");
   });
 


### PR DESCRIPTION
**Jira:**
[SSOAP-2211](https://clever.atlassian.net/browse/SSOAP-2211)

**Overview:**
The styling used to be in the `docs` folder, so other services using MultiplePanelModals wouldn't have the privilege of nice styling for stepNumber. It has now been moved to the `src` folder. 

In addition, some styles were removed because they did not do anything 😁 

**Screenshots/GIFs:**
![Screen Shot 2020-02-14 at 2 57 41 PM](https://user-images.githubusercontent.com/12452249/74575061-6e924a80-4f3a-11ea-9c54-ae02b2b7a86f.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
