### PR TITLE
v2.47.5 - convertNameToInitials utility function bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.47.4",
+  "version": "2.47.5",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingAvatar/MessagingAvatar.tsx
+++ b/src/MessagingAvatar/MessagingAvatar.tsx
@@ -43,10 +43,20 @@ export const MessagingAvatar: React.FC<Props> = ({ className, text, color, image
         backgroundColor: color.color || `#${_determineAvatarColor(color.seed)}`,
       }}
     >
-      <div className={cssClasses.TEXT}>{convertNameToInitials(text)}</div>
+      <div className={cssClasses.TEXT}>{_getInitialsFromText(text)}</div>
     </div>
   );
 };
+
+// Helper function: Uses the convertNameToInitials util function to get
+//  appropriate initials from the text prop, with a precautionary fallback.
+function _getInitialsFromText(text: string): string {
+  try {
+    return convertNameToInitials(text);
+  } catch (e) {
+    return "";
+  }
+}
 
 // Helper function: Uses a string as the seed to fairly randomly determine
 //  the hex color for this avatar.

--- a/src/MessagingAvatar/utils.ts
+++ b/src/MessagingAvatar/utils.ts
@@ -1,6 +1,6 @@
 /** A utility function that can be used with MessagingAvatar to convert a name into initials. */
 export function convertNameToInitials(name: string): string {
-  if (!name) {
+  if (!name.trim()) {
     return "";
   }
 


### PR DESCRIPTION
`convertNameToInitials` utility function now properly handles whitespace-only input.

Currently it _crashes_, which is yikes. 😟 

**Jira:**

**Overview:**

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
