### PR TITLE
Add "plain" theme to TopBar

### DIFF
--- a/docs/components/TopBarView.jsx
+++ b/docs/components/TopBarView.jsx
@@ -7,7 +7,7 @@ import FontAwesome from "react-fontawesome";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import { FlexBox, FlexItem, ItemAlign, TextInput, Menu } from "src";
+import { FlexBox, FlexItem, ItemAlign, TextInput, Menu, Select } from "src";
 import { TopBar } from "src/TopBar";
 
 import "./TopBarView.less";
@@ -18,6 +18,7 @@ const cssClass = {
   CONFIG: "TopBarView--config",
   CONFIG_TOGGLE: "TopBarView--configToggle",
   CONTAINER: "TopBarView",
+  DROPDOWN_THEME: "TopBarView--dropdown--theme",
   INPUT_TITLE: "TopBarView--input--title",
   INTRO: "TopBarView--intro",
   PROPS: "TopBarView--props",
@@ -40,12 +41,13 @@ export default class TopBarView extends React.PureComponent {
 
   state = {
     addArbitraryContent: true,
+    theme: null,
     title: "Welcome back to Clever",
   };
 
   render() {
     const { location } = this.props;
-    const { addArbitraryContent, title } = this.state;
+    const { addArbitraryContent, theme, title } = this.state;
 
     const page = location.query.page || "portal";
 
@@ -67,7 +69,12 @@ export default class TopBarView extends React.PureComponent {
         <Example title="Basic Usage:">
           <div className={cssClass.WINDOW}>
             <ExampleCode>
-              <TopBar className={cssClass.TOP_BAR} logoHref="//clever.com" title={title}>
+              <TopBar
+                className={cssClass.TOP_BAR}
+                logoHref="//clever.com"
+                theme={theme}
+                title={title}
+              >
                 <TopBar.Button
                   active={page === "dashboard"}
                   component={Link}
@@ -137,10 +144,27 @@ export default class TopBarView extends React.PureComponent {
   _logUserMenuButtonClick = () => console.log("user menu button clicked");
 
   _renderConfig() {
-    const { addArbitraryContent, title } = this.state;
+    const { addArbitraryContent, theme, title } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
+        <div className={cssClass.CONFIG}>
+          <Select
+            className={classnames(cssClass.CONFIG_OPTIONS, cssClass.DROPDOWN_THEME)}
+            clearable
+            id={cssClass.DROPDOWN_THEME}
+            label="Theme"
+            name={cssClass.DROPDOWN_THEME}
+            onChange={o => this.setState({ theme: o && o.value })}
+            options={Object.keys(TopBar.Theme)
+              .sort()
+              .map(key => ({
+                label: key,
+                value: TopBar.Theme[key],
+              }))}
+            value={theme}
+          />
+        </div>
         <div className={cssClass.CONFIG}>
           <TextInput
             className={classnames(cssClass.CONFIG_OPTIONS, cssClass.INPUT_TITLE)}
@@ -193,6 +217,13 @@ export default class TopBarView extends React.PureComponent {
               type: <code>React.Node</code>,
               description: "Alternate node to show instead of the Clever logo.",
               optional: true,
+            },
+            {
+              name: "theme",
+              type: <code>TopBar.Theme</code>,
+              description: "Optional style theme to apply to the TopBar.",
+              optional: true,
+              defaultValue: "TopBar.Theme.DEFAULT",
             },
             {
               name: "title",

--- a/docs/components/TopBarView.jsx
+++ b/docs/components/TopBarView.jsx
@@ -8,7 +8,7 @@ import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import { FlexBox, FlexItem, ItemAlign, TextInput, Menu, Select } from "src";
-import { TopBar } from "src/TopBar";
+import { TopBar, TopBarThemes } from "src/TopBar";
 
 import "./TopBarView.less";
 
@@ -156,12 +156,10 @@ export default class TopBarView extends React.PureComponent {
             label="Theme"
             name={cssClass.DROPDOWN_THEME}
             onChange={o => this.setState({ theme: o && o.value })}
-            options={Object.keys(TopBar.Theme)
-              .sort()
-              .map(key => ({
-                label: key,
-                value: TopBar.Theme[key],
-              }))}
+            options={TopBarThemes.sort().map(value => ({
+              label: value,
+              value,
+            }))}
             value={theme}
           />
         </div>
@@ -220,10 +218,10 @@ export default class TopBarView extends React.PureComponent {
             },
             {
               name: "theme",
-              type: <code>TopBar.Theme</code>,
+              type: <code>"{TopBarThemes.sort().join('" | "')}"</code>,
               description: "Optional style theme to apply to the TopBar.",
               optional: true,
-              defaultValue: "TopBar.Theme.DEFAULT",
+              defaultValue: '"default"',
             },
             {
               name: "title",

--- a/docs/components/TopBarView.jsx
+++ b/docs/components/TopBarView.jsx
@@ -41,7 +41,7 @@ export default class TopBarView extends React.PureComponent {
 
   state = {
     addArbitraryContent: true,
-    theme: null,
+    theme: undefined,
     title: "Welcome back to Clever",
   };
 

--- a/docs/components/TopBarView.less
+++ b/docs/components/TopBarView.less
@@ -52,8 +52,8 @@ label.TopBarView--config {
   max-width: 70rem;
 }
 
-.TopBarView--dropdown--color {
-  width: 7rem;
+.TopBarView--dropdown--theme {
+  width: 9rem;
 }
 
 .TopBarView--input--title {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.33.0",
+  "version": "2.34.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TopBar/index.less
+++ b/src/TopBar/index.less
@@ -42,3 +42,35 @@
   color: @neutral_white;
   font-style: italic;
 }
+
+// PLAIN theme:
+.dewey--TopBar.dewey--TopBar--theme--plain {
+  background: none;
+  box-shadow: none;
+
+  .dewey--TopBar--logoSubtext {
+    color: @primary_blue;
+  }
+
+  .dewey--TopBar--title {
+    color: @primary_blue;
+  }
+
+  .TopBarButton {
+    color: @primary_blue;
+
+    // Copied from "link" Button type:
+    &:hover,
+    &:focus,
+    &:active {
+      color: @primary_blue_shade_2;
+      background-color: fade(@primary_blue, 5%);
+    }
+  }
+
+  .dewey--TopBar--logo {
+    .dewey--Logo--text {
+      fill: @primary_blue;
+    }
+  }
+}

--- a/src/TopBar/index.tsx
+++ b/src/TopBar/index.tsx
@@ -23,7 +23,6 @@ export interface Props {
   theme?: TopBarTheme;
 }
 
-
 /**
  * Global page-level header component.
  */

--- a/src/TopBar/index.tsx
+++ b/src/TopBar/index.tsx
@@ -28,7 +28,7 @@ export enum TopBarTheme {
  */
 export class TopBar extends React.PureComponent<Props> {
   static defaultProps: Partial<Props> = {
-    theme: TopBarTheme.PLAIN,
+    theme: TopBarTheme.DEFAULT,
   };
 
   static Button = TopBarButton;

--- a/src/TopBar/index.tsx
+++ b/src/TopBar/index.tsx
@@ -15,16 +15,28 @@ export interface Props {
   title?: React.ReactNode;
   customLogo?: React.ReactNode;
   onLogoClick?: Function;
+  theme?: TopBarTheme;
+}
+
+export enum TopBarTheme {
+  DEFAULT = "default",
+  PLAIN = "plain",
 }
 
 /**
  * Global page-level header component.
  */
 export class TopBar extends React.PureComponent<Props> {
+  static defaultProps: Partial<Props> = {
+    theme: TopBarTheme.PLAIN,
+  };
+
   static Button = TopBarButton;
 
+  static Theme = TopBarTheme;
+
   render() {
-    const { children, className, title, customLogo } = this.props;
+    const { children, className, title, customLogo, theme } = this.props;
 
     // If the last element is a "rounded" TopBarButton we need to add some additional padding to the right side.
     // To determine this we need to inspect the children;
@@ -45,6 +57,7 @@ export class TopBar extends React.PureComponent<Props> {
           "dewey--TopBar",
           className,
           needsRightPadding && "dewey--TopBar--rightPadding",
+          `dewey--TopBar--theme--${theme}`,
         )}
       >
         <TopBarButton

--- a/src/TopBar/index.tsx
+++ b/src/TopBar/index.tsx
@@ -8,6 +8,11 @@ import { TopBarButton } from "./TopBarButton";
 import "./index.less";
 import Menu from "../Menu";
 
+// Defined as an array first as a convenience to make automatic enumeration of all themes easier in
+// the demo code.
+export const TopBarThemes = ["default", "plain"] as const;
+type TopBarTheme = typeof TopBarThemes[number];
+
 export interface Props {
   children?: React.ReactNode;
   className?: string;
@@ -18,22 +23,16 @@ export interface Props {
   theme?: TopBarTheme;
 }
 
-export enum TopBarTheme {
-  DEFAULT = "default",
-  PLAIN = "plain",
-}
 
 /**
  * Global page-level header component.
  */
 export class TopBar extends React.PureComponent<Props> {
-  static defaultProps: Partial<Props> = {
-    theme: TopBarTheme.DEFAULT,
+  static defaultProps: Pick<Props, "theme"> = {
+    theme: "default",
   };
 
   static Button = TopBarButton;
-
-  static Theme = TopBarTheme;
 
   render() {
     const { children, className, title, customLogo, theme } = this.props;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "commonjs",
     "noUnusedLocals": true,
     "noImplicitAny": false,
+    "preserveConstEnums": true,
     "target": "es5",
     "types": ["jest"]
   },


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FAMBAM-67

**Overview:**
Re-adding very basic support for theming to TopBar.

"Plain" theme is more minimalist - just a bar with no background, no drop shadow (will add drop shadow in-app on the content pane when scrolling).

Pending first usage in the new Family Portal!

**Screenshots/GIFs:**
[![Screenshot from Gyazo](https://gyazo.com/f291dd4f7803623c04f6a5f71584d7c1/raw)](https://gyazo.com/f291dd4f7803623c04f6a5f71584d7c1)

**Mocks:**
https://www.figma.com/file/2dAb0x3W1ffZx0lJc8Ncw3/Family-Portal-MVP?node-id=755%3A1584

**Testing:**
- [n/a] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [n/a] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [n/a] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
