### PR TITLE
Reapply pagination changes

### DIFF
--- a/docs/components/MessagingThreadHistoryView.jsx
+++ b/docs/components/MessagingThreadHistoryView.jsx
@@ -21,6 +21,7 @@ const cssClass = {
 // Start with an older time so we can better display the day separators.
 // We display any dates in the future as "today".
 const newestTime = moment().subtract(1, "week");
+let currentMessageIndex = -1;
 
 function randomElement(items) {
   return items[Math.floor(Math.random() * items.length)];
@@ -30,6 +31,7 @@ function newMessage() {
   const message = randomElement(["Hello!", "Hi!", "How are you doing?"]);
   const placement = randomElement(["left", "right"]);
   newestTime.add(6, "hours");
+  currentMessageIndex++;
   return {
     content: (
       <MessagingBubble theme={placement === "left" ? "otherMessage" : "ownMessage"}>
@@ -38,6 +40,7 @@ function newMessage() {
     ),
     placement,
     timestamp: new Date(newestTime),
+    index: currentMessageIndex,
   };
 }
 
@@ -117,6 +120,13 @@ export default class MessagingThreadHistoryView extends React.PureComponent {
             name: "messages",
             type: "MessageData[]",
             description: "The data for messages to display in the history.",
+          },
+          {
+            name: "ref",
+            type: "React.Ref<HTMLDivElement>",
+            description:
+              "Allows getting a ref to the underlying div container. Required for auto scrolling on new messages.",
+            optional: true,
           },
           {
             name: "className",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.51.0",
+  "version": "2.52.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/MessagingThreadHistory.less
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.less
@@ -3,7 +3,6 @@
 .ThreadHistory--Container {
   overflow-y: auto;
   .padding--right--s();
-  flex-direction: column;
 }
 
 .ThreadHistory--Divider {

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { useEffect, useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 import * as classNames from "classnames";
 import * as moment from "moment";
-
-import { FlexBox } from "../index";
 import { MessageMetadata } from "./MessageMetadata";
+import { cssClass as FlexBoxCSS } from "../flex/FlexBox";
+import { cssClass as FlexItemCSS } from "../flex/FlexItem";
 
 import "./MessagingThreadHistory.less";
 
@@ -19,6 +19,7 @@ export interface MessageData {
   placement: "left" | "right" | "center";
   timestamp?: Date;
   content: React.ReactNode;
+  index: number;
 }
 
 interface Props {
@@ -27,30 +28,69 @@ interface Props {
   messages: MessageData[];
 }
 
-export const MessagingThreadHistory: React.FC<Props> = ({
-  className,
-  threadID,
-  messages,
-}: Props) => {
-  const lastMessageRef = useRef<HTMLDivElement>(null);
-  const messagesWithDividers = _interleaveMessagesWithDividers(messages, lastMessageRef);
+const SCROLL_BUFFER = 200;
 
-  // We want to scroll to the bottom if there is a new message (received in real-time, or
-  //  user just sent one themselves) or if the user switches to another thread. Cannot rely
-  //  on messages themselves (new reference each render) nor on message count alone (different
-  //  threads can have the same message count). Instead, need the threadID AND message count.
-  useEffect(() => {
-    if (messages.length > 0) {
-      lastMessageRef.current.scrollIntoView();
-    }
-  }, [messages.length, threadID]);
-
+// Always returns true with current mobile strategy of scrolling the entire thread history
+function isScrolledToBottom(ref: React.MutableRefObject<HTMLDivElement>) {
   return (
-    <FlexBox grow className={classNames(cssClasses.CONTAINER, className)}>
-      {messagesWithDividers}
-    </FlexBox>
+    ref &&
+    ref.current &&
+    ref.current.scrollTop + SCROLL_BUFFER >= ref.current.scrollHeight - ref.current.clientHeight
   );
-};
+}
+
+function isOwnMessage(message: MessageData) {
+  return message.placement === "right";
+}
+
+export const MessagingThreadHistory = React.forwardRef(
+  (
+    { className, threadID, messages }: Props,
+    containerRef: React.MutableRefObject<HTMLDivElement>,
+  ) => {
+    const lastMessageRef = useRef<HTMLDivElement>(null);
+    const lastMessageIndex = useRef(
+      messages.length > 0 ? messages[messages.length - 1].index : null,
+    );
+    const messagesWithDividers = _interleaveMessagesWithDividers(messages, lastMessageRef);
+
+    // Scroll to the bottom if the user switches to a new non-null thread
+    useLayoutEffect(() => {
+      if (lastMessageRef.current) {
+        lastMessageRef.current.scrollIntoView();
+      }
+    }, [threadID]);
+
+    // Scroll to bottom if the user sends a new message
+    //  or if they are viewing the last message when a new message comes in
+    useLayoutEffect(() => {
+      const isNewMessage =
+        messages.length > 0 && messages[messages.length - 1].index !== lastMessageIndex.current;
+      if (isNewMessage) {
+        const newMessage = messages[messages.length - 1];
+        if (isOwnMessage(newMessage) || isScrolledToBottom(containerRef)) {
+          lastMessageRef.current.scrollIntoView();
+        }
+        lastMessageIndex.current = newMessage.index;
+      }
+    }, [messages]);
+
+    return (
+      <div
+        className={classNames(
+          cssClasses.CONTAINER,
+          FlexBoxCSS.FLEXBOX,
+          FlexBoxCSS.COLUMN,
+          FlexItemCSS.GROW,
+          className,
+        )}
+        ref={containerRef}
+      >
+        {messagesWithDividers}
+      </div>
+    );
+  },
+);
 
 function _interleaveMessagesWithDividers(
   messages: MessageData[],
@@ -76,7 +116,7 @@ function _interleaveMessagesWithDividers(
     // All content is wrapped in MessageMetadata, which handles placement and timestamps.
     messagesWithDividers.push(
       <MessageMetadata
-        key={`message-${i}`}
+        key={`message-${message.index}`}
         // Last message in the history gets a ref, to allow scrolling down to bottom message.
         ref={i === messages.length - 1 ? lastMessageRef : undefined}
         placement={message.placement}


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/SSOAP-2655

**Overview:**
This reapplies this pr - https://github.com/Clever/components/pull/508
It allows for paging for MessagingThreadHistory

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change? Run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
