### PR TITLE
Table2beta: selected users row

### DIFF
--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -19,6 +19,42 @@ import {
 
 import "./Table2BetaView.less";
 
+const sampleActionInputs = [
+  {
+    callback: selectedRows => {
+      // for (var row of Array.from(selectedRows.values())) {
+      //   console.log(row.name);
+      // }
+      console.log(selectedRows);
+    },
+    title: { singular: "Launch an app" },
+    icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
+  },
+  {
+    callback: () => console.log("sampleAction 2"),
+    title: { singular: "Log out student", plural: "Log out students" },
+    icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
+  },
+  {
+    callback: () => console.log("sampleAction 1"),
+    title: { singular: "Download badge", plural: "Download badges" },
+  },
+  {
+    callback: () => console.log("sampleAction 2"),
+    title: { singular: "Download username", plural: "Download usernames" },
+    icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
+  },
+  // {
+  //   callback: () => console.log("sampleAction 1"),
+  //   title: "Do this action",
+  // },
+  // {
+  //   callback: () => console.log("sampleAction 2"),
+  //   title: "Do another action",
+  //   icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
+  // },
+];
+
 export default class Table2BetaView extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -140,10 +176,11 @@ export default class Table2BetaView extends React.PureComponent {
                 rowIDFn={r => r.id}
                 rowClassNameFn={r => (r.age < 10 ? "additionalClass" : null)}
                 selectable={enableSelectable}
-                contentType={{
+                selectedRowsHeaderContentType={{
                   singular: this.state.tableFilter,
                   plural: `${this.state.tableFilter}s`,
                 }}
+                selectedRowsHeaderActions={sampleActionInputs}
               >
                 <Table2Beta.Column
                   id="details"

--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -35,6 +35,16 @@ const sampleActionInputs = [
   {
     callback: () => console.log("sampleAction 1"),
     title: { singular: "Download badge", plural: "Download badges" },
+    icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
+  },
+  {
+    callback: () => console.log("sampleAction 2"),
+    title: { singular: "Download username", plural: "Download usernames" },
+    icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
+  },
+  {
+    callback: () => console.log("sampleAction 1"),
+    title: { singular: "Download badge", plural: "Download badges" },
   },
   {
     callback: () => console.log("sampleAction 2"),
@@ -129,6 +139,7 @@ export default class Table2BetaView extends React.PureComponent {
           <div style={{ marginTop: "20px" }}>
             <ExampleCode>
               <Table2Beta
+                className={cssClass.TABLE}
                 data={tableData}
                 filter={rowData =>
                   !this.state.tableFilter ||
@@ -441,6 +452,14 @@ export default class Table2BetaView extends React.PureComponent {
               optional: true,
               defaultValue: "None",
             },
+            {
+              name: "numDisplayedActions",
+              type: "number",
+              description:
+                "Number of actions to show in SelectedRowsHeader. If there are greater than this number of actions in selectedRowsHeaderActions, they will appear in an'Ellipse' dropdown menu at the right of the actions",
+              optional: true,
+              defaultValue: "4",
+            },
           ]}
           title="Table 2 Beta"
         />
@@ -601,4 +620,5 @@ Table2BetaView.cssClass = {
   CONFIG: "Table2BetaView--config",
   CONFIG_OPTIONS: "Table2BetaView--configOptions",
   CONTAINER: "Table2BetaView",
+  TABLE: "Table2BetaView--table",
 };

--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -22,9 +22,6 @@ import "./Table2BetaView.less";
 const sampleActionInputs = [
   {
     callback: selectedRows => {
-      // for (var row of Array.from(selectedRows.values())) {
-      //   console.log(row.name);
-      // }
       console.log(selectedRows);
     },
     title: { singular: "Launch an app" },
@@ -44,15 +41,6 @@ const sampleActionInputs = [
     title: { singular: "Download username", plural: "Download usernames" },
     icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
   },
-  // {
-  //   callback: () => console.log("sampleAction 1"),
-  //   title: "Do this action",
-  // },
-  // {
-  //   callback: () => console.log("sampleAction 2"),
-  //   title: "Do another action",
-  //   icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
-  // },
 ];
 
 export default class Table2BetaView extends React.PureComponent {
@@ -438,12 +426,20 @@ export default class Table2BetaView extends React.PureComponent {
               optional: true,
             },
             {
-              name: "contentType",
+              name: "selectedRowsHeaderContentType",
               type: "{ singular: string; plural?: string }",
               description:
-                'Description of the content displayed in the rows of the table. I.e. "student", "student in grade", etc.',
+                'Description of the content displayed in the rows of the table. I.e. "student", "student in grade", etc. This is used in the SelectedRowsHeader: "Select a <selectedRowsHeaderContentType>"',
               optional: true,
               defaultValue: '{ singular: "row", plural: "rows" }',
+            },
+            {
+              name: "selectedRowsHeaderActions",
+              type: "Array<ActionInput>",
+              description:
+                "An array of ActionInputs. These are the actions shown in SelectedRowsHeader. Each ActionInput contains a callback which takes props `(selectedRows: Set<any>)`, a title object `{ singular: string; plural?: string }`, and an icon url",
+              optional: true,
+              defaultValue: "None",
             },
           ]}
           title="Table 2 Beta"

--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -18,6 +18,7 @@ import {
 } from "src";
 
 import "./Table2BetaView.less";
+import FontAwesome from "react-fontawesome";
 
 const sampleActionInputs = [
   {
@@ -38,13 +39,16 @@ const sampleActionInputs = [
     icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
   },
   {
+    callback: () => console.log("sampleAction 1"),
+    title: {
+      singular: [<FontAwesome name="question-circle" />, " Do action with FontAwesome"],
+      plural: [<FontAwesome name="question-circle" />, " Do actions with FontAwesome"],
+    },
+  },
+  {
     callback: () => console.log("sampleAction 2"),
     title: { singular: "Download username", plural: "Download usernames" },
     icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
-  },
-  {
-    callback: () => console.log("sampleAction 1"),
-    title: { singular: "Download badge", plural: "Download badges" },
   },
   {
     callback: () => console.log("sampleAction 2"),
@@ -448,7 +452,7 @@ export default class Table2BetaView extends React.PureComponent {
               name: "selectedRowsHeaderActions",
               type: "Array<ActionInput>",
               description:
-                "An array of ActionInputs. These are the actions shown in SelectedRowsHeader. Each ActionInput contains a callback which takes props `(selectedRows: Set<any>)`, a title object `{ singular: string; plural?: string }`, and an icon url",
+                "An array of ActionInputs. These are the actions shown in SelectedRowsHeader. Each ActionInput contains a callback which takes props `(selectedRows: Set<any>)`, a title object `{ singular: React.ReactNode; plural?: React.ReactNode }`, and an optional icon url. Title.singular and plural can be a string, or a single or list of React elements if you want to include FontAwesome, etc",
               optional: true,
               defaultValue: "None",
             },

--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -140,6 +140,10 @@ export default class Table2BetaView extends React.PureComponent {
                 rowIDFn={r => r.id}
                 rowClassNameFn={r => (r.age < 10 ? "additionalClass" : null)}
                 selectable={enableSelectable}
+                contentType={{
+                  singular: this.state.tableFilter,
+                  plural: `${this.state.tableFilter}s`,
+                }}
               >
                 <Table2Beta.Column
                   id="details"
@@ -395,6 +399,14 @@ export default class Table2BetaView extends React.PureComponent {
               type: "boolean",
               description: "Adds selectable checkboxes to the table",
               optional: true,
+            },
+            {
+              name: "contentType",
+              type: "{ singular: string; plural?: string }",
+              description:
+                'Description of the content displayed in the rows of the table. I.e. "student", "student in grade", etc.',
+              optional: true,
+              defaultValue: '{ singular: "row", plural: "rows" }',
             },
           ]}
           title="Table 2 Beta"

--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -41,8 +41,16 @@ const sampleActionInputs = [
   {
     callback: () => console.log("sampleAction 1"),
     title: {
-      singular: [<FontAwesome name="question-circle" />, " Do action with FontAwesome"],
-      plural: [<FontAwesome name="question-circle" />, " Do actions with FontAwesome"],
+      singular: (
+        <div>
+          <FontAwesome name="question-circle" /> Do action with FontAwesome
+        </div>
+      ),
+      plural: (
+        <div>
+          <FontAwesome name="question-circle" /> Do actions with FontAwesome
+        </div>
+      ),
     },
   },
   {
@@ -452,7 +460,7 @@ export default class Table2BetaView extends React.PureComponent {
               name: "selectedRowsHeaderActions",
               type: "Array<ActionInput>",
               description:
-                "An array of ActionInputs. These are the actions shown in SelectedRowsHeader. Each ActionInput contains a callback which takes props `(selectedRows: Set<any>)`, a title object `{ singular: React.ReactNode; plural?: React.ReactNode }`, and an optional icon url. Title.singular and plural can be a string, or a single or list of React elements if you want to include FontAwesome, etc",
+                "An array of ActionInputs. These are the actions shown in SelectedRowsHeader. Each ActionInput contains a callback which takes props `(selectedRows: Set<any>)`, a title object `{ singular: React.ReactNode; plural?: React.ReactNode }`, and an optional icon url. Title.singular and plural can be a string, or a React element if you want to include FontAwesome, etc",
               optional: true,
               defaultValue: "None",
             },

--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -177,8 +177,8 @@ export default class Table2BetaView extends React.PureComponent {
                 rowClassNameFn={r => (r.age < 10 ? "additionalClass" : null)}
                 selectable={enableSelectable}
                 selectedRowsHeaderContentType={{
-                  singular: this.state.tableFilter,
-                  plural: `${this.state.tableFilter}s`,
+                  singular: this.state.tableFilter || "",
+                  plural: !!this.state.tableFilter ? `${this.state.tableFilter}s` : "",
                 }}
                 selectedRowsHeaderActions={sampleActionInputs}
               >

--- a/docs/components/Table2BetaView.less
+++ b/docs/components/Table2BetaView.less
@@ -27,3 +27,13 @@
   background-color: @alert_red;
   color: @neutral_white;
 }
+
+// For testing compatibility with Analytics Actions
+// Not necessary long term
+.Table2BetaView--table {
+  max-width: 64rem;
+}
+// Accounting for 2rem padding and 2px border
+.Table2Beta--selectedRowsHeader {
+  max-width: calc(62rem - 2px);
+}

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/jest": "^20.0.8",
     "@types/jest-matchers": "^20.0.0",
     "@types/node": "^12.12.51",
-    "@types/react": "^16.8.6",
+    "@types/react": "^16.9.49",
     "@typescript-eslint/eslint-plugin": "^1.9.0",
     "@typescript-eslint/parser": "^1.9.0",
     "autoprefixer": "^6.5.3",

--- a/src/Table2Beta/HeaderCell.less
+++ b/src/Table2Beta/HeaderCell.less
@@ -28,7 +28,7 @@
 
 .Table--header--cell--sort_icons {
   fill: darken(@neutral_silver, 5%);
-  margin-left: 5px;
+  margin-left: 0.3125rem;
   transition: fill 0.25s ease-out;
   vertical-align: middle;
 

--- a/src/Table2Beta/SelectedRowsHeader.less
+++ b/src/Table2Beta/SelectedRowsHeader.less
@@ -1,0 +1,16 @@
+@import (reference) "../less/utilities.less";
+
+.Table2Beta--selectedRowsHeader {
+  height: 3rem;
+  border: @size_4xs solid @neutral_silver;
+  border-collapse: collapse;
+  .cardHeader();
+}
+
+.Table2Beta--selectedRowsHeader--titleCell {
+  padding: 0.75rem;
+}
+
+.Table2Beta--selectedRowsHeader--actionsCell {
+  padding: 0.75rem;
+}

--- a/src/Table2Beta/SelectedRowsHeader.less
+++ b/src/Table2Beta/SelectedRowsHeader.less
@@ -37,9 +37,11 @@
   padding: 0.5rem;
   border-radius: 0.25rem;
 }
+
 .Table2Beta--selectedRowsHeader--action:last-of-type {
   margin-right: 0;
 }
+
 .Table2Beta--selectedRowsHeader--action:hover {
   background-color: #f6f7fe;
 }

--- a/src/Table2Beta/SelectedRowsHeader.less
+++ b/src/Table2Beta/SelectedRowsHeader.less
@@ -69,11 +69,6 @@
   color: #2f4ca9;
 }
 
-// .Table2Beta--selectedRowsHeader--actionMenu ul:hover {
-//   background-color: none;
-//   color: @primary_blue;
-// }
-
 .Table2Beta--selectedRowsHeader--actionMenu--trigger {
   vertical-align: middle;
 }

--- a/src/Table2Beta/SelectedRowsHeader.less
+++ b/src/Table2Beta/SelectedRowsHeader.less
@@ -14,3 +14,29 @@
 .Table2Beta--selectedRowsHeader--actionsCell {
   padding: 0.75rem;
 }
+
+.Table2Beta--selectedRowsHeader--actionsFlexbox {
+  flex-wrap: wrap;
+  margin-top: -1rem;
+  // in the future, replace wth row-gap and column-gap, currently not supported in Safari
+  // row-gap: 1rem;
+  // column-gap: 1.5rem;
+}
+
+.Table2Beta--selectedRowsHeader--action {
+  margin: 1rem 1.5rem 0 0;
+  cursor: pointer;
+}
+
+.Table2Beta--selectedRowsHeader--actionIcon {
+  height: 1.25rem;
+  width: 1.25rem;
+  margin-right: 0.3125rem;
+}
+
+.Table2Beta--selectedRowsHeader--actionTitle {
+  .text--medium;
+  .text--semi-bold;
+  font-family: "Proxima Nova";
+  white-space: nowrap;
+}

--- a/src/Table2Beta/SelectedRowsHeader.less
+++ b/src/Table2Beta/SelectedRowsHeader.less
@@ -1,21 +1,27 @@
 @import (reference) "../less/utilities.less";
 
 .Table2Beta--selectedRowsHeader {
-  height: 3rem;
+  height: 1.5rem;
+  line-height: 1.5rem;
   .border--s(@neutral_silver);
-  // not working
-  .borderRadius--top--m;
+  .borderRadius--top--l;
   border-collapse: collapse;
-  .cardHeader();
+  .padding--x--m;
+  .padding--y--m;
+  .text--medium;
+  .text--semi-bold;
+  background-color: @neutral_off_white;
+  color: @neutral_dark_gray;
+  font-family: "Proxima Nova";
 }
 
-.Table2Beta--selectedRowsHeader--titleCell {
-  padding: 0.75rem;
-}
+// .Table2Beta--selectedRowsHeader--titleCell {
+// padding: 0.75rem;
+// }
 
-.Table2Beta--selectedRowsHeader--actionsCell {
-  padding: 0.75rem;
-}
+// .Table2Beta--selectedRowsHeader--actionsCell {
+// padding: 0.75rem;
+// }
 
 .Table2Beta--selectedRowsHeader--actionsFlexbox {
   flex-wrap: wrap;
@@ -26,19 +32,57 @@
 }
 
 .Table2Beta--selectedRowsHeader--action {
-  margin: 1rem 1.5rem 0 0;
+  margin: 0.5rem 0.5rem 0 0;
   cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+}
+.Table2Beta--selectedRowsHeader--action:last-of-type {
+  margin-right: 0;
+}
+.Table2Beta--selectedRowsHeader--action:hover {
+  background-color: #f6f7fe;
 }
 
 .Table2Beta--selectedRowsHeader--actionIcon {
-  // height: 100%;
+  display: inline-block;
+  height: 1.5rem;
   width: 1.25rem;
   margin-right: 0.3125rem;
 }
 
 .Table2Beta--selectedRowsHeader--actionTitle {
+  display: inline-block;
   .text--medium;
   .text--semi-bold;
   font-family: "Proxima Nova";
   white-space: nowrap;
+  vertical-align: middle;
+}
+
+.Table2Beta--selectedRowsHeader--actionMenu {
+  margin: 0.5rem 0 0 0.5rem;
+  padding: 0.375rem 0 0.625rem 0;
+  width: 1.25rem;
+  text-align: center;
+  color: @primary_blue;
+  cursor: pointer;
+  border-radius: 0.25rem;
+}
+
+.Table2Beta--selectedRowsHeader--actionMenu:hover {
+  background-color: #f6f7fe;
+  color: #2f4ca9;
+}
+
+.Table2Beta--selectedRowsHeader--actionMenu--trigger {
+  vertical-align: middle;
+}
+
+.Table2Beta--selectedRowsHeader--actionMenu--item img {
+  vertical-align: middle;
+}
+
+.Table2Beta--selectedRowsHeader--actionMenu--item--title {
+  line-height: 1.5rem;
 }

--- a/src/Table2Beta/SelectedRowsHeader.less
+++ b/src/Table2Beta/SelectedRowsHeader.less
@@ -2,7 +2,9 @@
 
 .Table2Beta--selectedRowsHeader {
   height: 3rem;
-  border: @size_4xs solid @neutral_silver;
+  .border--s(@neutral_silver);
+  // not working
+  .borderRadius--top--m;
   border-collapse: collapse;
   .cardHeader();
 }
@@ -29,7 +31,7 @@
 }
 
 .Table2Beta--selectedRowsHeader--actionIcon {
-  height: 1.25rem;
+  // height: 100%;
   width: 1.25rem;
   margin-right: 0.3125rem;
 }

--- a/src/Table2Beta/SelectedRowsHeader.less
+++ b/src/Table2Beta/SelectedRowsHeader.less
@@ -15,14 +15,6 @@
   font-family: "Proxima Nova";
 }
 
-// .Table2Beta--selectedRowsHeader--titleCell {
-// padding: 0.75rem;
-// }
-
-// .Table2Beta--selectedRowsHeader--actionsCell {
-// padding: 0.75rem;
-// }
-
 .Table2Beta--selectedRowsHeader--actionsFlexbox {
   flex-wrap: wrap;
   margin-top: -1rem;
@@ -76,6 +68,11 @@
   background-color: #f6f7fe;
   color: #2f4ca9;
 }
+
+// .Table2Beta--selectedRowsHeader--actionMenu ul:hover {
+//   background-color: none;
+//   color: @primary_blue;
+// }
 
 .Table2Beta--selectedRowsHeader--actionMenu--trigger {
   vertical-align: middle;

--- a/src/Table2Beta/SelectedRowsHeader.tsx
+++ b/src/Table2Beta/SelectedRowsHeader.tsx
@@ -17,8 +17,6 @@ interface Props {
 
 const cssClasses = {
   ROW: "Table2Beta--selectedRowsHeader",
-  TITLE_CELL: "Table2Beta--selectedRowsHeader--titleCell",
-  ACTIONS_CELL: "Table2Beta--selectedRowsHeader--actionsCell",
   ACTIONS_FLEXBOX: "Table2Beta--selectedRowsHeader--actionsFlexbox",
   ACTION: "Table2Beta--selectedRowsHeader--action",
   ACTION_ICON: "Table2Beta--selectedRowsHeader--actionIcon",
@@ -26,6 +24,7 @@ const cssClasses = {
   ACTION_MENU: "Table2Beta--selectedRowsHeader--actionMenu",
   ACTION_MENU_TRIGGER: "Table2Beta--selectedRowsHeader--actionMenu--trigger",
   ACTION_MENU_ITEM: "Table2Beta--selectedRowsHeader--actionMenu--item",
+  ACTION_MENU_ITEM_TITLE: "Table2Beta--selectedRowsHeader--actionMenu--item--title",
 };
 
 export default function SelectedRowsHeader({
@@ -50,7 +49,7 @@ export default function SelectedRowsHeader({
   return (
     <>
       <FlexBox grow className={cssClasses.ROW}>
-        <FlexItem grow className={cssClasses.TITLE_CELL}>
+        <FlexItem grow>
           {!rowsAreSelected && <div>Select {contentType.plural || "rows"} to access tools</div>}
           {rowsAreSelected && !allSelected && (
             <>
@@ -65,7 +64,7 @@ export default function SelectedRowsHeader({
             <div>{`All ${contentType.plural || "rows"} selected (${selectedRows.size})`}</div>
           )}
         </FlexItem>
-        <FlexItem className={cssClasses.ACTIONS_CELL}>
+        <FlexItem>
           <FlexBox className={cssClasses.ACTIONS_FLEXBOX}>
             {rowsAreSelected &&
               displayedActions.map(action => (
@@ -76,7 +75,6 @@ export default function SelectedRowsHeader({
                     icon: action.icon,
                   }}
                   selectedRows={selectedRows}
-                  // Is this necessary? Is it the ideal value?
                   key={action.title.singular}
                 />
               ))}
@@ -91,15 +89,20 @@ export default function SelectedRowsHeader({
                 placement={Menu.Placement.RIGHT}
               >
                 {moreActions.map(action => (
-                  <MenuAction
-                    actionInput={{
-                      callback: action.callback,
-                      title: action.title,
-                      icon: action.icon,
-                    }}
-                    selectedRows={selectedRows}
+                  <Menu.Item
+                    className={cssClasses.ACTION_MENU_ITEM}
+                    onClick={e => action.callback(selectedRows)}
                     key={action.title.singular}
-                  />
+                  >
+                    <div className={cssClasses.ACTION_MENU_ITEM_TITLE}>
+                      {action.icon && <img className={cssClasses.ACTION_ICON} src={action.icon} />}
+                      <div className={cssClasses.ACTION_TITLE}>
+                        {singleRowSelected || !action.title.plural
+                          ? action.title.singular
+                          : action.title.plural}
+                      </div>
+                    </div>
+                  </Menu.Item>
                 ))}
               </Menu>
             )}
@@ -130,24 +133,5 @@ function Action({ actionInput, selectedRows }: ActionProps) {
         </div>
       </a>
     </>
-  );
-}
-
-function MenuAction({ actionInput, selectedRows }: ActionProps) {
-  const { callback, title, icon } = actionInput;
-  const singleRowSelected = selectedRows.size === 1;
-  return (
-    <Menu.Item
-      className={cssClasses.ACTION_MENU_ITEM}
-      onClick={e => callback(selectedRows)}
-      key={title.singular}
-    >
-      <p className={"Table2Beta--selectedRowsHeader--actionMenu--item--title"}>
-        {icon && <img className={cssClasses.ACTION_ICON} src={icon} />}
-        <div className={cssClasses.ACTION_TITLE}>
-          {singleRowSelected || !title.plural ? title.singular : title.plural}
-        </div>
-      </p>
-    </Menu.Item>
   );
 }

--- a/src/Table2Beta/SelectedRowsHeader.tsx
+++ b/src/Table2Beta/SelectedRowsHeader.tsx
@@ -1,32 +1,44 @@
-// import { NewComponent } from "bin/NewComponent";
 import * as React from "react";
-// import * as PropTypes from "prop-types";
 
-// import * as tablePropTypes from "./tablePropTypes";
-// import Column from "./Column";
 import Cell from "src/Table/Cell";
-
 import "./SelectedRowsHeader.less";
+import { FlexBox } from "src/flex";
 
-export interface Props {
+interface Props {
   selectedRows: Set<any>;
   contentType?: string;
+  actions: Array<ActionInput>;
 }
 
-export const cssClass = {
+export interface ActionInput {
+  callback: () => void;
+  // callback(selectedRows: Set<any>): void;
+  // selectedRows?: Set<any>;
+  // Todo: Account for singular vs multiple selected
+  title: string;
+  // should icon be required?
+  icon?: string;
+}
+
+const cssClasses = {
   ROW: "Table2Beta--selectedRowsHeader",
   TITLE_CELL: "Table2Beta--selectedRowsHeader--titleCell",
   ACTIONS_CELL: "Table2Beta--selectedRowsHeader--actionsCell",
+  ACTIONS_FLEXBOX: "Table2Beta--selectedRowsHeader--actionsFlexbox",
+  ACTION: "Table2Beta--selectedRowsHeader--action",
+  ACTION_ICON: "Table2Beta--selectedRowsHeader--actionIcon",
+  ACTION_TITLE: "Table2Beta--selectedRowsHeader--actionTitle",
 };
 
-export default function SelectedRowsHeader({ selectedRows: selectedRows, contentType }: Props) {
+export default function SelectedRowsHeader({ selectedRows, contentType, actions }: Props) {
   const rowsAreSelected = selectedRows.size > 0;
   const singleRowSelected = selectedRows.size === 1;
 
+  // console.log(selectedRows);
   return (
     <>
-      <tr className={cssClass.ROW}>
-        <Cell class={cssClass.TITLE_CELL} colspan={3}>
+      <tr className={cssClasses.ROW}>
+        <Cell class={cssClasses.TITLE_CELL} colspan={3}>
           {/* Figure out how to not hard code colspans */}
           {!rowsAreSelected && <div>Select {contentType || "row"}s to access tools</div>}
           {rowsAreSelected && (
@@ -36,13 +48,32 @@ export default function SelectedRowsHeader({ selectedRows: selectedRows, content
             </div>
           )}
         </Cell>
-        <Cell class={cssClass.ACTIONS_CELL} colspan={3}>
-          {/* Figure out how to not hard code colspans */}
-          {rowsAreSelected && <div>PLACEHOLDER: Actions go here</div>}
+        <Cell class={cssClasses.ACTIONS_CELL} colspan={3}>
+          {/* Figure out how to not hard code colspans? */}
+          <FlexBox row className={cssClasses.ACTIONS_FLEXBOX}>
+            {rowsAreSelected &&
+              actions.map(action => (
+                <Action
+                  callback={action.callback}
+                  // selectedRows={selectedRows}
+                  title={action.title}
+                  icon={action.icon}
+                />
+              ))}
+          </FlexBox>
         </Cell>
       </tr>
     </>
   );
 }
 
-// SelectedRowsHeader.propTypes = {}
+function Action({ callback, title, icon }: ActionInput) {
+  return (
+    <>
+      <a className={`${cssClasses.ACTION} flexbox items--center`} onClick={e => callback()}>
+        {icon && <img className={cssClasses.ACTION_ICON} src={icon} />}
+        <div className={cssClasses.ACTION_TITLE}>{title}</div>
+      </a>
+    </>
+  );
+}

--- a/src/Table2Beta/SelectedRowsHeader.tsx
+++ b/src/Table2Beta/SelectedRowsHeader.tsx
@@ -1,0 +1,48 @@
+// import { NewComponent } from "bin/NewComponent";
+import * as React from "react";
+// import * as PropTypes from "prop-types";
+
+// import * as tablePropTypes from "./tablePropTypes";
+// import Column from "./Column";
+import Cell from "src/Table/Cell";
+
+import "./SelectedRowsHeader.less";
+
+export interface Props {
+  selectedRows: Set<any>;
+  contentType?: string;
+}
+
+export const cssClass = {
+  ROW: "Table2Beta--selectedRowsHeader",
+  TITLE_CELL: "Table2Beta--selectedRowsHeader--titleCell",
+  ACTIONS_CELL: "Table2Beta--selectedRowsHeader--actionsCell",
+};
+
+export default function SelectedRowsHeader({ selectedRows: selectedRows, contentType }: Props) {
+  const rowsAreSelected = selectedRows.size > 0;
+  const singleRowSelected = selectedRows.size === 1;
+
+  return (
+    <>
+      <tr className={cssClass.ROW}>
+        <Cell class={cssClass.TITLE_CELL} colspan={3}>
+          {/* Figure out how to not hard code colspans */}
+          {!rowsAreSelected && <div>Select {contentType || "row"}s to access tools</div>}
+          {rowsAreSelected && (
+            <div>
+              {selectedRows.size} {contentType || "row"}
+              {!singleRowSelected && "s"} selected
+            </div>
+          )}
+        </Cell>
+        <Cell class={cssClass.ACTIONS_CELL} colspan={3}>
+          {/* Figure out how to not hard code colspans */}
+          {rowsAreSelected && <div>PLACEHOLDER: Actions go here</div>}
+        </Cell>
+      </tr>
+    </>
+  );
+}
+
+// SelectedRowsHeader.propTypes = {}

--- a/src/Table2Beta/SelectedRowsHeader.tsx
+++ b/src/Table2Beta/SelectedRowsHeader.tsx
@@ -2,9 +2,9 @@ import * as React from "react";
 import * as FontAwesome from "react-fontawesome";
 
 import "./SelectedRowsHeader.less";
-import { FlexBox } from "../../src";
-import { FlexItem } from "src/flex";
-import Menu from "src/Menu";
+import { FlexBox } from "../";
+import { FlexItem } from "../flex";
+import Menu from "../Menu";
 import { ActionInput } from "./Table";
 
 interface Props {

--- a/src/Table2Beta/SelectedRowsHeader.tsx
+++ b/src/Table2Beta/SelectedRowsHeader.tsx
@@ -6,14 +6,13 @@ import { FlexBox } from "../../src";
 
 interface Props {
   selectedRows: Set<any>;
-  contentType?: string;
+  contentType?: { singular: string; plural?: string };
   actions: Array<ActionInput>;
 }
 
 export interface ActionInput {
   callback(selectedRows?: Set<any>): void;
   selectedRows?: Set<any>;
-  // Todo: Account for singular vs multiple selected
   title: { singular: string; plural?: string };
   // should icon be required?
   icon?: string;
@@ -39,11 +38,12 @@ export default function SelectedRowsHeader({ selectedRows, contentType, actions 
       <tr className={cssClasses.ROW}>
         <Cell className={cssClasses.TITLE_CELL} colSpan={3}>
           {/* Figure out how to not hard code colspans */}
-          {!rowsAreSelected && <div>Select {contentType || "row"}s to access tools</div>}
+          {!rowsAreSelected && <div>Select {contentType.plural || "rows"} to access tools</div>}
           {rowsAreSelected && (
             <div>
-              {selectedRows.size} {contentType || "row"}
-              {!singleRowSelected && "s"} selected
+              {selectedRows.size}{" "}
+              {singleRowSelected ? contentType.singular || "row" : contentType.plural || "rows"}{" "}
+              selected
             </div>
           )}
         </Cell>

--- a/src/Table2Beta/SelectedRowsHeader.tsx
+++ b/src/Table2Beta/SelectedRowsHeader.tsx
@@ -11,8 +11,7 @@ interface Props {
 }
 
 export interface ActionInput {
-  callback(selectedRows?: Set<any>): void;
-  selectedRows?: Set<any>;
+  callback(selectedRows: Set<any>): void;
   title: { singular: string; plural?: string };
   // should icon be required?
   icon?: string;
@@ -53,10 +52,12 @@ export default function SelectedRowsHeader({ selectedRows, contentType, actions 
             {rowsAreSelected &&
               actions.map(action => (
                 <Action
-                  callback={action.callback}
+                  actionInput={{
+                    callback: action.callback,
+                    title: action.title,
+                    icon: action.icon,
+                  }}
                   selectedRows={selectedRows}
-                  title={action.title}
-                  icon={action.icon}
                   // Is this necessary? Is it the ideal value?
                   key={action.title.singular}
                 />
@@ -68,13 +69,19 @@ export default function SelectedRowsHeader({ selectedRows, contentType, actions 
   );
 }
 
-function Action({ callback, selectedRows, title, icon }: ActionInput) {
+interface ActionProps {
+  actionInput: ActionInput;
+  selectedRows: Set<any>;
+}
+
+function Action({ actionInput, selectedRows }: ActionProps) {
+  const { callback, title, icon } = actionInput;
   const singleRowSelected = selectedRows.size === 1;
   return (
     <>
       <a
         className={`${cssClasses.ACTION} flexbox items--center`}
-        onClick={e => (selectedRows ? callback(selectedRows) : callback())}
+        onClick={e => callback(selectedRows)}
       >
         {icon && <img className={cssClasses.ACTION_ICON} src={icon} />}
         <div className={cssClasses.ACTION_TITLE}>

--- a/src/Table2Beta/SelectedRowsHeader.tsx
+++ b/src/Table2Beta/SelectedRowsHeader.tsx
@@ -37,7 +37,6 @@ export default function SelectedRowsHeader({
   const rowsAreSelected = selectedRows.size > 0;
   const singleRowSelected = selectedRows.size === 1;
 
-  // console.log(selectedRows);
   return (
     <>
       <tr className={cssClasses.ROW}>
@@ -61,6 +60,7 @@ export default function SelectedRowsHeader({
           {/* Figure out how to not hard code colspans? */}
           <FlexBox className={cssClasses.ACTIONS_FLEXBOX}>
             {rowsAreSelected &&
+              // actions &&
               actions.map(action => (
                 <Action
                   actionInput={{

--- a/src/Table2Beta/SelectedRowsHeader.tsx
+++ b/src/Table2Beta/SelectedRowsHeader.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
-import Cell from "src/Table/Cell";
+import Cell from "./Cell";
 import "./SelectedRowsHeader.less";
-import { FlexBox } from "src/flex";
+import { FlexBox } from "../../src";
 
 interface Props {
   selectedRows: Set<any>;
@@ -11,11 +11,10 @@ interface Props {
 }
 
 export interface ActionInput {
-  callback: () => void;
-  // callback(selectedRows: Set<any>): void;
-  // selectedRows?: Set<any>;
+  callback(selectedRows?: Set<any>): void;
+  selectedRows?: Set<any>;
   // Todo: Account for singular vs multiple selected
-  title: string;
+  title: { singular: string; plural?: string };
   // should icon be required?
   icon?: string;
 }
@@ -38,7 +37,7 @@ export default function SelectedRowsHeader({ selectedRows, contentType, actions 
   return (
     <>
       <tr className={cssClasses.ROW}>
-        <Cell class={cssClasses.TITLE_CELL} colspan={3}>
+        <Cell className={cssClasses.TITLE_CELL} colSpan={3}>
           {/* Figure out how to not hard code colspans */}
           {!rowsAreSelected && <div>Select {contentType || "row"}s to access tools</div>}
           {rowsAreSelected && (
@@ -48,16 +47,18 @@ export default function SelectedRowsHeader({ selectedRows, contentType, actions 
             </div>
           )}
         </Cell>
-        <Cell class={cssClasses.ACTIONS_CELL} colspan={3}>
+        <Cell className={cssClasses.ACTIONS_CELL} colSpan={3}>
           {/* Figure out how to not hard code colspans? */}
-          <FlexBox row className={cssClasses.ACTIONS_FLEXBOX}>
+          <FlexBox className={cssClasses.ACTIONS_FLEXBOX}>
             {rowsAreSelected &&
               actions.map(action => (
                 <Action
                   callback={action.callback}
-                  // selectedRows={selectedRows}
+                  selectedRows={selectedRows}
                   title={action.title}
                   icon={action.icon}
+                  // Is this necessary? Is it the ideal value?
+                  key={action.title.singular}
                 />
               ))}
           </FlexBox>
@@ -67,12 +68,18 @@ export default function SelectedRowsHeader({ selectedRows, contentType, actions 
   );
 }
 
-function Action({ callback, title, icon }: ActionInput) {
+function Action({ callback, selectedRows, title, icon }: ActionInput) {
+  const singleRowSelected = selectedRows.size === 1;
   return (
     <>
-      <a className={`${cssClasses.ACTION} flexbox items--center`} onClick={e => callback()}>
+      <a
+        className={`${cssClasses.ACTION} flexbox items--center`}
+        onClick={e => (selectedRows ? callback(selectedRows) : callback())}
+      >
         {icon && <img className={cssClasses.ACTION_ICON} src={icon} />}
-        <div className={cssClasses.ACTION_TITLE}>{title}</div>
+        <div className={cssClasses.ACTION_TITLE}>
+          {singleRowSelected || !title.plural ? title.singular : title.plural}
+        </div>
       </a>
     </>
   );

--- a/src/Table2Beta/SelectedRowsHeader.tsx
+++ b/src/Table2Beta/SelectedRowsHeader.tsx
@@ -8,6 +8,7 @@ interface Props {
   selectedRows: Set<any>;
   contentType?: { singular: string; plural?: string };
   actions: Array<ActionInput>;
+  allSelected: boolean;
 }
 
 export interface ActionInput {
@@ -27,7 +28,12 @@ const cssClasses = {
   ACTION_TITLE: "Table2Beta--selectedRowsHeader--actionTitle",
 };
 
-export default function SelectedRowsHeader({ selectedRows, contentType, actions }: Props) {
+export default function SelectedRowsHeader({
+  selectedRows,
+  contentType,
+  actions,
+  allSelected,
+}: Props) {
   const rowsAreSelected = selectedRows.size > 0;
   const singleRowSelected = selectedRows.size === 1;
 
@@ -38,12 +44,17 @@ export default function SelectedRowsHeader({ selectedRows, contentType, actions 
         <Cell className={cssClasses.TITLE_CELL} colSpan={3}>
           {/* Figure out how to not hard code colspans */}
           {!rowsAreSelected && <div>Select {contentType.plural || "rows"} to access tools</div>}
-          {rowsAreSelected && (
-            <div>
-              {selectedRows.size}{" "}
-              {singleRowSelected ? contentType.singular || "row" : contentType.plural || "rows"}{" "}
-              selected
-            </div>
+          {rowsAreSelected && !allSelected && (
+            <>
+              <div>
+                {selectedRows.size}{" "}
+                {singleRowSelected ? contentType.singular || "row" : contentType.plural || "rows"}{" "}
+                selected
+              </div>
+            </>
+          )}
+          {allSelected && (
+            <div>{`All ${contentType.plural || "rows"} selected (${selectedRows.size})`}</div>
           )}
         </Cell>
         <Cell className={cssClasses.ACTIONS_CELL} colSpan={3}>

--- a/src/Table2Beta/Table.less
+++ b/src/Table2Beta/Table.less
@@ -6,11 +6,11 @@
   font-family: "Proxima Nova";
   font-size: 0.875rem;
   width: 100%;
-  max-width: 1032px;
+  max-width: 64.5rem;
 }
 
 .Table2Beta--header {
-  height: 56px;
+  height: @size_4xl;
 }
 
 &.Table2Beta--fixed {
@@ -30,7 +30,7 @@
 .Table2Beta--row {
   .border--bottom--s(@neutral_silver);
   transition: background-color @timingImmediately @motionSmooth;
-  min-height: 48px;
+  min-height: @size_3xl;
 }
 
 .Table2Beta--rowEven {

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -35,8 +35,7 @@ declare var process: {
 
 export interface ActionInput {
   callback(selectedRows: Set<any>): void;
-  title: { singular: string; plural?: string };
-  // should icon be required?
+  title: { singular: React.ReactNode; plural?: React.ReactNode };
   icon?: string;
 }
 

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -33,6 +33,13 @@ declare var process: {
   };
 };
 
+export interface ActionInput {
+  callback(selectedRows: Set<any>): void;
+  title: { singular: string; plural?: string };
+  // should icon be required?
+  icon?: string;
+}
+
 export interface Props {
   children?: ChildrenOf<typeof Column>;
   className?: string;
@@ -130,13 +137,6 @@ export const cssClass = {
   ROW_SELECTED: "Table2Beta--rowSelected",
   TABLE: "Table2Beta",
 };
-
-export interface ActionInput {
-  callback(selectedRows: Set<any>): void;
-  title: { singular: string; plural?: string };
-  // should icon be required?
-  icon?: string;
-}
 
 export class Table2Beta extends React.Component<Props, State> {
   static propTypes = propTypes;

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -423,33 +423,38 @@ export class Table2Beta extends React.Component<Props, State> {
     // For testing only
     const sampleActions: Array<ActionInput> = [
       {
-        callback: () => console.log("sampleAction 1"),
-        title: "Do this action",
+        callback: () => {
+          // for (var row of Array.from(selectedRows.values())) {
+          //   console.log(row.name);
+          // }
+          console.log(selectedRows);
+        },
+        title: { singular: "Launch an app" },
         icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
       },
       {
         callback: () => console.log("sampleAction 2"),
-        title: "Do another action",
+        title: { singular: "Log out student", plural: "Log out students" },
         icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
       },
       {
         callback: () => console.log("sampleAction 1"),
-        title: "Do this action",
+        title: { singular: "Download badge", plural: "Download badges" },
       },
       {
         callback: () => console.log("sampleAction 2"),
-        title: "Do another action",
+        title: { singular: "Download username", plural: "Download usernames" },
         icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
       },
-      {
-        callback: () => console.log("sampleAction 1"),
-        title: "Do this action",
-      },
-      {
-        callback: () => console.log("sampleAction 2"),
-        title: "Do another action",
-        icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
-      },
+      // {
+      //   callback: () => console.log("sampleAction 1"),
+      //   title: "Do this action",
+      // },
+      // {
+      //   callback: () => console.log("sampleAction 2"),
+      //   title: "Do another action",
+      //   icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
+      // },
     ];
 
     return (

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -15,6 +15,7 @@ import { ChildrenOf } from "../utils/types";
 import "./Table.less";
 import Checkbox from "../Checkbox";
 import HeaderCell from "./HeaderCell";
+import SelectedRowsHeader from "./SelectedRowsHeader";
 
 export type SortDirection = "asc" | "desc";
 
@@ -422,6 +423,7 @@ export class Table2Beta extends React.Component<Props, State> {
     return (
       <table className={classnames(cssClass.TABLE, fixed && cssClass.FIXED, className)}>
         <thead>
+          <SelectedRowsHeader selectedRows={selectedRows} contentType="student" />
           <tr className={cssClass.HEADER}>
             {selectable && (
               <HeaderCell>

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -15,7 +15,7 @@ import { ChildrenOf } from "../utils/types";
 import "./Table.less";
 import Checkbox from "../Checkbox";
 import HeaderCell from "./HeaderCell";
-import SelectedRowsHeader from "./SelectedRowsHeader";
+import SelectedRowsHeader, { ActionInput } from "./SelectedRowsHeader";
 
 export type SortDirection = "asc" | "desc";
 
@@ -420,10 +420,48 @@ export class Table2Beta extends React.Component<Props, State> {
       numColumns++;
     }
 
+    // For testing only
+    const sampleActions: Array<ActionInput> = [
+      {
+        callback: () => console.log("sampleAction 1"),
+        title: "Do this action",
+        icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
+      },
+      {
+        callback: () => console.log("sampleAction 2"),
+        title: "Do another action",
+        icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
+      },
+      {
+        callback: () => console.log("sampleAction 1"),
+        title: "Do this action",
+      },
+      {
+        callback: () => console.log("sampleAction 2"),
+        title: "Do another action",
+        icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
+      },
+      {
+        callback: () => console.log("sampleAction 1"),
+        title: "Do this action",
+      },
+      {
+        callback: () => console.log("sampleAction 2"),
+        title: "Do another action",
+        icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
+      },
+    ];
+
     return (
       <table className={classnames(cssClass.TABLE, fixed && cssClass.FIXED, className)}>
         <thead>
-          <SelectedRowsHeader selectedRows={selectedRows} contentType="student" />
+          {selectable && (
+            <SelectedRowsHeader
+              selectedRows={selectedRows}
+              contentType="student"
+              actions={sampleActions}
+            />
+          )}
           <tr className={cssClass.HEADER}>
             {selectable && (
               <HeaderCell>

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -68,6 +68,7 @@ interface State {
   currentPage: number;
   sortState: SortState;
   selectedRows: Set<any>;
+  allSelected: boolean;
 
   // lazy table state
   lazyPages: any[];
@@ -162,6 +163,7 @@ export class Table2Beta extends React.Component<Props, State> {
       currentPage: props.initialPage || 1,
       sortState: props.initialSortState,
       selectedRows: new Set(),
+      allSelected: false,
 
       // lazy table state
       lazyPages: [],
@@ -433,6 +435,7 @@ export class Table2Beta extends React.Component<Props, State> {
               selectedRows={selectedRows}
               contentType={selectedRowsHeaderContentType}
               actions={selectedRowsHeaderActions}
+              allSelected={this.state.allSelected}
             />
           )}
           <tr className={cssClass.HEADER}>
@@ -444,8 +447,10 @@ export class Table2Beta extends React.Component<Props, State> {
                   onChange={newState => {
                     if (newState.checked) {
                       selectedRows = new Set(displayedData);
+                      this.setState({ allSelected: true });
                     } else {
                       selectedRows.clear();
+                      this.setState({ allSelected: false });
                     }
                     this.setState({ selectedRows });
                   }}

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -54,6 +54,7 @@ export interface Props {
   rowClassNameFn?: Function;
   noDataContent?: React.ReactNode;
   selectable?: boolean;
+  contentType?: { singular: string; plural?: string };
 
   // These must be all set together. TODO: enforce that
   lazy?: boolean;
@@ -96,6 +97,10 @@ const propTypes = {
   rowClassNameFn: PropTypes.func,
   noDataContent: PropTypes.node,
   selectable: PropTypes.bool,
+  contentType: PropTypes.shape({
+    singular: PropTypes.string,
+    plural: PropTypes.string,
+  }),
 
   // these must all be set together
   lazy: PropTypes.bool,
@@ -399,6 +404,7 @@ export class Table2Beta extends React.Component<Props, State> {
       noDataContent,
       selectable,
       visiblePageRangeSize,
+      contentType,
     } = this.props;
     const { lazy, numRows } = this.props;
     const { currentPage, sortState, pageLoading, allLoaded } = this.state;
@@ -463,7 +469,7 @@ export class Table2Beta extends React.Component<Props, State> {
           {selectable && (
             <SelectedRowsHeader
               selectedRows={selectedRows}
-              contentType="student"
+              contentType={contentType}
               actions={sampleActions}
             />
           )}

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -54,7 +54,9 @@ export interface Props {
   rowClassNameFn?: Function;
   noDataContent?: React.ReactNode;
   selectable?: boolean;
-  contentType?: { singular: string; plural?: string };
+  selectedRowsHeaderContentType?: { singular: string; plural?: string };
+  // should this be optional?
+  selectedRowsHeaderActions: Array<ActionInput>;
 
   // These must be all set together. TODO: enforce that
   lazy?: boolean;
@@ -97,10 +99,6 @@ const propTypes = {
   rowClassNameFn: PropTypes.func,
   noDataContent: PropTypes.node,
   selectable: PropTypes.bool,
-  contentType: PropTypes.shape({
-    singular: PropTypes.string,
-    plural: PropTypes.string,
-  }),
 
   // these must all be set together
   lazy: PropTypes.bool,
@@ -404,7 +402,8 @@ export class Table2Beta extends React.Component<Props, State> {
       noDataContent,
       selectable,
       visiblePageRangeSize,
-      contentType,
+      selectedRowsHeaderContentType,
+      selectedRowsHeaderActions,
     } = this.props;
     const { lazy, numRows } = this.props;
     const { currentPage, sortState, pageLoading, allLoaded } = this.state;
@@ -426,51 +425,14 @@ export class Table2Beta extends React.Component<Props, State> {
       numColumns++;
     }
 
-    // For testing only
-    const sampleActions: Array<ActionInput> = [
-      {
-        callback: () => {
-          // for (var row of Array.from(selectedRows.values())) {
-          //   console.log(row.name);
-          // }
-          console.log(selectedRows);
-        },
-        title: { singular: "Launch an app" },
-        icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
-      },
-      {
-        callback: () => console.log("sampleAction 2"),
-        title: { singular: "Log out student", plural: "Log out students" },
-        icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
-      },
-      {
-        callback: () => console.log("sampleAction 1"),
-        title: { singular: "Download badge", plural: "Download badges" },
-      },
-      {
-        callback: () => console.log("sampleAction 2"),
-        title: { singular: "Download username", plural: "Download usernames" },
-        icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
-      },
-      // {
-      //   callback: () => console.log("sampleAction 1"),
-      //   title: "Do this action",
-      // },
-      // {
-      //   callback: () => console.log("sampleAction 2"),
-      //   title: "Do another action",
-      //   icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
-      // },
-    ];
-
     return (
       <table className={classnames(cssClass.TABLE, fixed && cssClass.FIXED, className)}>
         <thead>
           {selectable && (
             <SelectedRowsHeader
               selectedRows={selectedRows}
-              contentType={contentType}
-              actions={sampleActions}
+              contentType={selectedRowsHeaderContentType}
+              actions={selectedRowsHeaderActions}
             />
           )}
           <tr className={cssClass.HEADER}>


### PR DESCRIPTION
[Figma](https://www.figma.com/file/ukZPUy54yug5SpYwfBVcv4/Analytics-Actions-(table-explorations)?node-id=544%3A36242): Section "Checkboxes, select states, and bulk actions"

**Overview:**

Create a row in the header which shows how many rows are selected and displays the available actions. 

Notes: 
* Only shows if Table2Beta has `selectable=true`
* Assumes "select all" checkbox selects all rows _on all pages_. However, this is not true and needs to be added to Table2Beta

To Do:
* [ ] Rounded top corners are giving me trouble, still need to figure this out

**Screenshots/GIFs:**

With no rows selected:
<img width="1158" alt="Screen Shot 2020-09-11 at 4 41 24 PM" src="https://user-images.githubusercontent.com/54862564/92981494-f8fa4880-f44e-11ea-8cc2-3b9bc599b525.png">

Title changes with rows selected (singular). Actions also show
<img width="1169" alt="Screen Shot 2020-09-11 at 4 41 33 PM" src="https://user-images.githubusercontent.com/54862564/92981500-fdbefc80-f44e-11ea-84ba-ce19132888eb.png">

Title and actions reflect if one or multiple rows are selected
<img width="1063" alt="Screen Shot 2020-09-11 at 4 53 56 PM" src="https://user-images.githubusercontent.com/54862564/92981609-6a39fb80-f44f-11ea-8013-90fdc6046ba3.png">

Title reflects if all rows are selected
<img width="1074" alt="Screen Shot 2020-09-11 at 4 41 53 PM" src="https://user-images.githubusercontent.com/54862564/92981508-0283b080-f44f-11ea-8c30-f02678acc6df.png">

Custom title can be set by setting `selectedRowsHeaderContentType`. In this example, `selectedRowsHeaderContentType = this.state.tableFilter`
<img width="1073" alt="Screen Shot 2020-09-11 at 4 42 11 PM" src="https://user-images.githubusercontent.com/54862564/92981515-06173780-f44f-11ea-864d-0f318be31212.png">

Can set `numDisplayedActions` in Table2Beta, and if you pass in more than that many actions, the rest end up in an "Ellipsis" dropdown menu
<img width="629" alt="Screen Shot 2020-09-15 at 5 04 36 PM" src="https://user-images.githubusercontent.com/54862564/93276921-c9607e80-f775-11ea-8937-acdd91587975.png">

Hover state
<img width="861" alt="Screen Shot 2020-09-15 at 5 04 43 PM" src="https://user-images.githubusercontent.com/54862564/93276928-ccf40580-f775-11ea-95d5-fc6e4b7cd299.png">


**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component