### PR TITLE
Change medium label to map to small

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.37.1",
+  "version": "2.37.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Label/Label.tsx
+++ b/src/Label/Label.tsx
@@ -42,10 +42,10 @@ const Color = {
 } as const;
 
 // We are reducing the options from S/M/L to only S/L so
-// here we map M -> l for backwards compatibility.
+// here we map M -> s for backwards compatibility.
 const Size = {
   S: "s",
-  M: "l",
+  M: "s",
   L: "l",
 } as const;
 


### PR DESCRIPTION
**Jira:**
Change of plans - we want medium labels to map to small instead of large.

**Overview:**

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
