### PR TITLE
Small messaging changes

### DIFF
--- a/docs/components/MessagingInputView.jsx
+++ b/docs/components/MessagingInputView.jsx
@@ -52,7 +52,6 @@ export default class MessagingInputView extends React.PureComponent {
             <MessagingInput
               value={inputValue}
               onChange={newValue => this.setState({ inputValue: newValue })}
-              recipientName="Demo Viewer"
               onSubmit={message => {
                 // eslint-disable-next-line no-alert
                 alert(message);
@@ -76,11 +75,6 @@ export default class MessagingInputView extends React.PureComponent {
             name: "value",
             type: "string",
             description: "The text that's been entered in the MessagingInput.",
-          },
-          {
-            name: "recipientName",
-            type: "string",
-            description: "The name of the person that we're messaging.",
           },
           {
             name: "onChange",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.47.2",
+  "version": "2.47.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -24,13 +24,10 @@
 
 // For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
-  .MessagingBubble--Message--Own {
-    font-size: 0.875rem;
-    line-height: 1rem;
-  }
-
+  .MessagingBubble--Message--Own,
   .MessagingBubble--Message--Other {
     font-size: 0.875rem;
     line-height: 1rem;
+    .padding--xs();
   }
 }

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -40,7 +40,7 @@
 
 button.MessagingInput--SendButton {
   // Sizing for this button is pretty particular
-  padding: 0.625rem @size_l 0.625rem;
+  padding: 0.6875rem 1.5rem 0.6875rem;
 }
 
 // For mobile/tablet

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -41,6 +41,7 @@
 button.MessagingInput--SendButton {
   // Sizing for this button is pretty particular
   padding: 0.6875rem 1.5rem 0.6875rem;
+  line-height: normal;
 }
 
 // For mobile/tablet

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -11,7 +11,6 @@ function cssClass(element: string) {
 
 interface Props {
   className?: string;
-  recipientName: string;
   value: string;
   onChange: (newValue: string) => void;
   // onSubmit accepts a value rather than submitting the current message value
@@ -29,7 +28,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
   props,
   ref,
 ) => {
-  const { className, recipientName, value, onChange, onSubmit, onBlur } = props;
+  const { className, value, onChange, onSubmit, onBlur } = props;
   const textAreaRef = React.useRef<TextArea>(null);
 
   React.useImperativeHandle(ref, () => ({
@@ -46,7 +45,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
         ref={textAreaRef}
         className={cssClass("TextField")}
         name="newMessage"
-        placeholder={`Message ${recipientName}`}
+        placeholder="Message"
         value={value}
         onChange={e => {
           onChange(e.target.value);


### PR DESCRIPTION
**Jira:**

**Overview:**

Messaging fixes:
1. Drop `recipientName` from `messagingInput` to appease pendo security risk
2. Have button height match input
3. Add padding to messaging bubbles on mobile

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
