### PR TITLE
Searching for the magic scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.56.0",
+  "version": "2.56.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/SSOAP-2770

**Overview:**
Ideally we want to scroll to a new message if a user is at the bottom of the thread when they receive a new message. The current way to do this doesn't work if a user gets sent a long message. With this fix, we save if the user was at the bottom of the thread before the new message comes in, instead of after the message comes. 

That is preferred, because if we calculate after the message comes in, the new message gets inserted at the bottom of the container and only if the total size is within `SCROLL_BUFFER` do we scroll to the bottom of the page, but we don't know how big that message will be. Therefore, its better to do the checks beforehand! 

I've also reorganized the code a bit and added some comments.

**Screenshots/GIFs:**

GIF - https://share.getcloudapp.com/Qwu0pYvJ
New behavior on left, old behavior on right

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
~  - [ ] Updated docs~
~  - [ ] Bumped version in `package.json`~
