### PR TITLE
make URL optional in ResourceTile

### DIFF
--- a/docs/components/ResourceTileView.jsx
+++ b/docs/components/ResourceTileView.jsx
@@ -224,6 +224,7 @@ export default class ResourceTileView extends React.PureComponent {
             name: "url",
             type: "string",
             description: "URL to navigate to on click",
+            optional: true,
           },
         ]}
         className={cssClass.PROPS}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.34.0",
+  "version": "2.34.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ResourceTile/ResourceTile.tsx
+++ b/src/ResourceTile/ResourceTile.tsx
@@ -61,7 +61,7 @@ export interface Props {
   overlays?: React.ReactNode[];
   size: IconSize;
   title: string;
-  url: string;
+  url?: string;
 }
 
 interface State {


### PR DESCRIPTION
**Jira:** n/a

**Overview:** url should be optional because of onClick behavior

**Roll Out:**
- Before merging:
  - [X] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
