### PR TITLE
MessagingInput text overlap with button, MessagingThreadHistory vertical padding, MessagingBubble mobile line height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.47.1",
+  "version": "2.47.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -6,6 +6,7 @@
   border-radius: 0.3125rem;
   color: @neutral_white;
   background-color: @neutral_dark_gray;
+  font-size: 1rem;
   .text--line-height-4();
   white-space: pre-wrap;
 }
@@ -16,6 +17,20 @@
   border-radius: 0.3125rem;
   color: @neutral_black;
   background-color: #f3f5fd; /* stylelint-disable-line */
+  font-size: 1rem;
   .text--line-height-4();
   white-space: pre-wrap;
+}
+
+// For mobile/tablet
+@media only screen and (max-width: @breakpointM) {
+  .MessagingBubble--Message--Own {
+    font-size: 0.875rem;
+    line-height: 1rem;
+  }
+
+  .MessagingBubble--Message--Other {
+    font-size: 0.875rem;
+    line-height: 1rem;
+  }
 }

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -49,6 +49,12 @@ button.MessagingInput--SendButton {
     .margin--right--none();
     border-radius: @size_m;
     min-height: 2rem;
+
+    .TextArea--input {
+      // Padding to account for the inside-textarea Send button in mobile UI.
+      //  Ensures that text is to the left of the Send button.
+      padding-right: 2.5rem;
+    }
   }
 
   .MessagingInput--SendIcon {

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -46,11 +46,15 @@
 
 // For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
+  .MessageMetadata--Message--center {
+    .margin--y--m();
+  }
+
   .MessageMetadata--Message--right {
-    .margin--y--xs();
+    .margin--y--2xs();
   }
 
   .MessageMetadata--Message--left {
-    .margin--y--xs();
+    .margin--y--2xs();
   }
 }

--- a/src/MessagingThreadHistory/MessagingThreadHistory.less
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.less
@@ -17,3 +17,11 @@
 .ThreadHistory--FirstMessage {
   margin-top: auto;
 }
+
+// For mobile/tablet
+@media only screen and (max-width: @breakpointM) {
+  .ThreadHistory--Divider {
+    margin-top: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+}


### PR DESCRIPTION
**Overview:**

* MessagingInput text will no longer overlap button in mobile UI
* Corrections to MessagingThreadHistory message padding (vertical) to bring it closer to mobile mocks
* MessagingBubble line height lower on mobile, per mocks

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)

---

**Screenshots/GIFs:**

**MessagingInput padding for text/button**

![Screen Shot 2020-07-29 at 5 26 56 PM](https://user-images.githubusercontent.com/57963785/88867022-281b6a00-d1c1-11ea-8506-2dcdda578731.png)

**MessagingThreadHistory vertical padding for messages - Desktop**
![Screen Shot 2020-07-29 at 5 25 31 PM](https://user-images.githubusercontent.com/57963785/88867053-3bc6d080-d1c1-11ea-9c95-2a6864e24fae.png)

**MessagingThreadHistory vertical padding for messages - Mobile**
![Screen Shot 2020-07-29 at 5 23 32 PM](https://user-images.githubusercontent.com/57963785/88867075-4a14ec80-d1c1-11ea-99a4-02fa85d55158.png)