### PR TITLE
TopBarButton accessibility: moving div outside <a> tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.48.0",
+  "version": "2.48.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TopBar/TopBarButton.less
+++ b/src/TopBar/TopBarButton.less
@@ -1,6 +1,10 @@
 @import (reference) "../less/index";
 @import (reference) "./common";
 
+.TopBarButton--container {
+  position: relative;
+}
+
 .TopBarButton {
   .text--semi-bold;
   .button--reset;
@@ -14,7 +18,6 @@
   color: @neutral_white;
   height: @topBarHeight - @size_xs;
   .padding--x--m;
-  position: relative;
   text-align: center;
 }
 

--- a/src/TopBar/TopBarButton.tsx
+++ b/src/TopBar/TopBarButton.tsx
@@ -2,6 +2,7 @@ import * as _ from "lodash";
 import * as classnames from "classnames";
 import * as PropTypes from "prop-types";
 import * as React from "react";
+import { FlexBox } from "..";
 
 import "./TopBarButton.less";
 
@@ -44,22 +45,24 @@ export class TopBarButton extends React.PureComponent<Props> {
     const Wrapper = this._getWrapperComponent();
 
     return (
-      <Wrapper
-        {...additionalProps}
-        className={classnames(
-          "TopBarButton",
-          className,
-          this.props.round ? "TopBarButton--rounded" : null,
-        )}
-        href={href}
-        onClick={onClick}
-        ref={ref => {
-          this._containerRef = ref;
-        }}
-      >
-        {children}
+      <FlexBox className="TopBarButton--container">
+        <Wrapper
+          {...additionalProps}
+          className={classnames(
+            "TopBarButton",
+            className,
+            this.props.round ? "TopBarButton--rounded" : null,
+          )}
+          href={href}
+          onClick={onClick}
+          ref={ref => {
+            this._containerRef = ref;
+          }}
+        >
+          {children}
+        </Wrapper>
         {active && <div className="TopBarButton--activeIndicator" />}
-      </Wrapper>
+      </FlexBox>
     );
   }
 


### PR DESCRIPTION
**Jira:** [DISC-1798](https://clever.atlassian.net/browse/DISC-1798)

**Overview:**

<div> tags can't be nested inside <a> or <button> tags for accessibility reasons. this PR moves the `activeIndicator` div outside the <a> tag, while maintaining the same visual appearance.

**Screenshots/GIFs:**

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10 ** (i don't have IE10 on my machine; is this necessary for a small change??) **

## nesting works (this branch)
![Screen Shot 2020-08-19 at 9 41 30 AM](https://user-images.githubusercontent.com/13992076/90665145-82c44680-e200-11ea-9dd1-854ccff44320.png)

## prod (for comparison that visual appearance is the same)
![Screen Shot 2020-08-19 at 8 48 47 AM](https://user-images.githubusercontent.com/13992076/90665227-9bccf780-e200-11ea-89d3-4fc21b47f8bd.png)

## testing nesting in launchpad (this branch)
![Screen Shot 2020-08-19 at 9 40 43 AM](https://user-images.githubusercontent.com/13992076/90665323-bbfcb680-e200-11ea-8712-dff50b941212.png)

## launchpad prod (for visual comparison)
![Screen Shot 2020-08-19 at 9 41 17 AM](https://user-images.githubusercontent.com/13992076/90665391-cdde5980-e200-11ea-859f-efe43bce6591.png)


**Roll Out:**
- Before merging:
  - [ ] Updated docs ** not needed ?**
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
