### PR TITLE
Add beta tags to all beta components

### DIFF
--- a/docs/components/MessagingAvatarView.jsx
+++ b/docs/components/MessagingAvatarView.jsx
@@ -4,11 +4,12 @@ import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import Colors from "src/utils/Colors";
-import { MessagingAvatar, convertNameToInitials } from "src";
+import { MessagingAvatar, convertNameToInitials, Label } from "src";
 
 import "./MessagingAvatarView.less";
 
 const cssClass = {
+  BETA: "MessagingAvatarView--beta",
   CONFIG_CONTAINER: "MessagingAvatarView--configContainer",
   CONFIG_OPTIONS: "MessagingAvatarView--configOptions",
   CONFIG: "MessagingAvatarView--config",
@@ -29,6 +30,10 @@ export default class MessagingAvatarView extends React.PureComponent {
         sourcePath="src/MessagingAvatar/MessagingAvatar.tsx"
       >
         <header className={cssClass.INTRO}>
+          <p className={cssClass.BETA}>
+            <Label color="new-feature">Beta</Label> MessagingAvatar is in Beta and breaking changes
+            may still be introduced.
+          </p>
           <p>MessagingAvatar is to be used for displaying a user's avatar.</p>
           <CodeSample>
             {`

--- a/docs/components/MessagingAvatarView.less
+++ b/docs/components/MessagingAvatarView.less
@@ -4,6 +4,10 @@
   .margin--bottom--xl;
 }
 
+.MessagingAvatarView--beta {
+  .text--italic();
+}
+
 .MessagingAvatarView--configContainer {
   .border--top--l(@neutral_silver);
   .margin--top--xl;

--- a/docs/components/MessagingBubbleView.jsx
+++ b/docs/components/MessagingBubbleView.jsx
@@ -3,11 +3,12 @@ import * as React from "react";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import { MessagingBubble, FlexBox, ItemAlign, SegmentedControl } from "src";
+import { MessagingBubble, FlexBox, ItemAlign, SegmentedControl, Label } from "src";
 
 import "./MessagingBubbleView.less";
 
 const cssClass = {
+  BETA: "MessagingBubbleView--beta",
   CONFIG_CONTAINER: "MessagingBubbleView--configContainer",
   CONFIG_OPTIONS: "MessagingBubbleView--configOptions",
   CONFIG: "MessagingBubbleView--config",
@@ -34,6 +35,10 @@ export default class MessagingBubbleView extends React.PureComponent {
         sourcePath="src/MessagingBubble/MessagingBubble.tsx"
       >
         <header className={cssClass.INTRO}>
+          <p className={cssClass.BETA}>
+            <Label color="new-feature">Beta</Label> MessagingBubble is in Beta and breaking changes
+            may still be introduced.
+          </p>
           <p>
             MessagingBubble is a single bubble that would appear in a messaging thread. It can
             contain text or other content.

--- a/docs/components/MessagingBubbleView.less
+++ b/docs/components/MessagingBubbleView.less
@@ -4,6 +4,10 @@
   .margin--bottom--xl;
 }
 
+.MessagingBubbleView--beta {
+  .text--italic();
+}
+
 .MessagingBubbleView--configContainer {
   .border--top--l(@neutral_silver);
   .margin--top--xl;

--- a/docs/components/MessagingInputView.jsx
+++ b/docs/components/MessagingInputView.jsx
@@ -3,11 +3,12 @@ import * as React from "react";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import { MessagingInput, FlexBox, ItemAlign } from "src";
+import { MessagingInput, Label } from "src";
 
 import "./MessagingInputView.less";
 
 const cssClass = {
+  BETA: "MessagingInputView--beta",
   CONFIG_CONTAINER: "MessagingInputView--configContainer",
   CONFIG_OPTIONS: "MessagingInputView--configOptions",
   CONFIG: "MessagingInputView--config",
@@ -34,9 +35,12 @@ export default class MessagingInputView extends React.PureComponent {
         sourcePath="src/MessagingInput/MessagingInput.tsx"
       >
         <header className={cssClass.INTRO}>
+          <p className={cssClass.BETA}>
+            <Label color="new-feature">Beta</Label> MessagingInput is in Beta and breaking changes
+            may still be introduced.
+          </p>
           <p>
-            MessagingInputView is an input to be used for entering and submitting text for
-            messaging.
+            MessagingInput is an input to be used for entering and submitting text for messaging.
           </p>
           <CodeSample>
             {`

--- a/docs/components/MessagingInputView.less
+++ b/docs/components/MessagingInputView.less
@@ -4,6 +4,10 @@
   .margin--bottom--xl;
 }
 
+.MessagingInputView--beta {
+  .text--italic();
+}
+
 .MessagingInputView--configContainer {
   .border--top--l(@neutral_silver);
   .margin--top--xl;

--- a/docs/components/MessagingThreadHistoryView.jsx
+++ b/docs/components/MessagingThreadHistoryView.jsx
@@ -4,11 +4,12 @@ import moment from "moment";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import { MessagingThreadHistory, FlexBox, ItemAlign, Button, MessagingBubble } from "src";
+import { MessagingThreadHistory, FlexBox, ItemAlign, Button, MessagingBubble, Label } from "src";
 
 import "./MessagingThreadHistoryView.less";
 
 const cssClass = {
+  BETA: "MessagingThreadHistoryView--beta",
   CONFIG_CONTAINER: "MessagingThreadHistoryView--configContainer",
   CONFIG_OPTIONS: "MessagingThreadHistoryView--configOptions",
   CONFIG: "MessagingThreadHistoryView--config",
@@ -65,6 +66,10 @@ export default class MessagingThreadHistoryView extends React.PureComponent {
         sourcePath="src/MessagingThreadHistory/MessagingThreadHistory.tsx"
       >
         <header className={cssClass.INTRO}>
+          <p className={cssClass.BETA}>
+            <Label color="new-feature">Beta</Label> MessagingThreadHistory is in Beta and breaking
+            changes may still be introduced.
+          </p>
           <p>
             MessagingThreadHistory is a container for messages between users, in the form of
             MessagingBubble or other data.

--- a/docs/components/MessagingThreadHistoryView.less
+++ b/docs/components/MessagingThreadHistoryView.less
@@ -4,6 +4,10 @@
   .margin--bottom--xl;
 }
 
+.MessagingThreadHistoryView--beta {
+  .text--italic();
+}
+
 .MessagingThreadHistoryView--configContainer {
   .border--top--l(@neutral_silver);
   .margin--top--xl;

--- a/docs/components/MessagingThreadListItemView.jsx
+++ b/docs/components/MessagingThreadListItemView.jsx
@@ -3,11 +3,12 @@ import * as React from "react";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import { MessagingThreadListItem, FlexBox, ItemAlign, SegmentedControl, Icon } from "src";
+import { MessagingThreadListItem, FlexBox, ItemAlign, SegmentedControl, Icon, Label } from "src";
 
 import "./MessagingThreadListItemView.less";
 
 const cssClass = {
+  BETA: "MessagingThreadListItemView--beta",
   CONFIG_CONTAINER: "MessagingThreadListItemView--configContainer",
   CONFIG_OPTIONS: "MessagingThreadListItemView--configOptions",
   CONFIG: "MessagingThreadListItemView--config",
@@ -37,6 +38,10 @@ export default class MessagingThreadListItemView extends React.PureComponent {
         sourcePath="src/MessagingThreadListItem/MessagingThreadListItem.tsx"
       >
         <header className={cssClass.INTRO}>
+          <p className={cssClass.BETA}>
+            <Label color="new-feature">Beta</Label> MessagingThreadHistory is in Beta and breaking
+            changes may still be introduced.
+          </p>
           <p>
             MessagingThreadListItem is used for showing a preview of a single thread in a list of
             them.

--- a/docs/components/MessagingThreadListItemView.less
+++ b/docs/components/MessagingThreadListItemView.less
@@ -4,6 +4,10 @@
   .margin--bottom--xl;
 }
 
+.MessagingThreadListItemView--beta {
+  .text--italic();
+}
+
 .MessagingThreadListItemView--configContainer {
   .border--top--l(@neutral_silver);
   .margin--top--xl;

--- a/docs/components/SideBar/SideBar.jsx
+++ b/docs/components/SideBar/SideBar.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import * as PropTypes from "prop-types";
 import { Link as ReactRouterLink, routerShape } from "react-router";
 
-import { Icon, LeftNav } from "../../../src";
+import { Icon, LeftNav, Label } from "../../../src";
 
 import "./SideBar.less";
 
@@ -20,15 +20,24 @@ export default class SideBar extends React.Component {
     this.setState({ collapsed: !this.state.collapsed });
   }
 
-  _renderLink(path, label, icon = null) {
+  _renderLink(path, label, options = { icon: null, beta: false }) {
     const { NavLink } = LeftNav;
     const { router } = this.context;
+
+    let betaLabel;
+    if (options.beta) {
+      betaLabel = (
+        <span>
+          {label} <Label color="new-feature">Beta</Label>
+        </span>
+      );
+    }
 
     return (
       <NavLink
         component={ReactRouterLink}
-        icon={icon}
-        label={label}
+        icon={options.icon}
+        label={options.beta ? betaLabel : label}
         selected={router.isActive(path)}
         to={path}
       />
@@ -54,9 +63,11 @@ export default class SideBar extends React.Component {
         withActiveNavGroups
         withTooltips
       >
-        {this._renderLink("/component-list", "Component List", icon(Icon.names.PORTAL_OPEN))}
-        {this._renderLink("/intro", "Introduction", icon(Icon.names.PRESENTATION))}
-        {this._renderLink("/getting-started", "Getting Started", icon(Icon.names.BLOCKS))}
+        {this._renderLink("/component-list", "Component List", {
+          icon: icon(Icon.names.PORTAL_OPEN),
+        })}
+        {this._renderLink("/intro", "Introduction", { icon: icon(Icon.names.PRESENTATION) })}
+        {this._renderLink("/getting-started", "Getting Started", { icon: icon(Icon.names.BLOCKS) })}
         <NavGroup id="design" label="Design" icon={icon(Icon.names.ORIGAMI)}>
           {this._renderLink("/design/colors", "Colors")}
           {this._renderLink("/design/typography", "Typography")}
@@ -93,11 +104,15 @@ export default class SideBar extends React.Component {
           {this._renderLink("/components/list", "List")}
           {this._renderLink("/components/logo", "Logo")}
           {this._renderLink("/components/menu", "Menu")}
-          {this._renderLink("/components/messaging-avatar", "MessagingAvatar")}
-          {this._renderLink("/components/messaging-bubble", "MessagingBubble")}
-          {this._renderLink("/components/messaging-input", "MessagingInput")}
-          {this._renderLink("/components/messaging-thread-history", "MessagingThreadHistory")}
-          {this._renderLink("/components/messaging-thread-list-item", "MessagingThreadListItem")}
+          {this._renderLink("/components/messaging-avatar", "MessagingAvatar", { beta: true })}
+          {this._renderLink("/components/messaging-bubble", "MessagingBubble", { beta: true })}
+          {this._renderLink("/components/messaging-input", "MessagingInput", { beta: true })}
+          {this._renderLink("/components/messaging-thread-history", "MessagingThreadHistory", {
+            beta: true,
+          })}
+          {this._renderLink("/components/messaging-thread-list-item", "MessagingThreadListItem", {
+            beta: true,
+          })}
           {this._renderLink("/components/modal", "Modal")}
           {this._renderLink("/components/modal-button", "ModalButton")}
           {this._renderLink("/components/multiple-panel-modals", "MultiplePanelModals")}
@@ -112,7 +127,7 @@ export default class SideBar extends React.Component {
           {this._renderLink("/components/switch", "Switch")}
           {this._renderLink("/components/tab-bar", "TabBar")}
           {this._renderLink("/components/table", "Table")}
-          {this._renderLink("/components/table-2-beta", "Table2Beta")}
+          {this._renderLink("/components/table-2-beta", "Table2Beta", { beta: true })}
           {this._renderLink("/components/text-area", "TextArea")}
           {this._renderLink("/components/text-input", "TextInput")}
           {this._renderLink("/components/text-truncate", "TextTruncate")}

--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -14,6 +14,7 @@ import {
   FlexBox,
   ItemAlign,
   SegmentedControl,
+  Label,
 } from "src";
 
 import "./Table2BetaView.less";
@@ -72,6 +73,10 @@ export default class Table2BetaView extends React.PureComponent {
         title="Table 2 Beta"
         sourcePath="src/Table2Beta/Table2Beta.tsx"
       >
+        <p className={cssClass.BETA}>
+          <Label color="new-feature">Beta</Label> Table 2 Beta is in Beta and breaking changes may
+          still be introduced.
+        </p>
         <p>
           This table component extends the original Table component, but now supports selection,
           among other things.
@@ -547,6 +552,7 @@ export default class Table2BetaView extends React.PureComponent {
 }
 
 Table2BetaView.cssClass = {
+  BETA: "Table2BetaView--beta",
   CONFIG: "Table2BetaView--config",
   CONFIG_OPTIONS: "Table2BetaView--configOptions",
   CONTAINER: "Table2BetaView",

--- a/docs/components/Table2BetaView.less
+++ b/docs/components/Table2BetaView.less
@@ -1,5 +1,9 @@
 @import (reference) "~less/index";
 
+.Table2BetaView--beta {
+  .text--italic();
+}
+
 .Table2BetaView--config {
   .margin--y--s;
   .margin--left--none;

--- a/src/LeftNav/sizing.less
+++ b/src/LeftNav/sizing.less
@@ -5,7 +5,7 @@
 @linkPaddingLeft: @size_m;
 @linkIconWidth: @size_l;
 @linkIconMarginRight: @size_s;
-@linkLabelWidth: 6.75rem;
+@linkLabelWidth: 8.75rem;
 @linkArrowMarginLeft: @size_xs;
 @linkArrowWidth: @size_m;
 @linkArrowMarginRight: @size_xs;


### PR DESCRIPTION

**Overview:**
As discussed at Frontend guild, we want to allow breaking changes to messaging components without forcing a major version bump. The compromise discussed was to mark these components as Beta.

<img width="1443" alt="Screen Shot 2020-08-31 at 11 03 16 AM" src="https://user-images.githubusercontent.com/26425483/91755244-a764da80-eb7f-11ea-89dc-e0c41920a0ee.png">


**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
