### PR TITLE
Fancy progress bar

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,4 +1,4 @@
-extends: "airbnb"
+extends: ["airbnb", "prettier", "prettier/react"]
 env:
   mocha: true
   jest: true

--- a/docs/components/ProgressBarView.jsx
+++ b/docs/components/ProgressBarView.jsx
@@ -50,10 +50,11 @@ export default class ProgressBarView extends React.PureComponent {
     label: "",
     striped: false,
     inactive: false,
+    markNumbers: "25,50,75",
   };
 
   render() {
-    const { color, fill, size, width, striped, inactive, showLabel, label, labelType } = this.state;
+    const { color, fill, size, width, striped, inactive, showLabel, label, labelType, markNumbers } = this.state;
 
     return (
       <View
@@ -85,6 +86,8 @@ export default class ProgressBarView extends React.PureComponent {
               showLabel={showLabel}
               labelType={labelType}
               label={label}
+              markNumbers={markNumbers.split(",").map(Number)}
+              // markNumbers stored as string on this page for testing config so needs conversion
             />
           </ExampleCode>
           {this._renderConfig()}
@@ -170,6 +173,13 @@ export default class ProgressBarView extends React.PureComponent {
               defaultValue: "",
               optional: true,
             },
+            {
+              name: "markNumbers",
+              type: "Array<number>",
+              description: "Places a mark at each number in the progress bar. Numbers should be in increasing order and between 0 and 100",
+              defaultValue: "[]",
+              optional: true,
+            },
           ]}
           className={cssClass.PROPS}
           title="ProgressBar"
@@ -179,7 +189,7 @@ export default class ProgressBarView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { color, fill, size, width, striped, inactive, showLabel, label, labelType } = this.state;
+    const { color, fill, size, width, striped, inactive, showLabel, label, labelType, markNumbers } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -285,6 +295,15 @@ export default class ProgressBarView extends React.PureComponent {
           />{" "}
           Inactive
         </label>
+        <div className={cssClass.CONFIG}>
+          <TextInput
+            className={cssClass.CONFIG_OPTIONS}
+            label="markNumbers"
+            name="markNumbers"
+            value={markNumbers}
+            onChange={e => this.setState({ markNumbers: e.target.value })}
+          />
+        </div>
       </FlexBox>
     );
   }

