### PR TITLE
A number of quality-of-life improvements

### DIFF
--- a/docs/components/MessagingThreadHistoryView.jsx
+++ b/docs/components/MessagingThreadHistoryView.jsx
@@ -65,8 +65,10 @@ export default class MessagingThreadHistoryView extends React.PureComponent {
         sourcePath="src/MessagingThreadHistory/MessagingThreadHistory.tsx"
       >
         <header className={cssClass.INTRO}>
-          <p>TODO: Describe your component/state it's purpose</p>
-          <p>TODO(optional): Describe scenarios where the component might be useful.</p>
+          <p>
+            MessagingThreadHistory is a container for messages between users, in the form of
+            MessagingBubble or other data.
+          </p>
           <CodeSample>
             {`
               import {MessagingThreadHistory} from "clever-components";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.43.0",
+  "version": "2.44.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingAvatar/MessagingAvatar.tsx
+++ b/src/MessagingAvatar/MessagingAvatar.tsx
@@ -27,10 +27,7 @@ export const MessagingAvatar: React.FC<Props> = ({ className, text, color }: Pro
       // If defined, use color. Otherwise, use seed to determine color.
       // If all else fails, we can use text as the seed to determine color.
       style={{
-        backgroundColor:
-          "color" in color
-            ? color.color
-            : `hsl(${_determineAvatarHue(color.seed || text)}, 80%, 85%)`,
+        backgroundColor: color.color || `#${_determineAvatarColor(color.seed || text)}`,
       }}
     >
       <div className={cssClasses.TEXT}>{text}</div>
@@ -38,17 +35,25 @@ export const MessagingAvatar: React.FC<Props> = ({ className, text, color }: Pro
   );
 };
 
