### PR TITLE
Table2Beta: Header Style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.57.0",
+  "version": "2.58.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table2Beta/SelectedRowsHeader.less
+++ b/src/Table2Beta/SelectedRowsHeader.less
@@ -13,6 +13,9 @@
   background-color: @neutral_off_white;
   color: @neutral_dark_gray;
   font-family: "Proxima Nova";
+  // Max-width of the table is 64.5rem
+  // The max-width here is 64.5rem - 2*1rem (padding left and right) - 2*0.0625rem (border width)
+  max-width: 62.375rem;
 }
 
 .Table2Beta--selectedRowsHeader--actionsFlexbox {


### PR DESCRIPTION
**Jira:**

**Overview:**
The SelectedRowsHeader didn't have a max-width before, so it would stretch past the table! 

**Screenshots/GIFs:**
Before:
<img width="1661" alt="Screen Shot 2020-09-22 at 2 00 11 PM" src="https://user-images.githubusercontent.com/12452249/93937041-f06e0180-fcdb-11ea-966f-474589a9e6f8.png">

After:
<img width="1105" alt="Screen Shot 2020-09-22 at 1 59 53 PM" src="https://user-images.githubusercontent.com/12452249/93937019-e51ad600-fcdb-11ea-9bfa-4c2c5ed5005a.png">


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component