### PR TITLE
[wizardlayout] support any button type

### DIFF
--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -293,6 +293,13 @@ export default class WizardLayoutView extends React.PureComponent {
             optional: true,
           },
           {
+            name: "nextStepButtonType",
+            type: "String",
+            description: "One of primary, secondary, destructive, link, linkPlain, plain",
+            defaultValue: "primary",
+            optional: true,
+          },
+          {
             name: "onNextStep",
             type: "Function",
             description: "Called when user clicks on 'Next step' button.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.30.1",
+  "version": "2.31.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -19,6 +19,7 @@ export interface Props {
   hideSaveAndExit?: boolean;
   nextStepButtonDisabled?: boolean;
   nextStepButtonText?: string;
+  nextStepButtonType?: "primary" | "secondary" | "destructive" | "link" | "linkPlain" | "plain";
   onNextStep: () => void;
   onPrevStep: () => void;
   onSaveAndExit?: () => void;
@@ -44,6 +45,7 @@ const propTypes = {
   hidePreviousStepButton: PropTypes.bool,
   nextStepButtonDisabled: PropTypes.bool,
   nextStepButtonText: PropTypes.string,
+  nextStepButtonType: PropTypes.string,
   prevStepButtonDisabled: PropTypes.bool,
   prevStepButtonText: PropTypes.string,
   hideSaveAndExit: PropTypes.bool,
@@ -95,6 +97,7 @@ export default class WizardLayout extends React.PureComponent<Props> {
       helpContent,
       nextStepButtonDisabled,
       nextStepButtonText,
+      nextStepButtonType,
       hidePreviousStepButton,
       hideSaveAndExit,
       onSaveAndExit,
@@ -165,7 +168,7 @@ export default class WizardLayout extends React.PureComponent<Props> {
             />
           )}
           <Button
-            type="primary"
+            type={nextStepButtonType || "primary"}
             value={nextStepButtonText || "Next step"}
             className={cssClass.NEXT_BUTTON}
             onClick={this._onNextStep}


### PR DESCRIPTION
**Overview:**
This change lets us use any button type for the `WizardLayout`'s next button. I saw a couple of cases in some of our design mocks where the `secondary` button type is used. I'm not sure if we'd ever actually use the other button types, but they'll be there if we want them.

**Screenshots/GIFs:**
Here's an example of a design mock that uses a `secondary` button type for the next button.
![](https://cl.ly/87aa026f9cfa/Image%202020-02-20%20at%202.30.36%20PM.png)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
