### PR TITLE
Messaging avatar touchups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.45.0",
+  "version": "2.45.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingAvatar/MessagingAvatar.less
+++ b/src/MessagingAvatar/MessagingAvatar.less
@@ -1,6 +1,7 @@
 @import (reference) "../less/index";
 
 .Avatar--Image {
+  .flexbox();
   height: @size_xl;
   width: @size_xl;
   border-radius: 50%;
@@ -10,14 +11,13 @@
   height: @size_xl;
   width: @size_xl;
   border-radius: 50%;
-  display: table;
-  .text--center();
+  .flexbox();
+  .items--center();
+  .justify--center();
 }
 
 .Avatar--Text {
   .text--small();
   .text--semi-bold();
   color: @neutral_dark_gray;
-  display: table-cell;
-  vertical-align: middle;
 }

--- a/src/MessagingAvatar/MessagingAvatar.tsx
+++ b/src/MessagingAvatar/MessagingAvatar.tsx
@@ -39,9 +39,8 @@ export const MessagingAvatar: React.FC<Props> = ({ className, text, color, image
     <div
       className={classNames(cssClasses.CIRCLE, className)}
       // If defined, use color. Otherwise, use seed to determine color.
-      // If all else fails, we can use text as the seed to determine color.
       style={{
-        backgroundColor: color.color || `#${_determineAvatarColor(color.seed || text)}`,
+        backgroundColor: color.color || `#${_determineAvatarColor(color.seed)}`,
       }}
     >
       <div className={cssClasses.TEXT}>{convertNameToInitials(text)}</div>


### PR DESCRIPTION
**Jira:**

**Overview:**

The way that centering of the avatars was done - using `display: table` and text centering, would cause weird behavior when interacting with other elements (i.e. in screenshot within div that had a border. Instead, this PR changes the Avatar to just use flex with centering, which better fits the actual use of the avatar and achieves the same benefit the `display: table` did (I think it was previously chosen because the default `display: inline`[ suffered from this
](https://stackoverflow.com/questions/5804256/image-inside-div-has-extra-space-below-the-image).

Old - 
<img width="276" alt="Screen Shot 2020-07-18 at 11 20 33 AM" src="https://user-images.githubusercontent.com/26425483/87989326-b17ebe00-ca96-11ea-8e59-9f817cd2c0d1.png">

New - 
<img width="252" alt="Screen Shot 2020-07-20 at 1 42 13 PM" src="https://user-images.githubusercontent.com/26425483/87989313-ac217380-ca96-11ea-9771-dc6994fa56ac.png">


**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
