### PR TITLE
Messaging component tweaks and badge prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.47.0",
+  "version": "2.47.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -30,7 +30,7 @@ const Color = {
   RED: "red",
   BLUE: "blue",
   GRAY: "gray",
-};
+} as const;
 
 const defaultProps = {
   color: Color.BLUE,

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -43,6 +43,7 @@ button.MessagingInput--SendButton {
   padding: 0.625rem @size_l 0.625rem;
 }
 
+// For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
   .MessagingInput--TextField {
     .margin--right--none();

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -51,6 +51,7 @@ button.MessagingInput--SendButton {
   }
 
   .MessagingInput--SendIcon {
+    height: 100%;
     display: block;
     background-color: transparent;
     border-radius: 50%;

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -44,6 +44,7 @@
   color: @neutral_medium_gray;
 }
 
+// For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
   .MessageMetadata--Message--right {
     .margin--y--xs();

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -43,3 +43,13 @@
   .text--line-height-1();
   color: @neutral_medium_gray;
 }
+
+@media only screen and (max-width: @breakpointM) {
+  .MessageMetadata--Message--right {
+    .margin--y--xs();
+  }
+
+  .MessageMetadata--Message--left {
+    .margin--y--xs();
+  }
+}


### PR DESCRIPTION
**Jira:** N/A

**Overview:** This makes a few small fixes to some messaging components on mobile (credit to Chloe for those). Specifically, it fixes some broken styling for an icon and tightens the spacing on mobile (to match the mocks). Unrelatedly, it also fixes types for the `Badge` component to make the `color` prop correctly typed as a union of strings instead of getting widened to `string`.

**Screenshots/GIFs:**
Broken messaging input icon:
![messaging input](https://user-images.githubusercontent.com/39533986/88703916-33d43700-d0c2-11ea-90cd-d2befc1d805e.gif)

Fixed:
<img width="866" alt="Screen Shot 2020-07-28 at 10 48 39 AM" src="https://user-images.githubusercontent.com/39533986/88703898-2fa81980-d0c2-11ea-8907-56569b1e19b4.png">


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [X] Chrome
  - [X] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [X] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
