### PR TITLE
Table2Beta: Mobile Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.59.1",
+  "version": "2.59.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table2Beta/SelectedRowsHeader.less
+++ b/src/Table2Beta/SelectedRowsHeader.less
@@ -1,7 +1,7 @@
 @import (reference) "../less/utilities.less";
 
 .Table2Beta--selectedRowsHeader {
-  height: 1.5rem;
+  height: 3.5rem;
   line-height: 1.5rem;
   .border--s(@neutral_silver);
   .borderRadius--top--l;
@@ -14,6 +14,7 @@
   color: @neutral_dark_gray;
   font-family: "Proxima Nova";
   width: 100%;
+  box-sizing: border-box;
 }
 
 .Table2Beta--selectedRowsHeader--actionsFlexbox {


### PR DESCRIPTION
**Jira:**

**Overview:**
I broke the mobile version of the SelectedRowsHeader in 2.59.1. Fixing it here. 

**Screenshots/GIFs:**
Broken version:
<img width="444" alt="Screen Shot 2020-09-29 at 4 08 40 PM" src="https://user-images.githubusercontent.com/12452249/94625621-0c3e4e00-026e-11eb-8b49-03f5e05627ec.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component