### PR TITLE
make rendering Modal through react portal optional

### DIFF
--- a/docs/components/ModalView.jsx
+++ b/docs/components/ModalView.jsx
@@ -86,6 +86,13 @@ export default class ModalView extends Component {
               defaultValue: "true",
               optional: true,
             },
+            {
+              name: "createPortal",
+              type: "Boolean",
+              description: "Whether or not to render the modal into document.body through react portal (if supported)",
+              defaultValue: "true",
+              optional: true,
+            },
           ]}
           className={cssClass.PROPS}
           title="Modal"

--- a/docs/components/ModalView.jsx
+++ b/docs/components/ModalView.jsx
@@ -89,7 +89,8 @@ export default class ModalView extends Component {
             {
               name: "createPortal",
               type: "Boolean",
-              description: "Whether or not to render the modal into document.body through react portal (if supported)",
+              description:
+                "Whether or not to render the modal into document.body through react portal (if supported)",
               defaultValue: "true",
               optional: true,
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.46.0",
+  "version": "2.47.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -13,6 +13,7 @@ export interface Props {
   closeModal: () => void;
   children: React.ReactNode;
   focusLocked?: boolean;
+  createPortal?: boolean;
 }
 
 interface State {
@@ -34,11 +35,13 @@ const propTypes = {
   closeModal: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
   focusLocked: PropTypes.bool,
+  createPortal: PropTypes.bool,
 };
 
 const defaultProps = {
   width: DEFAULT_WIDTH,
   focusLocked: true,
+  createPortal: true,
 };
 
 export class Modal extends React.Component<Props, State> {
@@ -111,7 +114,7 @@ export class Modal extends React.Component<Props, State> {
     } else {
       modal = modalContent;
     }
-    if (reactDom.createPortal) {
+    if (reactDom.createPortal && this.props.createPortal) {
       return reactDom.createPortal(modal, document.body);
     }
     return modal;


### PR DESCRIPTION
**Jira:**

**Overview:**
GetClever is a google chrome tab managed web app that replaces the document body with an iframe containing the rendered `family-media-center` application. When a families subscription is expired, we want to immediately render a non-closable Modal prompting them to subscribe in order to continue using the product.

Currently, if `createPortal` is supported, Modal renders itself through reacts `createPortal` into `document.body` by default. In GetClever's case, this results in two Modals being rendered, one on top of each other, one in the document body, and the other in the resulting iframe:

<img width="1790" alt="Screen Shot 2020-07-23 at 4 24 47 PM" src="https://user-images.githubusercontent.com/17110185/88412217-12a3db80-cd8e-11ea-8c29-175aebdc149b.png">

This adds an optional parameter `createPortal` that defaults to true, and when false, returns the rendered Modal as is, bypassing `createPortal`.

**Testing:**
- [x] Unit tests -still passing
- Manual tests:
  - [x] Chrome
  - [x] Safari - tested not passing in `createPortal` as well as passing both false and true
  - [ ] IE10

**Testing with GetClever**:

- with `createPortal` not specified:
<img width="1790" alt="Screen Shot 2020-07-23 at 4 24 47 PM" src="https://user-images.githubusercontent.com/17110185/88412792-f5bbd800-cd8e-11ea-9c28-d10c392c4edc.png">

- with `createPortal` set to false:
<img width="1787" alt="Screen Shot 2020-07-24 at 8 43 17 AM" src="https://user-images.githubusercontent.com/17110185/88412798-f7859b80-cd8e-11ea-9096-ef3ac8b9d411.png">

- with `createPortal` set to true:
<img width="1790" alt="Screen Shot 2020-07-23 at 4 24 47 PM" src="https://user-images.githubusercontent.com/17110185/88412841-08361180-cd8f-11ea-813a-6840ca6a5804.png">


**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
