### PR TITLE
Add id to input component of TextInput (a11y)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.58.0",
+  "version": "2.58.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -205,7 +205,8 @@ export class TextInput extends React.Component<Props, State> {
 
     // (a11y) The 'for' attribute of the label tag and the 'id' attribute
     // of the input tag should match so screen readers can determine which
-    // label goes with which form element
+    // label goes with which form element. If an 'id' isn't specified, we
+    // use 'name' instead for this purpose.
     const id = additionalProps.id || this.props.name;
 
     return (

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -219,6 +219,7 @@ export class TextInput extends React.Component<Props, State> {
         </div>
         <input
           {...additionalProps}
+          id={this.props.name}
           autoComplete={autoComplete}
           className="TextInput--input"
           disabled={this.props.disabled}

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -203,6 +203,11 @@ export class TextInput extends React.Component<Props, State> {
       propTypes,
     ) as (keyof typeof propTypes)[]);
 
+    // (a11y) The 'for' attribute of the label tag and the 'id' attribute
+    // of the input tag should match so screen readers can determine which
+    // label goes with which form element
+    const id = additionalProps.id || this.props.name;
+
     return (
       <div
         className={classnames(
@@ -212,14 +217,14 @@ export class TextInput extends React.Component<Props, State> {
         )}
       >
         <div className="TextInput--infoRow">
-          <label className="TextInput--label" htmlFor={this.props.name}>
+          <label className="TextInput--label" htmlFor={id}>
             {this.props.label}
           </label>
           <span aria-live="polite">{inputNote}</span>
         </div>
         <input
           {...additionalProps}
-          id={this.props.name}
+          id={id}
           autoComplete={autoComplete}
           className="TextInput--input"
           disabled={this.props.disabled}


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FAMBAM-539

Notes from accessibility audit:
![image](https://user-images.githubusercontent.com/21094551/94070902-dac60e00-fda7-11ea-92a3-dc3c61c151e5.png)


**Overview:**
This PR adds an id to to the input component of TextInput to match that of the "for" attribute of the label component. We're learning from the most recent accessibility audit to family-portal that these should match for blind people to determine which label goes with which form element. Rather than making the change just in fampo, this seems applicable to all TextInputs. 

This change is compatible even if prior uses of TextInput pass in an id prop as that will take precedence over the default `this.props.name` and in both cases, the same value will be applied to the two tag attributes as desired. 

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component