### PR TITLE
Fixed dropdown button menu buttons from being transparent on hover

### DIFF
--- a/src/DropdownButton/Menu.less
+++ b/src/DropdownButton/Menu.less
@@ -62,3 +62,7 @@
 .Button.DropdownButton--WhiteBackground {
   background: white;
 }
+
+.Button.DropdownButton--WhiteBackground:hover {
+  background: white;
+}


### PR DESCRIPTION
**Jira:**

**Overview:**
Quick fix to make the hover work better. Before, hovering would make the button transparent. Now it maintains the white background. 

**Screenshots/GIFs:**
<img width="622" alt="Screen Shot 2020-09-16 at 5 36 30 PM" src="https://user-images.githubusercontent.com/12452249/93405904-2a09bd00-f843-11ea-9a80-4d320d786f67.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component