### PR TITLE
Tooltip: making all tooltips focusable for accessibility

### DIFF
--- a/docs/components/TooltipView.jsx
+++ b/docs/components/TooltipView.jsx
@@ -58,18 +58,6 @@ export default class TooltipView extends Component {
                 </Tooltip>
               </div>
               <div className={cssClass.EXAMPLE}>
-                With focusable trigger{" "}
-                <Tooltip
-                  content="Tooltips can be triggered by focus as well."
-                  placement={placement}
-                  textAlign={textAlign}
-                >
-                  <span ref="focusableTrigger" tabIndex={0}>
-                    <FontAwesome className={cssClass.TRIGGER} name="question-circle" />
-                  </span>
-                </Tooltip>
-              </div>
-              <div className={cssClass.EXAMPLE}>
                 With clickable trigger{" "}
                 <Tooltip
                   content="Tooltips triggered by clicks stay open."
@@ -100,12 +88,9 @@ export default class TooltipView extends Component {
               options={_.map(Tooltip.Align, (p) => ({ content: p, value: p }))}
             />
           </div>
-          <div className={cssClass.FOCUS_CONTROL}>
-            <Button
-              onClick={() => this.refs.focusableTrigger.focus()}
-              type="linkPlain"
-              value="Click to focus on tooltip trigger"
-            />
+          <div className={cssClass.ACCESSIBILITY_NOTICE}>
+            For accessibility reasons, all tooltips are also triggered by focus. Press the tab key
+            to move focus throughout the page.
           </div>
         </Example>
         <PropDocumentation
@@ -184,7 +169,7 @@ TooltipView.cssClass = {
   CONTAINER: "TooltipView",
   DEMO_CONTAINER: "TooltipView--demoContainer",
   EXAMPLE: "TooltipView--example",
-  FOCUS_CONTROL: "TooltipView--focusControl",
+  ACCESSIBILITY_NOTICE: "TooltipView--accessibilityNotice",
   PROPS: "TooltipView--props",
   TRIGGER: "TooltipView--tooltipTrigger",
 };

--- a/docs/components/TooltipView.less
+++ b/docs/components/TooltipView.less
@@ -34,7 +34,7 @@
   display: inline-block;
 }
 
-.TooltipView--focusControl {
-  .margin--top--s;
+.TooltipView--accessibilityNotice {
+  .margin--top--m;
   .text--small;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.62.5",
+  "version": "2.63.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -11,7 +11,7 @@ import { Values } from "../utils/types";
 import "./Tooltip.less";
 
 export interface Props {
-  children: React.ReactNode;
+  children: React.ReactElement;
   className?: string;
   clickTrigger?: boolean;
   content: React.ReactNode;
@@ -59,7 +59,7 @@ const defaultProps = {
 
 export const cssClass = {
   CONTENT: "Tooltip--content",
-
+  FOCUSABLE_TRIGGER: "Tooltip--focusable-trigger",
   align: (textAlign) => `Tooltip--content--${textAlign}`,
 };
 
@@ -104,6 +104,8 @@ export default class Tooltip extends React.Component<Props> {
       </BootstrapTooltip>
     );
 
+    const child = React.Children.only(children);
+
     return (
       <OverlayTrigger
         delayShow={delayMs}
@@ -113,7 +115,12 @@ export default class Tooltip extends React.Component<Props> {
         rootClose
         trigger={hide ? [] : ["focus", clickTrigger ? "click" : "hover"]}
       >
-        {children}
+        {React.cloneElement(child, {
+          tabIndex: 0,
+          "aria-describedby": this.id,
+          className: cssClass.FOCUSABLE_TRIGGER,
+          ...child.props,
+        })}
       </OverlayTrigger>
     );
   }


### PR DESCRIPTION
**Jira:** [DISC-1801](https://clever.atlassian.net/browse/DISC-1801)

**Overview:**

making all tooltips focusable by tab for accessibility

**Screenshots/GIFs:**
tested in dewey
![tab-index-3](https://user-images.githubusercontent.com/13992076/95774326-105a6a80-0c75-11eb-9263-15b3d5526593.gif)

tested in launchpad
![tab-index-1](https://user-images.githubusercontent.com/13992076/95774322-0c2e4d00-0c75-11eb-9413-5813a00200ec.gif)
![tab-index-2](https://user-images.githubusercontent.com/13992076/95774324-0f293d80-0c75-11eb-8f52-6a7e32c7cff6.gif)

hover still works
![hover](https://user-images.githubusercontent.com/13992076/95774836-0e44db80-0c76-11eb-9e6e-1397436f457e.gif)



**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
