### PR TITLE
Add span wrapper to RichText to match old behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.54.0",
+  "version": "2.54.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/RichText/RichText.tsx
+++ b/src/RichText/RichText.tsx
@@ -21,12 +21,14 @@ export default function RichText(props: Props) {
 
   return (
     <Linkify componentDecorator={componentDecorator}>
-      {lines.map((item, index) => (
-        <span key={index}>
-          {item}
-          {index < lines.length - 1 && <br />}
-        </span>
-      ))}
+      <span>
+        {lines.map((item, index) => (
+          <span key={index}>
+            {item}
+            {index < lines.length - 1 && <br />}
+          </span>
+        ))}
+      </span>
     </Linkify>
   );
 }


### PR DESCRIPTION
**Overview:**

I updated the `RichText` component in https://github.com/Clever/components/pulls?q=is%3Apr+is%3Aclosed because I updated the underlying library `Linkify` from v 0.2.x to 1.0.0. It seems that in the older version, Linkify would wrap any output in an extra `span` element -

OLD Linkify v0.2.x
<img width="601" alt="Screen Shot 2020-09-14 at 5 58 45 PM" src="https://user-images.githubusercontent.com/26425483/93153512-43c9c980-f6b6-11ea-8c52-8fa1489e3a11.png">

NEW Linkify v1.0.0
<img width="577" alt="Screen Shot 2020-09-14 at 5 58 34 PM" src="https://user-images.githubusercontent.com/26425483/93153520-4b896e00-f6b6-11ea-9ac5-ba44e5fc9a69.png">

We rely on that `span` being there, because otherwise the `RichText` output will take the parent element's styling. In the example above it results in each child span element being treated as a child of the outer `Flexbox class=CollectionPageHeader--teacherAnnouncementBody`, instead of it being a single child span.

New Linkify without added span - 

<img width="1417" alt="Screen Shot 2020-09-14 at 5 58 16 PM" src="https://user-images.githubusercontent.com/26425483/93153686-b044c880-f6b6-11ea-8af9-4ab045e709b2.png">

New Linkify with added span - 

<img width="947" alt="Screen Shot 2020-09-14 at 6 27 59 PM" src="https://user-images.githubusercontent.com/26425483/93154249-07976880-f6b8-11ea-874e-7e89ac3b186e.png">


This PR adds in that `span` as the wrapper for any `RichText` output. 


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component