### PR TITLE
Make RadioGroup and Radio generic components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/RadioGroup/Radio.tsx
+++ b/src/RadioGroup/Radio.tsx
@@ -1,31 +1,19 @@
 import * as classnames from "classnames";
-import * as PropTypes from "prop-types";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
 import "./Radio.less";
 
-export interface Props {
+export interface Props<IDType extends string = string, ValueType = any> {
   checked?: boolean;
   children: React.ReactNode;
   className?: string;
   disabled?: boolean;
-  id: string;
-  onSelect?: (id: string, value: any) => void;
+  id: IDType;
+  onSelect?: (id: IDType, value: ValueType) => void;
   tabIndex?: number;
-  value?: any;
+  value?: ValueType;
 }
-
-const propTypes = {
-  checked: PropTypes.bool,
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string,
-  disabled: PropTypes.bool,
-  id: PropTypes.string.isRequired,
-  onSelect: PropTypes.func,
-  tabIndex: PropTypes.number,
-  value: PropTypes.any,
-};
 
 const cssClass = {
   CHECKED: "Radio--checked",
@@ -44,9 +32,10 @@ const getNextLabelID = () => `${LABEL_ID_PREFIX}--${nextLabelIDSuffix++}`;
  * Single radio button input.
  * Usually used in a RadioGroup for providing a list of mutually-exclusive options to the user.
  */
-export default class Radio extends React.PureComponent<Props> {
-  static propTypes = propTypes;
-
+export default class Radio<
+  IDType extends string = string,
+  ValueType = any
+> extends React.PureComponent<Props<IDType, ValueType>> {
   _element = null;
   _labelID = getNextLabelID();
 

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -1,6 +1,5 @@
 import * as _ from "lodash";
 import * as classnames from "classnames";
-import * as PropTypes from "prop-types";
 import * as React from "react";
 
 import FormError from "../FormError";
@@ -9,39 +8,22 @@ import WithKeyboardNav from "../WithKeyboardNav";
 
 import "./RadioGroup.less";
 
-interface Option {
-  id: string;
+interface Option<IDType extends string = string, ValueType = any> {
+  id: IDType;
   disabled?: boolean;
   label: React.ReactNode;
-  value?: any;
+  value?: ValueType;
 }
 
-export interface Props {
+export interface Props<OptionIDType extends string, OptionValueType> {
   className?: string;
   disabled?: boolean;
   error?: React.ReactNode;
   label?: React.ReactNode;
-  onChange: RadioProps["onSelect"];
-  options: Option[];
-  selectedID?: string;
+  onChange: RadioProps<OptionIDType, OptionValueType>["onSelect"];
+  options: Option<OptionIDType, OptionValueType>[];
+  selectedID?: OptionIDType;
 }
-
-const OPTION_PROP_TYPE = PropTypes.shape({
-  id: PropTypes.string.isRequired,
-  disabled: PropTypes.bool,
-  label: PropTypes.node.isRequired,
-  value: PropTypes.any,
-});
-
-const propTypes = {
-  className: PropTypes.string,
-  disabled: PropTypes.bool,
-  error: PropTypes.node,
-  label: PropTypes.node,
-  onChange: PropTypes.func.isRequired,
-  options: PropTypes.arrayOf(OPTION_PROP_TYPE).isRequired,
-  selectedID: PropTypes.string,
-};
 
 const cssClass = {
   CONTAINER: "RadioGroup",
@@ -56,9 +38,10 @@ const getNextLabelID = () => `${LABEL_ID_PREFIX}--${nextLabelIDSuffix++}`;
 /**
  * Form element that allows for a single, required selection from a small set of 2 or more options.
  */
-export default class RadioGroup extends React.PureComponent<Props> {
-  static propTypes = propTypes;
-
+export default class RadioGroup<
+  OptionIDType extends string = string,
+  OptionValueType = any
+> extends React.PureComponent<Props<OptionIDType, OptionValueType>> {
   _labelID = getNextLabelID();
   _optionRefsByID = {};
 
@@ -82,8 +65,8 @@ export default class RadioGroup extends React.PureComponent<Props> {
             {label}
           </div>
           {error && <FormError>{error}</FormError>}
-          {_.map(options, (o: any) => (
-            <Radio
+          {_.map(options, o => (
+            <Radio<OptionIDType, OptionValueType>
               checked={o.id === selectedID}
               className={cssClass.RADIO}
               disabled={!!disabled || !!o.disabled}


### PR DESCRIPTION
**Overview:** RadioGroup and Radio components currently always type IDs as strings and values as `any`. However, often we want to constrain the IDs to a specific set of strings or type values as a specific type. This PR makes RadioGroup and Radio generic so that we can optionally specify the types to constrain IDs and values to! 

This is important because before we were giving up type safety in both cases. As a specific example of ID types being important, take the commit form in SD2 where the user selects a radio button for the reason they're not using the Portal. In state, `noReason` is typed using a union of specific strings. However, the RadioGroup only promises that the options IDs are strings. This means that in the `onChange` callback we have to tell the compiler we know it's actually a more specific type of string, as seen here https://github.com/Clever/sd2/blob/bd6ef983d87485e4a33c2e0a4cf6a300546deeaa/ui/components/PortalCommitBanner/PortalCommitModals/PortalCommitNoModal.tsx#L69. This is problematic because we're getting less verification from the compiler! We could accidentally add an option that has an ID not of the correct type and we'd be none the wiser. Now, if RadioGroup is typed appropriately it will know the type of `id` without requiring a type assertion and would give a compile time error if an option with an invalid id was added.

I made the generics default to string and any for backwards compatibility. I expected that to get these type checking benefits the user would specifically have to add generics, but in doing testing I found that TypeScript's type inference seems to be good enough to figure out the generics on its own (at least for IDs)!

We should eventually add generics for other components as well (Select comes to mind).

**Screenshots/GIFs:**
None, it's just types

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [X] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
