### PR TITLE
DISC-1795 Allow passing of aria-label to Button component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.48.1",
+  "version": "2.48.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -19,6 +19,7 @@ export interface Props {
   submit?: boolean;
   style?: React.CSSProperties;
   underlined?: boolean;
+  ariaLabel?: string;
   [additionalProp: string]: any;
 }
 
@@ -53,6 +54,7 @@ const propTypes = {
   submit: PropTypes.bool,
   style: PropTypes.object,
   underlined: PropTypes.bool,
+  ariaLabel: PropTypes.string,
 };
 
 const defaultProps = {
@@ -84,6 +86,7 @@ export class Button extends React.PureComponent<Props> {
 
   render() {
     const {
+      ariaLabel,
       className,
       disabled,
       href,
@@ -119,12 +122,14 @@ export class Button extends React.PureComponent<Props> {
       underlined ? "Button--linkUnderlined" : "",
     );
 
+    const aria = ariaLabel || (typeof value === "string" ? (value as string) : null);
+
     if (href == null || disabled) {
       // use <button>s for all disabled links and things with no href prop (buttons)
       return (
         <button
-          aria-label={typeof value === "string" ? (value as string) : null}
           {...additionalProps}
+          aria-label={aria}
           className={classes}
           disabled={disabled}
           onClick={onClick}
@@ -140,8 +145,8 @@ export class Button extends React.PureComponent<Props> {
     }
     return (
       <a
-        aria-label={typeof value === "string" ? (value as string) : null}
         {...additionalProps}
+        aria-label={aria}
         className={classes}
         href={href}
         onClick={onClick}

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -123,6 +123,7 @@ export class Button extends React.PureComponent<Props> {
       // use <button>s for all disabled links and things with no href prop (buttons)
       return (
         <button
+          aria-label={typeof value === "string" ? (value as string) : null}
           {...additionalProps}
           className={classes}
           disabled={disabled}
@@ -132,7 +133,6 @@ export class Button extends React.PureComponent<Props> {
           }}
           style={style}
           type={submit ? "submit" : "button"}
-          aria-label={typeof value === "string" ? (value as string) : null}
         >
           {value}
         </button>
@@ -140,6 +140,7 @@ export class Button extends React.PureComponent<Props> {
     }
     return (
       <a
+        aria-label={typeof value === "string" ? (value as string) : null}
         {...additionalProps}
         className={classes}
         href={href}
@@ -149,7 +150,6 @@ export class Button extends React.PureComponent<Props> {
         }}
         style={style}
         target={target}
-        aria-label={typeof value === "string" ? (value as string) : null}
       >
         {value}
       </a>


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/DISC-1795

**Overview:**
This PR allows consumers of the Button component to pass an aria-label prop that doesn't get overwritten by the existing aria-label logic. No changes to the Button interface, just fixes the logic

**Testing:**
Tested with locally-running launchpad

new aria-label passes properly
<img width="1552" alt="Screen Shot 2020-08-25 at 12 21 38 PM" src="https://user-images.githubusercontent.com/13992076/91218294-ad654200-e6cd-11ea-8dd6-3e68f0825375.png">

existing aria-labels unaffected
<img width="1552" alt="Screen Shot 2020-08-25 at 12 21 58 PM" src="https://user-images.githubusercontent.com/13992076/91218326-b9e99a80-e6cd-11ea-945c-a68be414d4a1.png">

