### PR TITLE
Table2beta Select all button selects all rows

### DIFF
--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -412,9 +412,7 @@ export default class Table2BetaView extends React.PureComponent {
               name: "lazy",
               type: "boolean",
               description:
-                'Puts the table in "lazy" mode - data is fetched ' +
-                'from the getData function rather than needing the whole "data" ' +
-                "array up front.",
+                'Puts the table in "lazy" mode - data is fetched from the getData function rather than needing the whole "data" array up front. NOTE: with lazy data loading, "Select All" checkbox only selects the current page.',
               defaultValue: "false",
               optional: true,
             },
@@ -422,8 +420,7 @@ export default class Table2BetaView extends React.PureComponent {
               name: "getData",
               type: "({startingAfter?: string, pageSize: number}) => Object[]",
               description:
-                "If `lazy`, this function is called to retrieve new " +
-                "data. Cannot be provided if not `lazy`.",
+                "If `lazy`, this function is called to retrieve new data. Cannot be provided if not `lazy`.",
             },
             {
               name: "numRows",
@@ -445,7 +442,8 @@ export default class Table2BetaView extends React.PureComponent {
             {
               name: "selectable",
               type: "boolean",
-              description: "Adds selectable checkboxes to the table",
+              description:
+                "Adds selectable checkboxes to the table. NOTE: with lazy data loading, 'Select All' checkbox only selects the current page. With data passed in in the 'data' prop, 'Select All' selects all rows.",
               optional: true,
             },
             {

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -75,6 +75,7 @@ interface State {
   sortState: SortState;
   selectedRows: Set<any>;
   allSelected: boolean;
+  allData: Set<any>;
 
   // lazy table state
   lazyPages: any[];
@@ -172,6 +173,7 @@ export class Table2Beta extends React.Component<Props, State> {
       sortState: props.initialSortState,
       selectedRows: new Set(),
       allSelected: false,
+      allData: new Set(),
 
       // lazy table state
       lazyPages: [],
@@ -366,7 +368,7 @@ export class Table2Beta extends React.Component<Props, State> {
 
     const numPages = pages.length;
     const idx = Math.min(currentPage, numPages) - 1;
-    return { displayedData: pages[idx], numPages };
+    return { displayedData: pages[idx], numPages, allRows: displayedData };
   }
 
   _getLazyData() {
@@ -392,7 +394,7 @@ export class Table2Beta extends React.Component<Props, State> {
     return { displayedData: [], numPages };
   }
 
-  _getDisplayedData() {
+  _getDisplayedData(): { displayedData: any; numPages: any; allRows?: any } {
     if (!this.props.lazy) {
       return this._getSynchronousData();
     }
@@ -427,7 +429,7 @@ export class Table2Beta extends React.Component<Props, State> {
       );
     }
 
-    const { displayedData, numPages } = this._getDisplayedData();
+    const { displayedData, numPages, allRows } = this._getDisplayedData();
     const displayedPage = Math.min(currentPage, numPages);
     const disableSort = numPages <= 1 && displayedData.length <= 1;
 
@@ -454,10 +456,10 @@ export class Table2Beta extends React.Component<Props, State> {
                 <HeaderCell>
                   <Checkbox
                     checked={selectedRows.size > 0}
-                    partial={selectedRows.size < displayedData.length}
+                    partial={selectedRows.size < (allRows || displayedData).length}
                     onChange={newState => {
                       if (newState.checked) {
-                        selectedRows = new Set(displayedData);
+                        selectedRows = new Set(allRows || displayedData);
                         this.setState({ allSelected: true });
                       } else {
                         selectedRows.clear();
@@ -518,8 +520,12 @@ export class Table2Beta extends React.Component<Props, State> {
                         onChange={newState => {
                           if (newState.checked) {
                             selectedRows.add(rowData);
+                            if (selectedRows.size === (allRows || displayedData).length) {
+                              this.setState({ allSelected: true });
+                            }
                           } else {
                             selectedRows.delete(rowData);
+                            this.setState({ allSelected: false });
                           }
                           this.setState({ selectedRows });
                         }}


### PR DESCRIPTION
**Overview:**

Want "Select All" checkbox to select all rows, not only the current page. 

**However** this isn't really feasible with lazy data loading option. So, if data is passed in as the `data` prop, "Select All" checkbox will select all rows. If data is loaded with lazy loading, Select All will only select the current page

Essentially, lazy loading works by loading one page of data at a time, when that page is accessed. To select all rows, the component would have to query for all pages one by one, which defeats the purpose of lazy loading. So if the consumer wants this feature, they should load all data in one query outside of the component and pass it in as `data`.

**Screenshots/GIFs:**

<img width="1079" alt="Screen Shot 2020-09-18 at 2 21 13 PM" src="https://user-images.githubusercontent.com/54862564/93646135-79262e00-f9ba-11ea-8d43-b19099e82b10.png">


**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component