### PR TITLE
Add optional prop to specify visible page range size in the table footer

### DIFF
--- a/docs/components/TableView.jsx
+++ b/docs/components/TableView.jsx
@@ -115,6 +115,7 @@ export default class TableView extends PureComponent {
                 onViewChange={data => console.log("Table view changed:", data.map(d => d.id))}
                 paginated
                 pageSize={9}
+                visiblePageRangeSize={5}
                 rowIDFn={r => r.id}
                 rowClassNameFn={r => (r.age < 10 ? "additionalClass" : null)}
               >
@@ -311,6 +312,14 @@ export default class TableView extends PureComponent {
               optional: true,
             },
             {
+              name: "visiblePageRangeSize",
+              type: "1 | 3 | 5 | 7 | 9",
+              description:
+                "Range of page numbers to show in footer, centered on the current page number",
+              defaultValue: "5",
+              optional: true,
+            },
+            {
               name: "rowClassNameFn",
               type: "Function",
               description:
@@ -450,6 +459,7 @@ export default class TableView extends PureComponent {
             onViewChange={data => console.log("Table view changed:", data.map(d => d.id))}
             paginated
             pageSize={9}
+            visiblePageRangeSize={5}
             rowIDFn={r => r.id}
             rowClassNameFn={r => (r.age < 10 ? "additionalClass" : null)}
           >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.37.2",
+  "version": "2.38.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table/Footer.tsx
+++ b/src/Table/Footer.tsx
@@ -62,14 +62,10 @@ export default function Footer({
   }
 
   // As a safeguard for when the typescript PageSizeNumber type is not enforced (jsx files),
-  // check if the visiblePageRangeSize is not a PageSizeNumber (even, < 1, > 11),
-  // and if so, set it to the default value.
+  // check if the visiblePageRangeSize is a valid PageSizeNumber (1, 3, 5, 7, 9),
+  // and if not, set it to the default value.
   let safeVisiblePageRangeSize = visiblePageRangeSize;
-  if (
-    safeVisiblePageRangeSize < 1 ||
-    safeVisiblePageRangeSize > 11 ||
-    safeVisiblePageRangeSize % 2 === 0
-  ) {
+  if (visiblePageRangeSize < 1 || visiblePageRangeSize > 11 || visiblePageRangeSize % 2 === 0) {
     safeVisiblePageRangeSize = DEFAULT_VISIBLE_PAGE_RANGE_SIZE;
   }
 

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -21,6 +21,8 @@ export interface SortState {
   direction?: SortDirection;
 }
 
+export type PageRangeSize = 1 | 3 | 5 | 7 | 9;
+
 // Webpack will inject process.env in so declare it here so we can use it to decide to log or not
 declare var process: {
   env: {
@@ -44,6 +46,7 @@ export interface Props {
   onViewChange?: Function;
   pageSize?: number;
   paginated?: boolean;
+  visiblePageRangeSize?: PageRangeSize;
   rowIDFn: Function;
   rowClassNameFn?: Function;
   noDataContent?: React.ReactNode;
@@ -65,6 +68,7 @@ interface State {
 }
 
 const DEFAULT_PAGE_SIZE = 10;
+export const DEFAULT_VISIBLE_PAGE_RANGE_SIZE = 5;
 
 const propTypes = {
   children: PropTypes.arrayOf(MorePropTypes.instanceOfComponent(Column)),
@@ -82,6 +86,7 @@ const propTypes = {
   onViewChange: PropTypes.func,
   pageSize: PropTypes.number,
   paginated: PropTypes.bool,
+  visiblePageRangeSize: PropTypes.number,
   rowIDFn: PropTypes.func.isRequired,
   rowClassNameFn: PropTypes.func,
   noDataContent: PropTypes.node,
@@ -96,6 +101,7 @@ const defaultProps = {
   onPageChange: () => {},
   onSortChange: () => {},
   pageSize: DEFAULT_PAGE_SIZE,
+  visiblePageRangeSize: DEFAULT_VISIBLE_PAGE_RANGE_SIZE,
   firstSortDirection: sortDirection.ASCENDING,
 };
 
@@ -380,6 +386,7 @@ export class Table extends React.Component<Props, State> {
       onRowClick,
       onRowMouseOver,
       noDataContent,
+      visiblePageRangeSize,
     } = this.props;
     const { lazy, numRows } = this.props;
     const { currentPage, sortState, pageLoading, allLoaded } = this.state;
@@ -445,6 +452,7 @@ export class Table extends React.Component<Props, State> {
             numColumns={columns.length}
             numPages={numPages}
             showLastPage={!lazy}
+            visiblePageRangeSize={visiblePageRangeSize}
             isLoading={pageLoading}
             lengthUnknown={lazy && numRows == null && !allLoaded}
           />

--- a/test/Table/Footer_test.tsx
+++ b/test/Table/Footer_test.tsx
@@ -4,11 +4,20 @@ import * as sinon from "sinon";
 import { shallow } from "enzyme";
 
 import Cell from "../../src/Table/Cell";
-import Footer, { cssClass, VISIBLE_PAGE_RANGE_SIZE } from "../../src/Table/Footer";
+import Footer, { cssClass } from "../../src/Table/Footer";
+import { DEFAULT_VISIBLE_PAGE_RANGE_SIZE } from "../../src/Table/Table";
 
 describe("Footer", () => {
   const newFooter = (props = {}) =>
-    shallow(<Footer currentPage={1} numColumns={3} numPages={3} {...props} />);
+    shallow(
+      <Footer
+        currentPage={1}
+        numColumns={3}
+        numPages={3}
+        visiblePageRangeSize={DEFAULT_VISIBLE_PAGE_RANGE_SIZE}
+        {...props}
+      />,
+    );
 
   it("is empty for numPages < 2", () => {
     assert(
@@ -83,9 +92,9 @@ describe("Footer", () => {
   });
 
   describe("page buttons", () => {
-    it("renders all page numbers for numPages <= `VISIBLE_PAGE_RANGE_SIZE` + 2", () => {
+    it("renders all page numbers for numPages <= `DEFAULT_VISIBLE_PAGE_RANGE_SIZE` + 2", () => {
       const expectedButtons = ["1"];
-      for (let i = 2; i <= VISIBLE_PAGE_RANGE_SIZE + 2; i++) {
+      for (let i = 2; i <= DEFAULT_VISIBLE_PAGE_RANGE_SIZE + 2; i++) {
         const midPage = Math.ceil(i / 2);
 
         const footer = newFooter({ numPages: i, currentPage: midPage });


### PR DESCRIPTION
**Jira:**

Needed for: https://clever.atlassian.net/browse/FAMBAM-245

**Overview:**

Right now, there is no way to specify how many page numbers are visible in the footer. If a table is too small, the footer can wrap to two lines. This allows an optional `visiblePageRangeSize` property to specify how many page numbers should show in the footer, centered on the current page number. The options are limited to 1, 3, 5, 7, and 9; they are odd to ensure that the UX is smooth with an equal number of pages shown on either side of the current page, and capped at 9 because the current pageRangeSize was fixed at only 5 and 9 seemed like a reasonable upper bound. 

**Screenshots/GIFs:**

OLD - 

<img width="1227" alt="broken" src="https://user-images.githubusercontent.com/26425483/83206675-30462300-a106-11ea-9eae-645636488e2f.png">
<img width="1234" alt="fixed" src="https://user-images.githubusercontent.com/26425483/83206681-31775000-a106-11ea-8528-7791c048d44a.png">


**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10
- [x] Locally by placing build in sd2

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
