### PR TITLE
Use empty alt text for the ResourceTile icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.57.0",
+  "version": "2.57.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ResourceTile/ResourceTile.tsx
+++ b/src/ResourceTile/ResourceTile.tsx
@@ -110,7 +110,9 @@ export class ResourceTile extends React.PureComponent<Props, State> {
       <img
         className={classnames(CssClasses.ICON, IconOrientationCssClasses[iconOrientation])}
         src={icon.src}
-        alt={`${title} icon`}
+        // ResourceTile icons are decorative images (redundant to the displayed text) and therefore should use an empty alt tag
+        alt=""
+        role="presentation"
         title={title}
         ref={this.iconRef}
         onLoad={() => this.determineIconOrientation()}


### PR DESCRIPTION
**Jira:**
Appears to be a necessary change for https://clever.atlassian.net/browse/FAMBAM-533
More information from the Deque review:
![image](https://user-images.githubusercontent.com/21094551/93934431-024da580-fcd8-11ea-89f1-8b880a749ba5.png)

**Overview:**
This PR changes the alt text for ResourceTile icons to the empty string. These icons are decorative images as identified by Deque during a Family Portal audit, and thus it is inappropriate to have alt text for them for screen readers to read. Currently, it is not possible to modify the alt text without removing the title which will still be necessary as that is tied to the displayed text. As ResourceTile icons will always be decorative, this PR modifies the alt text to be empty and explicitly adds a role="presentation" tag to make that clear. 

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component