### PR TITLE
Make the types of some WizardLayout props more flexible

### DIFF
--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -254,7 +254,7 @@ export default class WizardLayoutView extends React.PureComponent {
           },
           {
             name: "exitButtonText",
-            type: "String",
+            type: "React.Node",
             description: "Optional exit button text",
             defaultValue: "Save & exit",
             optional: true,
@@ -287,7 +287,7 @@ export default class WizardLayoutView extends React.PureComponent {
           },
           {
             name: "nextStepButtonText",
-            type: "String",
+            type: "React.Node",
             description: "Optional next button text, 'Next step' by default",
             defaultValue: "Next step",
             optional: true,
@@ -330,7 +330,7 @@ export default class WizardLayoutView extends React.PureComponent {
           },
           {
             name: "prevStepButtonText",
-            type: "String",
+            type: "React.Node",
             description: "Optional previous button text, 'Previous step' by default",
             optional: true,
             defaultValue: "Previous Step",

--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -344,6 +344,7 @@ export default class WizardLayoutView extends React.PureComponent {
             name: "subtitle",
             type: "String",
             description: "Subtitle string to be displayed in the header.",
+            optional: true,
           },
           {
             name: "title",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.38.1",
+  "version": "2.39.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -10,7 +10,7 @@ import "./WizardLayout.less";
 
 export interface Props {
   className?: string;
-  exitButtonText?: string;
+  exitButtonText?: React.ReactNode;
   sections: any[];
   fullscreen?: boolean;
   headerImg?: any;
@@ -18,12 +18,12 @@ export interface Props {
   hidePreviousStepButton?: boolean;
   hideSaveAndExit?: boolean;
   nextStepButtonDisabled?: boolean;
-  nextStepButtonText?: string;
+  nextStepButtonText?: React.ReactNode;
   onNextStep: () => void;
   onPrevStep: () => void;
   onSaveAndExit?: () => void;
   prevStepButtonDisabled?: boolean;
-  prevStepButtonText?: string;
+  prevStepButtonText?: React.ReactNode;
   stepper: React.ReactNode;
   subtitle: string;
   title: string;
@@ -37,15 +37,15 @@ const SECTION_PROP_TYPE = PropTypes.shape({
 
 const propTypes = {
   className: PropTypes.string,
-  exitButtonText: PropTypes.string,
+  exitButtonText: PropTypes.node,
   fullscreen: PropTypes.bool,
   headerImg: PropTypes.element,
   helpContent: PropTypes.node,
   hidePreviousStepButton: PropTypes.bool,
   nextStepButtonDisabled: PropTypes.bool,
-  nextStepButtonText: PropTypes.string,
+  nextStepButtonText: PropTypes.node,
   prevStepButtonDisabled: PropTypes.bool,
-  prevStepButtonText: PropTypes.string,
+  prevStepButtonText: PropTypes.node,
   hideSaveAndExit: PropTypes.bool,
   onNextStep: PropTypes.func.isRequired,
   onPrevStep: PropTypes.func.isRequired,

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -25,7 +25,7 @@ export interface Props {
   prevStepButtonDisabled?: boolean;
   prevStepButtonText?: React.ReactNode;
   stepper: React.ReactNode;
-  subtitle: string;
+  subtitle?: string;
   title: string;
 }
 
@@ -52,7 +52,7 @@ const propTypes = {
   onSaveAndExit: PropTypes.func,
   sections: PropTypes.arrayOf(SECTION_PROP_TYPE).isRequired,
   stepper: PropTypes.node.isRequired,
-  subtitle: PropTypes.string.isRequired,
+  subtitle: PropTypes.string,
   title: PropTypes.string.isRequired,
 };
 
@@ -120,7 +120,7 @@ export default class WizardLayout extends React.PureComponent<Props> {
           {headerImg && <div className={cssClass.HEADER_IMG}>{headerImg}</div>}
           <div>
             <p className={cssClass.HEADER_TITLE}>{title}</p>
-            <p className={cssClass.HEADER_SUBTITLE}>{subtitle}</p>
+            {subtitle && <p className={cssClass.HEADER_SUBTITLE}>{subtitle}</p>}
           </div>
         </FlexBox>
         <FlexBox className={classnames(cssClass.BODY, fullscreen && cssClass.BODY_FULLSCREEN)}>


### PR DESCRIPTION
**Overview:**
This change makes it so that `WizardLayout` accepts `React.ReactNode` for the `prevStepButtonText`, `nextStepButtonText`, and `exitStepButtonText` props instead of `string`. 
There are a few use cases in propduction we do something along the lines of 
```js
nextButtonText={
   <span>
      {isUpdating && <FontAwesome name="spinner" spin />}
      Next
   </span>
}
```
and to get the typescript to compile, we've had to type assert it as `any`. With this change we won't have to worry about the compiler complaining anymore. The names of these prop suggest that they should be strings, so hopefully this change doesn't make it too confusing. In the next major version we could change the names to something like `nextButtonValue`.

There are also some use cases where we don't use `subtitle`. We can get around this by doing `subtitle=""`, but it's better to just mark it as optional.

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
