### PR TITLE
Table2Beta: Selected Rows are Blue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ gen-border-radius-styles:
 	@echo "Generating border-radius style definitions..."
 	@node genBorderRadius.js
 
-LINT_MAX_LESS_PROBLEMS := 98
+LINT_MAX_LESS_PROBLEMS := 100
 lint:
 	@echo "Linting files..."
 	@$(LINT) $(JS_FILES) $(JSX_FILES) $(TS_FILES)

--- a/src/Table2Beta/Table.less
+++ b/src/Table2Beta/Table.less
@@ -35,7 +35,15 @@
   background-color: @neutral_off_white;
 }
 
+.Table--rowSelected {
+  // We hope to add f3f5fd as a Dewey color one day
+  // TODO: Change this in the future when this is a Dewey color
+  background-color: #f3f5fd;
+}
+
 &.Table--clickable_row:hover {
-  .tint(background-color, @neutral_silver, 5);
+  // For whatever reason, the original Table's color style is used in Table2Beta as well.
+  // Remove this background-color styling when Table2Beta replaces Table
+  background-color: #f3f5fd;
   cursor: pointer;
 }

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -119,6 +119,7 @@ export const cssClass = {
   ROW: "Table--row",
   ROW_ODD: "Table--rowOdd",
   ROW_EVEN: "Table--rowEven",
+  ROW_SELECTED: "Table--rowSelected",
   TABLE: "Table",
 };
 
@@ -470,6 +471,7 @@ export class Table2Beta extends React.Component<Props, State> {
                   index % 2 ? cssClass.ROW_ODD : cssClass.ROW_EVEN,
                   onRowClick && cssClass.CLICKABLE_ROW,
                   rowClassNameFn && rowClassNameFn(rowData),
+                  selectedRows.has(rowData) && cssClass.ROW_SELECTED,
                 )}
                 key={rowIDFn(rowData)}
                 onClick={e => {


### PR DESCRIPTION
**Jira:**
[Mini-spec](https://docs.google.com/document/d/1eys3mDJYeI7pWbu50CCx-6qOg2vm1c-QlJeIlbWigSI/edit)

**Overview:**
Selected rows are now blue!

**Screenshots/GIFs:**
<img width="1161" alt="Screen Shot 2020-08-28 at 9 39 32 AM" src="https://user-images.githubusercontent.com/12452249/91591825-6320d280-e912-11ea-8ecd-495e03ed9121.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
