### PR TITLE
Support button children

### DIFF
--- a/docs/components/ButtonView.jsx
+++ b/docs/components/ButtonView.jsx
@@ -123,9 +123,18 @@ export default function ButtonView() {
       <PropDocumentation
         availableProps={[
           {
+            name: "children",
+            type: "ReactNode",
+            optional: true,
+            description:
+              "The content that appears in the button, and takes precedence over 'value'",
+          },
+          {
             name: "value",
-            type: "string",
-            description: "The text that appears on the button",
+            type: "ReactNode",
+            optional: true,
+            description:
+              "(Deprecated, use children instead) The content that appears in the button if children are not specified",
           },
           {
             name: "type",

--- a/docs/components/ButtonView.jsx
+++ b/docs/components/ButtonView.jsx
@@ -59,31 +59,21 @@ export default function ButtonView() {
 
       <Example title="Button with HTML content">
         <Button type="primary" value={<span className="fa fa-search" />} />
-        <Button
-          type="destructive"
-          value={
-            <div>
-              <span className="fa fa-trash" /> Remove
-            </div>
-          }
-        />
-        <Button
-          disabled
-          value={
-            <div>
-              <span className="fa fa-spin fa-spinner" /> Saving...
-            </div>
-          }
-        />
-        <Button
-          href="http://wikipedia.org"
-          type="link"
-          value={
-            <span>
-              <span className="fa fa-external-link" /> Learn more
-            </span>
-          }
-        />
+        <Button type="destructive">
+          <div>
+            <span className="fa fa-trash" /> Remove
+          </div>
+        </Button>
+        <Button disabled>
+          <div>
+            <span className="fa fa-spin fa-spinner" /> Saving...
+          </div>
+        </Button>
+        <Button href="http://wikipedia.org" type="link">
+          <span>
+            <span className="fa fa-external-link" /> Learn more
+          </span>
+        </Button>
       </Example>
 
       <h3>API:</h3>
@@ -101,8 +91,9 @@ export default function ButtonView() {
               _focusExampleRef = ref;
             }}
             type="destructive"
-            value="Focus on me!"
-          />
+          >
+            Focus on me!
+          </Button>
 
           <Button
             onClick={() => {
@@ -111,12 +102,11 @@ export default function ButtonView() {
             }}
             size={Button.Size.S}
             type="link"
-            value={
-              <span>
-                <code>focus()</code> ...but just for a second
-              </span>
-            }
-          />
+          >
+            <span>
+              <code>focus()</code> ...but just for a second
+            </span>
+          </Button>
         </ExampleCode>
       </Example>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.58.1",
+  "version": "2.59.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -8,10 +8,11 @@ import { Values } from "../utils/types";
 import "./Button.less";
 
 export interface Props {
+  children?: React.ReactNode;
   className?: string;
   type?: ButtonType;
   size?: ButtonSize;
-  value: React.ReactNode;
+  value?: React.ReactNode;
   href?: string;
   target?: "_self" | "_blank";
   disabled?: boolean;
@@ -43,10 +44,11 @@ const Type = {
 } as const;
 
 const propTypes = {
+  children: PropTypes.node,
   className: PropTypes.string,
   type: PropTypes.oneOf(_.values(Type)),
   size: PropTypes.oneOf(_.values(Size)),
-  value: PropTypes.node.isRequired,
+  value: PropTypes.node,
   href: PropTypes.string,
   target: PropTypes.oneOf(["_self", "_blank"]),
   disabled: PropTypes.bool,
@@ -87,6 +89,7 @@ export class Button extends React.PureComponent<Props> {
   render() {
     const {
       ariaLabel,
+      children,
       className,
       disabled,
       href,
@@ -122,7 +125,8 @@ export class Button extends React.PureComponent<Props> {
       underlined ? "Button--linkUnderlined" : "",
     );
 
-    const aria = ariaLabel || (typeof value === "string" ? (value as string) : null);
+    const content = children || value;
+    const aria = ariaLabel || (typeof content === "string" ? content : null);
 
     if (href == null || disabled) {
       // use <button>s for all disabled links and things with no href prop (buttons)
@@ -139,7 +143,7 @@ export class Button extends React.PureComponent<Props> {
           style={style}
           type={submit ? "submit" : "button"}
         >
-          {value}
+          {content}
         </button>
       );
     }
@@ -156,7 +160,7 @@ export class Button extends React.PureComponent<Props> {
         style={style}
         target={target}
       >
-        {value}
+        {content}
       </a>
     );
   }

--- a/src/ModalButton/ModalButton.tsx
+++ b/src/ModalButton/ModalButton.tsx
@@ -22,6 +22,7 @@ interface State {
 }
 
 const excludeModalProps = ["closeModal", "children"];
+const excludedButtonProps = ["children"];
 
 // inherit properties from Button and Modal except closeModal; don't prefix children,
 // but prefix the rest of Modal's keys.
@@ -60,7 +61,7 @@ export class ModalButton extends React.Component<Props, State> {
   }
 
   render() {
-    const buttonProps = propsFor(Button, this.props);
+    const buttonProps = omitKeys(propsFor(Button, this.props), ...excludedButtonProps);
     const modalProps = propsFor(Modal, unprefixKeys(this.props, "modal"));
 
     return (

--- a/test/Button_test.tsx
+++ b/test/Button_test.tsx
@@ -65,4 +65,14 @@ describe("Button", () => {
     button.simulate("click");
     assert(onClickSpy.calledOnce);
   });
+
+  it("renders a <Button> element with the provided children as its innner content", () => {
+    const button = shallow(<Button>foo</Button>);
+    assert.equal(button.text(), "foo");
+  });
+
+  it("renders a <Button> element and ignores 'value' when both 'children' and 'value' are passed in", () => {
+    const button = shallow(<Button value="bar">foo</Button>);
+    assert.equal(button.text(), "foo");
+  });
 });

--- a/test/Button_test.tsx
+++ b/test/Button_test.tsx
@@ -1,5 +1,3 @@
-/* eslint func-names: "off" */
-
 import * as assert from "assert";
 import * as React from "react";
 import * as sinon from "sinon";


### PR DESCRIPTION
**Overview:**
The content for a `Button` can now be passed in as its children. Content can still be passed in as `value` for backwards compatibility. 

Instead of this
```js
<Button
  type="primary"
  disabled
  value={
    <>
      <span className="fa fa-spin fa-spinner" /> Saving...
    </>
  }
/>;
```

we can now do this
```js
<Button type="primary" disabled>
  <span className="fa fa-spin fa-spinner" /> Saving...
</Button>;
```

I updated some of the examples in the `Button` documentation to use children instead of `value`, but not all. The examples I updated are the ones where the `Button`'s content is a react node since it makes the code a bit more compact. We could update all of the examples to use children if we want to encourage using children over `value`, but the code is equally compact when the content is just a string. Should we change all examples to use children instead of `value`? If we really wanted to be consistent everywhere and encourage using children, we could also make the same change in all components that contain `Button`s.

**Screenshots/GIFs:**
Buttons using `children`
<img width="983" alt="Screen Shot 2020-09-23 at 1 10 49 PM" src="https://user-images.githubusercontent.com/32328921/94064270-47d4a600-fd9e-11ea-99d8-9f899e6f6e2f.png">

ModalButton still works
<img width="1103" alt="Screen Shot 2020-09-23 at 1 10 29 PM" src="https://user-images.githubusercontent.com/32328921/94064267-473c0f80-fd9e-11ea-9150-b9f3e334647c.png">

**Testing:**
- [x] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
