### PR TITLE
Add link style support to DropdownButton

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.55.0",
+  "version": "2.56.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/DropdownButton/Menu.less
+++ b/src/DropdownButton/Menu.less
@@ -58,3 +58,7 @@
 .Button--large.DropdownButton--Option {
   .padding--y--s;
 }
+
+.Button.DropdownButton--WhiteBackground {
+  background: white;
+}

--- a/src/DropdownButton/Menu.tsx
+++ b/src/DropdownButton/Menu.tsx
@@ -32,6 +32,7 @@ const propTypes = {
 export const cssClass = {
   CONTAINER: "DropdownButton--Menu",
   OPTION: "DropdownButton--Option",
+  WHITE_BACKGROUND: "DropdownButton--WhiteBackground",
 };
 
 export default class Menu extends React.PureComponent<Props> {
@@ -41,9 +42,15 @@ export default class Menu extends React.PureComponent<Props> {
     const { onHide, size, type } = this.props;
     const { children, className, disabled, href, onClick, target } = option.props;
 
+    // Add the background color back in for the buttons
+    let backgroundColorClass = "";
+    if (type === Type.LINK) {
+      backgroundColorClass = cssClass.WHITE_BACKGROUND;
+    }
+
     return (
       <Button
-        className={classnames(cssClass.OPTION, className)}
+        className={classnames(cssClass.OPTION, className, backgroundColorClass)}
         disabled={disabled}
         href={href}
         onClick={e => {

--- a/src/DropdownButton/Type.ts
+++ b/src/DropdownButton/Type.ts
@@ -4,6 +4,7 @@ const Type = {
   PRIMARY: Button.Type.PRIMARY,
   SECONDARY: Button.Type.SECONDARY,
   DESTRUCTIVE: Button.Type.DESTRUCTIVE,
+  LINK: Button.Type.LINK,
 } as const;
 
 const ArrowType = {


### PR DESCRIPTION
**Jira:**

**Overview:**
Ever wanted a dropdown button without borders? Now you can do it!

**Screenshots/GIFs:**
<img width="1177" alt="Screen Shot 2020-09-16 at 11 03 57 AM" src="https://user-images.githubusercontent.com/12452249/93375109-830a2e80-f80c-11ea-91c0-9fd438a716d3.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Edge

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component