-// Helper function: Uses a string to determine the hue value for an HSL
-//  (Hue, Saturation, Lightness) color, to be used in an inline style.
-//  Unlikely to be the final method, waiting for direction from Design.
-function _determineAvatarHue(determiningString: string): number {
+// Helper function: Uses a string as the seed to fairly randomly determine
+//  the hex color for this avatar.
+function _determineAvatarColor(determiningString: string): string {
+  const colorPool = [
+    "C9F2F1",
+    "FDB9C0",
+    "FAE5B8",
+    "D9BDFD",
+    "B4EAD8",
+    "BFCEFF",
+    "FFBADE",
+    "FDBD81",
+  ];
+
   let hash = 0;
   for (let i = 0; i < determiningString.length; i++) {
     hash = determiningString.charCodeAt(i) + ((hash << 5) - hash);
     hash = hash & hash; // Converts to a 32bit int
   }
 
-  // Hue values for HSL color function are between 0 and 359,
-  //  for degrees on the color wheel.
-  return hash % 360;
+  return colorPool[Math.abs(hash % colorPool.length)];
 }

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -6,6 +6,8 @@
   margin-right: auto;
   .flexbox();
   .text--center();
+  // Without this, messages 'bunch up' on Safari.
+  flex-shrink: 0;
 }
 
 .MessageMetadata--Message--right {
@@ -14,6 +16,8 @@
   .flexbox();
   flex-direction: row-reverse;
   align-items: center;
+  // Without this, messages 'bunch up' on Safari.
+  flex-shrink: 0;
 }
 
 .MessageMetadata--Message--left {
@@ -22,6 +26,8 @@
   .flexbox();
   flex-direction: row;
   align-items: center;
+  // Without this, messages 'bunch up' on Safari.
+  flex-shrink: 0;
 }
 
 .MessageMetadata--Timestamp--right {

--- a/src/MessagingThreadHistory/MessagingThreadHistory.less
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.less
@@ -2,7 +2,7 @@
 
 .ThreadHistory--Container {
   .padding--right--s();
-  overflow-y: overlay;
+  overflow-y: auto;
   flex-direction: column;
 }
 

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -27,7 +27,7 @@ const cssClasses = {
 export type Status = "active" | "off";
 
 type Props = {
-  children: any;
+  children?: any;
   className?: string;
   hasDraft: boolean;
   icon: React.ReactNode;
@@ -60,7 +60,7 @@ export const MessagingThreadListItem: React.FC<
   let subContent: React.ReactNode;
   let subContentClass: string;
   if (status === "active" || !isRead) {
-    subContent = children;
+    subContent = _filterChildren(children);
     subContentClass = classNames(cssClasses.PREVIEW, !isRead && cssClasses.UNREAD_TEXT);
   } else {
     subContent = offStatusText || "Messages are turned off";
@@ -69,10 +69,10 @@ export const MessagingThreadListItem: React.FC<
 
   const indicator = (
     <FlexBox className={cssClasses.INDICATOR_CONTAINER} justify={Justify.END}>
-      {status === "active" && hasDraft ? (
-        <DraftPencilIcon />
+      {!isRead ? (
+        <div className={cssClasses.UNREAD_ORB} />
       ) : (
-        !isRead && <div className={cssClasses.UNREAD_ORB} />
+        status === "active" && hasDraft && <DraftPencilIcon />
       )}
     </FlexBox>
   );
@@ -128,4 +128,17 @@ function _formatDateForTimestamp(date: Date): string {
     return messageTimestamp.format("h:mm A");
   }
   return messageTimestamp.format("MMM D");
+}
+
+// Helper function: Filters out falsey values if multiple children,
+//  which avoids having 'blank' child elements that disrupt the styling.
+function _filterChildren(children: any) {
+  // If an array, we want to filter out the falsey elements.
+  if (children && Array.isArray(children)) {
+    const filteredChildren = children.filter(child => !!child);
+    // If now an empty array, nothing to render. Otherwise, render children!
+    return filteredChildren.length === 0 ? undefined : filteredChildren;
+  }
+  // If not an array, then there's no filtering we need to do.
+  return children;
 }


### PR DESCRIPTION
**Overview:**
A number of quality-of-life improvements. Individually annotated!

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - More testing to come next week with older OS's/browsers, covering everything (not just these changes).

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)

---

**Screenshots/GIFs:**

# Filtering out falsey values from children

The respective values of `children` in the four screenshots below:
1. `"This is some content!"`
2. `undefined` (implicit, nothing passed in)
3. `[]` (explicitly passed in)
4. `undefined` (explicitly passed in)
5. `[undefined, undefined]`
6. `[undefined, null, false, ""]`

Cases (3), (5), and (6) are fixed in this PR, without breaking the already-working cases (1), (2), and (4).

### OLD, NO draft
![Screen Shot 2020-07-17 at 4 10 19 PM](https://user-images.githubusercontent.com/57963785/87838410-d4696200-c84b-11ea-8d38-df6a74c08ecb.png)

### OLD, WITH draft
![Screen Shot 2020-07-17 at 4 09 07 PM](https://user-images.githubusercontent.com/57963785/87838416-da5f4300-c84b-11ea-82ec-92a6cdbca9a9.png)

### NEW, NO draft
![Screen Shot 2020-07-17 at 4 00 47 PM](https://user-images.githubusercontent.com/57963785/87838420-e21ee780-c84b-11ea-85ca-21c9d000a7fc.png)

### NEW, WITH draft
![Screen Shot 2020-07-17 at 4 00 59 PM](https://user-images.githubusercontent.com/57963785/87838425-e64b0500-c84b-11ea-935c-8101cfae16f5.png)

# Choosing correct indicator

The content describes the cases here, no need for a list. 🙂 

### OLD
![Screen Shot 2020-07-17 at 4 19 41 PM](https://user-images.githubusercontent.com/57963785/87838302-6ae95380-c84b-11ea-834e-a937ed04d9d7.png)

### NEW
![Screen Shot 2020-07-17 at 4 19 14 PM](https://user-images.githubusercontent.com/57963785/87838300-69b82680-c84b-11ea-84e1-90cf9079df74.png)