### PR TITLE
Being friendly is good, mobile friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.56.1",
+  "version": "2.56.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -10,6 +10,7 @@
   .padding--xs();
   .text--line-height-4();
   white-space: pre-wrap;
+  word-wrap: break-word; // IE name for overflow-wrap
 }
 
 .MessagingBubble--Message--Other {
@@ -22,6 +23,7 @@
   .padding--xs();
   .text--line-height-4();
   white-space: pre-wrap;
+  word-wrap: break-word; // IE name for overflow-wrap
 }
 
 .MessagingBubble--Link,

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -41,5 +41,7 @@
     font-size: 0.875rem;
     line-height: 1rem;
     .padding--xs();
+    // This improves how long words/links are broken on Chrome mobile and doesn't affect Safari
+    overflow-wrap: anywhere;
   }
 }

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -31,17 +31,19 @@
 }
 
 .MessageMetadata--Timestamp--right {
-  .margin--right--xs();
-  font-size: 0.875rem;
-  .text--line-height-1();
   color: @neutral_medium_gray;
+  font-size: 0.875rem;
+  .margin--right--xs();
+  .text--line-height-1();
+  white-space: nowrap;
 }
 
 .MessageMetadata--Timestamp--left {
-  .margin--left--xs();
-  font-size: 0.875rem;
-  .text--line-height-1();
   color: @neutral_medium_gray;
+  font-size: 0.875rem;
+  .margin--left--xs();
+  .text--line-height-1();
+  white-space: nowrap;
 }
 
 // For mobile/tablet


### PR DESCRIPTION
**Jira:**

https://clever.atlassian.net/browse/SSOAP-2786

**Overview:**

1) Don't wrap timestamps and 
2) better support for long links/words on Chrome mobile. Unfortunately Safari doesn't support the `anywhere` property for `overflow-wrap`, but there is no clear answer for Safari mobile so we can explore solutions later. The core of that issue is the whole mobile styling layout, so that's a bigger problem to solve.

**Screenshots/GIFs:**

Old timestamp wrap = bad 

![Screen Shot 2020-09-16 at 4 18 17 PM](https://user-images.githubusercontent.com/26425483/93402054-8e734f00-f838-11ea-913b-ab7385d3cfae.png)

New no wrap = good

![Screen Shot 2020-09-16 at 4 17 51 PM](https://user-images.githubusercontent.com/26425483/93402057-916e3f80-f838-11ea-89a3-29a26b4d33d7.png)

Old links on Chrome mobile = bad
![Screen Shot 2020-09-16 at 4 17 17 PM](https://user-images.githubusercontent.com/26425483/93402088-a5b23c80-f838-11ea-86d8-9b5254392b34.png)

New links on Chrome mobile = good

![Screen Shot 2020-09-16 at 4 16 54 PM](https://user-images.githubusercontent.com/26425483/93402132-bc589380-f838-11ea-952a-6442199ad6df.png)


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component