### PR TITLE
Add autocomplete field to TextInput

### DIFF
--- a/docs/components/TextInputView.jsx
+++ b/docs/components/TextInputView.jsx
@@ -153,6 +153,13 @@ export default class TextInputView extends Component {
               optional: true,
             },
             {
+              name: "autoComplete",
+              type: "String",
+              description:
+                "Hint for user agents (browsers and assistive technologies) when providing automated assistance in filling out form field values. The disableAutocomplete field will take precedence over this field",
+              optional: true,
+            },
+            {
               name: "enableShow",
               type: "Bool",
               description: "Displays a show/hide text link that reveals passwords",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.57.2",
+  "version": "2.58.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -13,6 +13,7 @@ import "../less/forms.less";
 export interface Props {
   disabled?: boolean;
   disableAutocomplete?: boolean;
+  autoComplete?: string;
   enableShow?: boolean;
   error?: string;
   label?: string;
@@ -43,6 +44,7 @@ const propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   disableAutocomplete: PropTypes.bool,
+  autoComplete: PropTypes.string,
   enableShow: PropTypes.bool,
   error: PropTypes.string,
   label: PropTypes.string,
@@ -190,6 +192,13 @@ export class TextInput extends React.Component<Props, State> {
       type = this.props.type || "text";
     }
 
+    let autoComplete;
+    if (this.props.disableAutocomplete) {
+      autoComplete = "off";
+    } else if (this.props.autoComplete) {
+      autoComplete = this.props.autoComplete;
+    }
+
     const additionalProps = _.omit(this.props, Object.keys(
       propTypes,
     ) as (keyof typeof propTypes)[]);
@@ -210,7 +219,7 @@ export class TextInput extends React.Component<Props, State> {
         </div>
         <input
           {...additionalProps}
-          autoComplete={this.props.disableAutocomplete && "off"}
+          autoComplete={autoComplete}
           className="TextInput--input"
           disabled={this.props.disabled}
           name={this.props.name}


### PR DESCRIPTION
**Jira:**
A necessary change for https://clever.atlassian.net/browse/FAMBAM-527. 

**Overview:**
This PR adds an autocomplete field to the TextInput component. From our accessibility audit for family-portal, we're learning that we should include the [autocomplete field](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) in order to provide a hint for user agents (browsers/assistive technologies) to provide automated assistance in filling out form field values.

Notes from the accessibility audit for family-portal:
![image](https://user-images.githubusercontent.com/21094551/94046840-0fc16900-fd86-11ea-8077-e42dc91cf9a4.png)

Other notes:
- I tried using the current additionalProps field, but that will be overridden by the current code for disableAutocomplete
- I also considered moving `additionalProps` lower in the list of props so that it would have precedence, but that may break other uses of additionalProps

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component