### PR TITLE
Fix console-level bug where key is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.57.2",
+  "version": "2.57.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -461,6 +461,7 @@ export class Table2Beta extends React.Component<Props, State> {
               <Menu.Item
                 className={cssClass.ACTION_MENU_ITEM}
                 onClick={e => action.callback(rowData)}
+                key="action.title.singular"
               >
                 <div className={cssClass.ACTION_MENU_ITEM_TITLE}>
                   {action.icon && <img className={cssClass.ACTION_ICON} src={action.icon} />}


### PR DESCRIPTION
**Jira:**
[Spec](https://docs.google.com/document/d/1eys3mDJYeI7pWbu50CCx-6qOg2vm1c-QlJeIlbWigSI/edit)

**Overview:**
Single actions don't appear when using this table, which might be because the keys aren't unique. 

**Screenshots/GIFs:**
Error I wanted to address: 
<img width="1672" alt="Screen Shot 2020-09-22 at 6 19 51 PM" src="https://user-images.githubusercontent.com/12452249/93953419-38068480-fd00-11ea-94fa-6c5f9d0211a1.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component