### PR TITLE
Patch backwards compatibility for gray labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.37.0",
+  "version": "2.37.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Label/Label.tsx
+++ b/src/Label/Label.tsx
@@ -38,6 +38,7 @@ const Color = {
   AQUA: "category-1",
   PURPLE: "category-1",
   PINK: "category-2",
+  GRAY: "default",
 } as const;
 
 // We are reducing the options from S/M/L to only S/L so


### PR DESCRIPTION
Reference https://github.com/Clever/components/pull/486

Missed gray on list of colors needed for backwards compatibility. Quick fix.