### PR TITLE
DISC-1829 Add name property to TextTruncate

### DIFF
--- a/docs/components/TextTruncateView.jsx
+++ b/docs/components/TextTruncateView.jsx
@@ -182,6 +182,12 @@ export default class TextTruncateView extends React.PureComponent {
             defaultValue: "false",
             optional: true,
           },
+          {
+            name: "name",
+            type: "string",
+            description: "Name appended to the toggle button aria label",
+            optional: true,
+          },
         ]}
         className={cssClass.PROPS}
       />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.49.0",
+  "version": "2.50.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextTruncate/TextTruncate.tsx
+++ b/src/TextTruncate/TextTruncate.tsx
@@ -13,6 +13,7 @@ export interface Props {
   lines?: number;
   maxCharsShown?: number;
   useRichText?: boolean;
+  name?: string;
 }
 
 const propTypes = {
@@ -23,6 +24,7 @@ const propTypes = {
   lines: PropTypes.number,
   maxCharsShown: PropTypes.number,
   useRichText: PropTypes.bool,
+  name: PropTypes.string,
 };
 
 const defaultProps = {
@@ -66,6 +68,7 @@ export default class TextTruncate extends React.PureComponent<Props> {
       showLessLabel,
       maxCharsShown,
       useRichText,
+      name,
     } = this.props;
     const { truncated } = this.state;
 
@@ -78,13 +81,15 @@ export default class TextTruncate extends React.PureComponent<Props> {
     }
 
     const displayText = truncated ? `${this.truncate(text)}…` : text;
+    const toggleText = truncated ? showMoreLabel : showLessLabel;
     return (
       <div className={classnames(cssClass.CONTAINER, className)}>
         {useRichText ? <RichText text={displayText} /> : displayText}{" "}
         <Button
           type="linkPlain"
           onClick={this.toggleTruncation}
-          value={truncated ? showMoreLabel : showLessLabel}
+          value={toggleText}
+          ariaLabel={name && `${toggleText}: ${name}`}
         />
       </div>
     );


### PR DESCRIPTION
**Jira:**
[DISC-1829](https://clever.atlassian.net/browse/DISC-1829)

**Overview:**
This PR adds a name property to TextTruncate so that the aria-label on the toggle button can be made unique.

**Screenshots/GIFs:**
With name of "asdasd":
![image](https://user-images.githubusercontent.com/47156875/91342749-570d0780-e790-11ea-9b6e-e7ae115f27e5.png)

With no name passed in:
![image](https://user-images.githubusercontent.com/47156875/91342968-aa7f5580-e790-11ea-90de-beee5f2ce8b9.png)

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
