### PR TITLE
Quick <ResourceTile> fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.34.1",
+  "version": "2.34.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ResourceTile/ResourceTile.less
+++ b/src/ResourceTile/ResourceTile.less
@@ -12,10 +12,10 @@
 @fontSizeLarge: 1rem;
 
 .dewey--ResourceTile {
-  .borderRadius--xl;
-  .margin--right--xs;
-  .margin--bottom--xs;
-  background-color: @neutral_white;
+  .borderRadius--xl();
+  .margin--right--xs();
+  .margin--bottom--xs();
+  .zIndex--0();
   position: relative;
 }
 
@@ -145,7 +145,7 @@ button.dewey--ResourceTile--actionButton {
 // Only apply the following styles if the device supports true hover
 .mq-hover {
   .dewey--ResourceTile {
-    .boxShadowHoverAnimation(@borderRadiusXL);
+    .boxShadowHoverAnimation(@borderRadiusXL, @zIndex0);
   }
 }
 


### PR DESCRIPTION
This PR makes two quick `<ResourceTile>` fixes!

-----

First, we used to explicitly set the background color to white. I've updated that to transparent. The transparent works better in situations like this:

_Before_

<img width="500" alt="before" src="https://user-images.githubusercontent.com/12616928/77213603-a1df7080-6ac8-11ea-8bc7-7114a16a57e2.png">

_After_

<img width="500" alt="after" src="https://user-images.githubusercontent.com/12616928/77213560-78bee000-6ac8-11ea-97b5-b220ddb2398f.png">

Of course, if you need an explicit white background, say because your page has a background of another color, you can always apply your own class name. I just figured transparent is a better default.

-----

Second, we're now explicitly setting the `z-index` of the `ResourceTile` to `0`. This is necessary for the hover styles to work correctly, which place a secret shadow element at `z-index` `-1`:

https://github.com/Clever/components/blob/f7e3980efbf5b72c26864d6c6d4e4446588b09b1/src/less/animations.less#L123-L125

To be clear, the secret shadow element actually lives at `@targetElementZIndex - 1`, where `@targetElementZIndex` [defaults to 0](https://github.com/Clever/components/blob/f7e3980efbf5b72c26864d6c6d4e4446588b09b1/src/less/animations.less#L107).

We were recently working in a UI where the `z-index` of the `ResourceTile`, though not explicitly set, was high enough such that the secret shadow element at `z-index` `-1` wasn't visible.