### PR TITLE
Missed a docs update in #498

### DIFF
--- a/docs/components/MessagingThreadListItemView.jsx
+++ b/docs/components/MessagingThreadListItemView.jsx
@@ -133,6 +133,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
             name: "children",
             type: "React.Node",
             description: "MessagingThreadListItem content.",
+            optional: true,
           },
           {
             name: "className",


### PR DESCRIPTION
Correctly note in docs that children prop is now optional in MessagingThreadListItem

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [N/A] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [N/A] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [N/A] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
