### PR TITLE
Add TabBar and TabBar.Tab a11y attributes

### DIFF
--- a/docs/components/TabBarView.jsx
+++ b/docs/components/TabBarView.jsx
@@ -126,6 +126,16 @@ export default class TabBarView extends PureComponent {
               defaultValue: "False",
               optional: true,
             },
+            {
+              name: "tabContentID",
+              type: "String",
+              description:
+                "The id tag of the tab content associated with the tab. For a11y purposes; Make sure to " +
+                "define the attributes role='tabpanel' and aria-labelledby={tabID} for the html tag marked with " +
+                "this tabContentID. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role",
+              defaultValue: "",
+              optional: true,
+            },
           ]}
           className={cssClass.PROPS}
           title="Tab"

--- a/docs/components/TabBarView.jsx
+++ b/docs/components/TabBarView.jsx
@@ -130,9 +130,9 @@ export default class TabBarView extends PureComponent {
               name: "tabContentID",
               type: "String",
               description:
-                "The id tag of the tab content associated with the tab. For a11y purposes; Make sure to " +
-                "define the attributes role='tabpanel' and aria-labelledby={tabID} for the html tag marked with " +
-                "this tabContentID. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role",
+                "The id attribute of the tab content associated with the tab. For a11y purposes, be sure to " +
+                "define the attributes role='tabpanel' and aria-labelledby={tabID} on this tab content: " +
+                "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role",
               defaultValue: "",
               optional: true,
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.63.2",
+  "version": "2.64.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TabBar/Tab.tsx
+++ b/src/TabBar/Tab.tsx
@@ -15,6 +15,7 @@ export interface Props {
   id: any;
   onSelect?: (id: any) => void;
   selected?: boolean;
+  tabContentID?: string;
 }
 
 export const cssClass = {
@@ -32,6 +33,7 @@ export default function Tab({
   id,
   onSelect,
   selected,
+  tabContentID,
   ...additionalProps
 }: Props) {
   let Wrapper = component;
@@ -56,6 +58,9 @@ export default function Tab({
         }
         onSelect(id);
       }}
+      role="tab"
+      aria-selected={selected}
+      aria-controls={tabContentID}
       {...additionalProps}
     >
       {children}

--- a/src/TabBar/TabBar.tsx
+++ b/src/TabBar/TabBar.tsx
@@ -33,6 +33,7 @@ const TabBar: TabBarComponent = function TabBar({ children, className, justify, 
     <FlexBox
       className={classnames(cssClass.CONTAINER, cssClass.size(size), className)}
       justify={justify}
+      role="tablist"
     >
       {children}
     </FlexBox>


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FAMBAM-540

**Overview:**
Adding compatibility for aria attributes for the TabBar + Tab components. We're learning from the accessibility audit for Family Portal that we should be adding labels to the tab components describing their role, giving the tags an id, and referencing the corresponding tab panel content. 

Related PR: https://github.com/Clever/family-portal/pull/200

Accessibility audit notes:
![image](https://user-images.githubusercontent.com/21094551/95793337-32b2af00-0c9a-11eb-8762-237c0363dfd2.png)

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component