### PR TITLE
Sometimes all you need is a newline

### DIFF
--- a/docs/components/MessagingInputView.jsx
+++ b/docs/components/MessagingInputView.jsx
@@ -23,10 +23,11 @@ export default class MessagingInputView extends React.PureComponent {
 
   state = {
     inputValue: "",
+    newlineOnEnter: false,
   };
 
   render() {
-    const { inputValue } = this.state;
+    const { inputValue, newlineOnEnter } = this.state;
 
     return (
       <View
@@ -55,6 +56,7 @@ export default class MessagingInputView extends React.PureComponent {
           <ExampleCode>
             <MessagingInput
               value={inputValue}
+              newlineOnEnter={newlineOnEnter}
               onChange={newValue => this.setState({ inputValue: newValue })}
               onSubmit={message => {
                 // eslint-disable-next-line no-alert
@@ -63,6 +65,14 @@ export default class MessagingInputView extends React.PureComponent {
               }}
             />
           </ExampleCode>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={newlineOnEnter}
+              onChange={({ target }) => this.setState({ newlineOnEnter: target.checked })}
+            />{" "}
+            Newline on enter
+          </label>
         </Example>
 
         {this._renderProps()}
@@ -94,6 +104,13 @@ export default class MessagingInputView extends React.PureComponent {
             name: "onBlur",
             type: "() => void",
             description: "Function that's called when the input is unfocused.",
+            optional: true,
+          },
+          {
+            name: "newlineOnEnter",
+            type: "boolean",
+            description:
+              "If true, pressing enter/return will create a newline instead of sending the message.",
             optional: true,
           },
           {

--- a/docs/components/MessagingInputView.less
+++ b/docs/components/MessagingInputView.less
@@ -15,15 +15,11 @@
 }
 
 .MessagingInputView--config {
-  .flexbox;
-  .items--center;
-  .margin--bottom--m;
-  .text--caps;
   .text--small;
-
-  &:not(:last-child) {
-    .margin--right--m;
-  }
+  cursor: pointer;
+  display: inline-block;
+  .margin--y--m();
+  text-transform: uppercase;
 }
 
 label.MessagingInputView--config {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.54.1",
+  "version": "2.55.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as cx from "classnames";
 
 import { TextArea, Button, FlexBox, ItemAlign } from "../index";
+import KeyCode from "../utils/KeyCode";
 
 import "./MessagingInput.less";
 
@@ -11,6 +12,7 @@ function cssClass(element: string) {
 
 interface Props {
   className?: string;
+  newlineOnEnter?: boolean;
   value: string;
   onChange: (newValue: string) => void;
   // onSubmit accepts a value rather than submitting the current message value
@@ -28,7 +30,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
   props,
   ref,
 ) => {
-  const { className, value, onChange, onSubmit, onBlur } = props;
+  const { className, newlineOnEnter, value, onChange, onSubmit, onBlur } = props;
   const textAreaRef = React.useRef<TextArea>(null);
 
   React.useImperativeHandle(ref, () => ({
@@ -52,8 +54,9 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
         }}
         onKeyDown={e => {
           // Shift+Enter is a line-break.
-          // Enter alone is an attempt to Send.
-          if (e.key === "Enter" && !e.shiftKey) {
+          // Enter alone is an attempt to Send, unless prop is
+          //  explicitly set to have enter be a newline.
+          if (e.key === KeyCode.ENTER && !e.shiftKey && !newlineOnEnter) {
             e.preventDefault();
             // If something other than whitespace is in the input area, Send the message.
             if (value.trim() !== "") {

--- a/src/utils/KeyCode.ts
+++ b/src/utils/KeyCode.ts
@@ -11,6 +11,7 @@ const KeyCode = {
   ARROW_RIGHT: "ArrowRight",
   ARROW_UP_IE: "Up",
   ARROW_UP: "ArrowUp",
+  ENTER: "Enter",
   J: "j",
   K: "k",
   TAB: "Tab",


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/SSOAP-2787

**Overview:**

On mobile, we want to have the "Enter/Return" key make a newline instead of sending the message. We have a listener for whether a device is mobile in launchpad, so instead of setting another listener here, we will take the `newlineOnEnter` flag as a prop.

Another important reason to take it as a prop is that long term, it would allow us to give the user the option whether they want "Enter" to be a newline or send. This is an option on Slack that is really popular.

**Screenshots/GIFs:**

![newline-on-enter](https://user-images.githubusercontent.com/26425483/93270440-002e9880-f766-11ea-9d4a-1941906e639e.gif)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [ x Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component