### PR TITLE
DropdownButton: Label changed to use ReactNode

### DIFF
--- a/docs/components/DropdownButtonView.jsx
+++ b/docs/components/DropdownButtonView.jsx
@@ -8,6 +8,7 @@ import Hello from "./DropdownButtonViewData";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import { Button, DropdownButton, FlexBox, ItemAlign, SegmentedControl } from "src";
+import FontAwesome from "react-fontawesome";
 
 import "./DropdownButtonView.less";
 
@@ -142,7 +143,11 @@ export default class DropdownButtonView extends Component {
             <ExampleCode>
               <DropdownButton
                 disabled={disabled}
-                label="Say Hello"
+                label={
+                  <div>
+                    <FontAwesome name="thumbs-up" /> Say hello
+                  </div>
+                }
                 onClick={() => this.say("Hello")}
                 size={size}
                 type={type}
@@ -252,7 +257,7 @@ export default class DropdownButtonView extends Component {
             },
             {
               name: "label",
-              type: "string",
+              type: "node",
               description: "Label for the main action button.",
             },
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.56.1",
+  "version": "2.57.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/DropdownButton/DropdownButton.tsx
+++ b/src/DropdownButton/DropdownButton.tsx
@@ -23,7 +23,7 @@ export interface Props {
   className?: string;
   disabled?: boolean;
   href?: string;
-  label: string;
+  label: React.ReactNode;
   onClick?: Function;
   size?: ButtonProps["size"];
   target?: "_self" | "_blank";
@@ -40,7 +40,7 @@ const propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   href: PropTypes.string,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
   onClick: PropTypes.func,
   size: PropTypes.oneOf(_.values(Button.Size)),
   target: PropTypes.oneOf(["_self", "_blank"]),


### PR DESCRIPTION
**Jira:**

**Overview:**
Buttons can use ReactNodes, why can't DropdownButtons? Tada! 🥳 

**Screenshots/GIFs:**
<img width="579" alt="Screen Shot 2020-09-16 at 10 49 41 PM" src="https://user-images.githubusercontent.com/12452249/93425473-eb89f780-f86e-11ea-97fd-780ec0035a3e.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Edge

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component