### PR TITLE
Add optional props onKeyDown, onKeyPress, and onKeyUp to TextArea. Th…

### DIFF
--- a/docs/components/TextAreaView.jsx
+++ b/docs/components/TextAreaView.jsx
@@ -182,6 +182,24 @@ export default class TextAreaView extends React.Component {
               optional: true,
             },
             {
+              name: "onKeyDown",
+              type: "function",
+              description: "Function called upon keydown in the element",
+              optional: true,
+            },
+            {
+              name: "onKeyPress",
+              type: "function",
+              description: "Function called upon keypress in the element",
+              optional: true,
+            },
+            {
+              name: "onKeyUp",
+              type: "function",
+              description: "Function called upon keyup in the element",
+              optional: true,
+            },
+            {
               name: "optional",
               type: "function",
               description: "Adds an 'Optional' label on the input. Cannot be used with 'required'.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.41.0",
+  "version": "2.42.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -19,6 +19,9 @@ export interface Props {
   onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
   onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
   onFocus?: React.FocusEventHandler<HTMLTextAreaElement>;
+  onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement>;
+  onKeyPress?: React.KeyboardEventHandler<HTMLTextAreaElement>;
+  onKeyUp?: React.KeyboardEventHandler<HTMLTextAreaElement>;
   optional?: boolean;
   placeholder?: string;
   readOnly?: boolean;
@@ -46,6 +49,9 @@ const propTypes = {
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  onKeyPress: PropTypes.func,
+  onKeyUp: PropTypes.func,
   optional: PropTypes.bool,
   placeholder: PropTypes.node,
   readOnly: PropTypes.bool,
@@ -108,6 +114,30 @@ export class TextArea extends React.Component<Props, State> {
     this.setState({ inFocus: false, hasBeenFocused: true });
     if (onBlur) {
       onBlur(e);
+    }
+  };
+
+  onKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = e => {
+    const { onKeyDown } = this.props;
+
+    if (onKeyDown) {
+      onKeyDown(e);
+    }
+  };
+
+  onKeyPress: React.KeyboardEventHandler<HTMLTextAreaElement> = e => {
+    const { onKeyPress } = this.props;
+
+    if (onKeyPress) {
+      onKeyPress(e);
+    }
+  };
+
+  onKeyUp: React.KeyboardEventHandler<HTMLTextAreaElement> = e => {
+    const { onKeyUp } = this.props;
+
+    if (onKeyUp) {
+      onKeyUp(e);
     }
   };
 
@@ -187,6 +217,9 @@ export class TextArea extends React.Component<Props, State> {
       onBlur: this.onBlur,
       onChange: this.props.onChange,
       onFocus: this.onFocus,
+      onKeyDown: this.onKeyDown,
+      onKeyPress: this.onKeyPress,
+      onKeyUp: this.onKeyUp,
       placeholder: this.props.placeholder,
       readOnly: this.props.readOnly,
       ref: this.textAreaEl,


### PR DESCRIPTION
**Overview:**

Adds three optional props (onKeyDown, onKeyPress, onKeyUp) to TextArea. These will be very handy for Portal Messaging, and likely elsewhere someday.

**Screenshots/GIFs:**

![Kapture 2020-06-11 at 12 28 38](https://user-images.githubusercontent.com/57963785/84441543-da3aaa80-abf0-11ea-90fd-2b7e6c5a0755.gif)

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