--- a/docs/components/ProgressBarView.jsx
+++ b/docs/components/ProgressBarView.jsx
@@ -54,7 +54,18 @@ export default class ProgressBarView extends React.PureComponent {
   };
 
   render() {
-    const { color, fill, size, width, striped, inactive, showLabel, label, labelType, markNumbers } = this.state;
+    const {
+      color,
+      fill,
+      size,
+      width,
+      striped,
+      inactive,
+      showLabel,
+      label,
+      labelType,
+      markNumbers,
+    } = this.state;
 
     return (
       <View
@@ -176,7 +187,8 @@ export default class ProgressBarView extends React.PureComponent {
             {
               name: "markNumbers",
               type: "Array<number>",
-              description: "Places a mark at each number in the progress bar. Numbers should be in increasing order and between 0 and 100",
+              description:
+                "Places a mark at each number in the progress bar. Numbers should be in increasing order and between 0 and 100",
               defaultValue: "[]",
               optional: true,
             },
@@ -189,7 +201,18 @@ export default class ProgressBarView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { color, fill, size, width, striped, inactive, showLabel, label, labelType, markNumbers } = this.state;
+    const {
+      color,
+      fill,
+      size,
+      width,
+      striped,
+      inactive,
+      showLabel,
+      label,
+      labelType,
+      markNumbers,
+    } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "enzyme-adapter-react-16": "^1.7.1",
     "eslint": "5.x",
     "eslint-config-airbnb": "^6.2.0",
+    "eslint-config-prettier": "^6.11.0",
     "eslint-import-resolver-webpack": "^0.7.0",
     "eslint-plugin-react": "^4.2.3",
     "extract-text-webpack-plugin": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.34.2",
+  "version": "2.35.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ProgressBar/Progress.tsx
+++ b/src/ProgressBar/Progress.tsx
@@ -38,12 +38,15 @@ export default class Progress extends React.PureComponent<Props> {
     let colorBorderStyle = cssClass.border(color, size);
 
     if (color === "changing") {
-      if (fill < 30) {
+      if (fill < 25) {
         colorStyle = cssClass.color("red");
         colorBorderStyle = cssClass.border("red", size);
-      } else if (fill < 90) {
+      } else if (fill < 50) {
         colorStyle = cssClass.color("orange");
-        colorBorderStyle = cssClass.border("orange", size);
+        colorBorderStyle = cssClass.border("red", size);
+      } else if (fill < 75) {
+        colorStyle = cssClass.color("blue");
+        colorBorderStyle = cssClass.border("blue", size);
       } else {
         colorStyle = cssClass.color("green");
         colorBorderStyle = cssClass.border("green", size);

--- a/src/ProgressBar/ProgressBar.less
+++ b/src/ProgressBar/ProgressBar.less
@@ -72,3 +72,17 @@
 .ProgressBar--label--bottom-right {
   .alignSelf(flex-end);
 }
+
+.ProgressBar--bar--mark {
+  position: absolute;
+  width: @size_4xs;
+  background-color: @neutral_gray;
+  height: 100%;
+  .border--bottom--m(@neutral_gray);
+}
+
+.ProgressBar--bar--mark--thick {
+  width: @size_3xs;
+  background-color: @neutral_black;
+  .border--bottom--m(@neutral_black);
+}

--- a/src/ProgressBar/ProgressBar.tsx
+++ b/src/ProgressBar/ProgressBar.tsx
@@ -22,7 +22,7 @@ export interface Props {
   showLabel?: string;
   style?: React.CSSProperties;
   width?: string | number;
-  markNumbers?: Array<number>;
+  markNumbers?: number[];
 }
 
 const Size = {
@@ -100,6 +100,9 @@ export default class ProgressBar extends React.PureComponent<Props> {
     const topLabel = this._maybeTopLabel();
     const bottomLabel = this._maybeBottomLabel();
 
+    const markNumbersInRange = (markNumbers || []).filter(mark => mark < 100 && mark > 0).sort();
+    const firstAfterFill = markNumbersInRange.find(mark => mark > fill);
+
     return (
       <div className={classnames(cssClass.CONTAINER, inactive && cssClass.INACTIVE, className)}>
         <FlexBox
@@ -119,23 +122,18 @@ export default class ProgressBar extends React.PureComponent<Props> {
               }}
             >
               <div className={classnames(cssClass.BAR_BORDER, cssClass.borderSize(size))} />
-              {markNumbers &&
-                markNumbers.map((element, index) =>
-                  element < 100 ? (
-                    <div
-                      className={classnames(
-                        cssClass.BAR_MARK,
-                        fill < element &&
-                          (index === 0 || fill >= markNumbers[index - 1]) &&
-                          cssClass.BAR_THICK_MARK,
-                      )}
-                      style={{
-                        left: `${element}%`,
-                      }}
-                      key={element}
-                    />
-                  ) : null,
-                )}
+              {markNumbersInRange.map(element => (
+                <div
+                  className={classnames(
+                    cssClass.BAR_MARK,
+                    firstAfterFill === element && cssClass.BAR_THICK_MARK,
+                  )}
+                  style={{
+                    left: `${element}%`,
+                  }}
+                  key={element}
+                />
+              ))}
               <Progress
                 fill={fill > 100 ? 100 : fill}
                 color={color}

--- a/src/ProgressBar/ProgressBar.tsx
+++ b/src/ProgressBar/ProgressBar.tsx
@@ -22,6 +22,7 @@ export interface Props {
   showLabel?: string;
   style?: React.CSSProperties;
   width?: string | number;
+  markNumbers?: Array<number>;
 }
 
 const Size = {
@@ -56,6 +57,7 @@ const propTypes = {
   inactive: PropTypes.bool,
   showLabel: PropTypes.string,
   labelType: PropTypes.string,
+  markNumbers: PropTypes.array,
 };
 
 const cssClass = {
@@ -64,6 +66,8 @@ const cssClass = {
   BAR_BORDER: "ProgressBar--bar--border",
   TRACKER: "ProgressBar--bar--tracker",
   INACTIVE: "ProgressBar--bar--inactive",
+  BAR_MARK: "ProgressBar--bar--mark",
+  BAR_THICK_MARK: "ProgressBar--bar--mark--thick",
   boxContainer: s => `ProgressBar--boxContainer--${s}`,
   borderSize: s => `ProgressBar--bar--border--${s}`,
   containerSize: s => `ProgressBar--bar--container--${s}`,
@@ -81,7 +85,7 @@ export default class ProgressBar extends React.PureComponent<Props> {
   };
 
   render() {
-    const { className, style, color, fill, width, size, striped, inactive } = this.props;
+    const { className, style, color, fill, width, size, striped, inactive, markNumbers } = this.props;
     const sizePX = SizePX[size];
     const topLabel = this._maybeTopLabel();
     const bottomLabel = this._maybeBottomLabel();
@@ -105,6 +109,19 @@ export default class ProgressBar extends React.PureComponent<Props> {
               }}
             >
               <div className={classnames(cssClass.BAR_BORDER, cssClass.borderSize(size))} />
+              {markNumbers && markNumbers.map((element, index) => (
+                element < 100 ?
+                  (<div
+                    className={classnames(
+                      cssClass.BAR_MARK,
+                      fill < element && (index === 0 || fill >= markNumbers[index - 1]) && cssClass.BAR_THICK_MARK
+                    )}
+                    style={{
+                      left: `${element}%`,
+                    }}
+                    key={element}
+                  />) : null
+              ))}
               <Progress
                 fill={fill > 100 ? 100 : fill}
                 color={color}

--- a/src/ProgressBar/ProgressBar.tsx
+++ b/src/ProgressBar/ProgressBar.tsx
@@ -85,7 +85,17 @@ export default class ProgressBar extends React.PureComponent<Props> {
   };
 
   render() {
-    const { className, style, color, fill, width, size, striped, inactive, markNumbers } = this.props;
+    const {
+      className,
+      style,
+      color,
+      fill,
+      width,
+      size,
+      striped,
+      inactive,
+      markNumbers,
+    } = this.props;
     const sizePX = SizePX[size];
     const topLabel = this._maybeTopLabel();
     const bottomLabel = this._maybeBottomLabel();
@@ -109,19 +119,23 @@ export default class ProgressBar extends React.PureComponent<Props> {
               }}
             >
               <div className={classnames(cssClass.BAR_BORDER, cssClass.borderSize(size))} />
-              {markNumbers && markNumbers.map((element, index) => (
-                element < 100 ?
-                  (<div
-                    className={classnames(
-                      cssClass.BAR_MARK,
-                      fill < element && (index === 0 || fill >= markNumbers[index - 1]) && cssClass.BAR_THICK_MARK
-                    )}
-                    style={{
-                      left: `${element}%`,
-                    }}
-                    key={element}
-                  />) : null
-              ))}
+              {markNumbers &&
+                markNumbers.map((element, index) =>
+                  element < 100 ? (
+                    <div
+                      className={classnames(
+                        cssClass.BAR_MARK,
+                        fill < element &&
+                          (index === 0 || fill >= markNumbers[index - 1]) &&
+                          cssClass.BAR_THICK_MARK,
+                      )}
+                      style={{
+                        left: `${element}%`,
+                      }}
+                      key={element}
+                    />
+                  ) : null,
+                )}
               <Progress
                 fill={fill > 100 ? 100 : fill}
                 color={color}


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/SSOAP-2412

**Overview:**
First commit updates color="CHANGING" according to design spec. Now <25 is red, <50 is orange, <75 is blue and <100 is green.

Second commit adds ability to add mark to the Progress Bar. Only the next mark is going to be thick others are thin. Location of marks is passed as Array<numbers>. 

Both changes are backwards compatible.

**Screenshots/GIFs:**
1) changing color
![changing](https://user-images.githubusercontent.com/18272584/80752597-98dab980-8ae0-11ea-95a3-b4f3acce0e8d.gif)
2) optional marks
![marks](https://user-images.githubusercontent.com/18272584/80752624-a7c16c00-8ae0-11ea-826d-77abe4b599b8.gif)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
