### PR TITLE
update processing state to spinner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.39.0",
+  "version": "2.40.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AlertBox/AlertBox.tsx
+++ b/src/AlertBox/AlertBox.tsx
@@ -9,7 +9,7 @@ import { FlexBox, FlexItem } from "../flex";
 
 import "./AlertBox.less";
 
-type AlertBoxType = "processing" | "processingSpin" | "warning" | "success" | "error" | "info";
+type AlertBoxType = "processing" | "warning" | "success" | "error" | "info";
 
 export interface Props {
   children: React.ReactNode;

--- a/src/AlertBox/AlertBox.tsx
+++ b/src/AlertBox/AlertBox.tsx
@@ -9,7 +9,7 @@ import { FlexBox, FlexItem } from "../flex";
 
 import "./AlertBox.less";
 
-type AlertBoxType = "processing" | "warning" | "success" | "error" | "info";
+type AlertBoxType = "processing" | "processingSpin" | "warning" | "success" | "error" | "info";
 
 export interface Props {
   children: React.ReactNode;
@@ -38,7 +38,7 @@ const propTypes = {
 };
 
 const iconMap = {
-  processing: "hourglass-half",
+  processing: "spinner",
   warning: "exclamation-triangle",
   success: "thumbs-up",
   error: "exclamation-circle",
@@ -76,6 +76,7 @@ export default class AlertBox extends React.PureComponent<Props> {
               size="lg"
               name={iconMap[type]}
               className={classnames(`AlertBox--Icon--${type}`, cssClass.ICON)}
+              spin={type === "processing"}
             />
           </FlexItem>
           <FlexItem>

--- a/src/ToastStack/ToastNotification.tsx
+++ b/src/ToastStack/ToastNotification.tsx
@@ -57,7 +57,7 @@ function typeCssClass(type: string): string {
 const iconMap = {
   [ToastType.ERROR]: "minus-circle",
   [ToastType.INFO]: "bell",
-  [ToastType.PROCESSING]: "hourglass",
+  [ToastType.PROCESSING]: "spinner",
   [ToastType.SUCCESS]: "thumbs-up",
   [ToastType.WARNING]: "exclamation-triangle",
 };


### PR DESCRIPTION
**Overview:**
We wanted to make the alert box `processing` state consistent with our current toast component but it's come to our attention that the spinning hourglass looks odd, so per design's request, updating both to use a loading spinner as opposed to an hourglass

**Screenshots/GIFs:**
![alert box spinner](https://user-images.githubusercontent.com/29630673/83681027-a5967580-a596-11ea-9ee8-0a8ccb84a35a.gif)
![toast spinner](https://user-images.githubusercontent.com/29630673/83681037-a8916600-a596-11ea-883d-91102256a186.gif)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10 (I changed a string and can confirm that the previously used spinner worked on IE10)

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
