### PR TITLE
Fambam 541 MessagingInput accessibility and translation support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -2,6 +2,11 @@
 
 .MessagingInput--Container {
   position: relative;
+  .margin--top--2xs();
+}
+
+.MessagingInput--TextFieldLabel {
+  color: @neutral_medium_gray;
 }
 
 .MessagingInput--TextField {

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -26,6 +26,8 @@ export interface MessagingInputHandle {
   focus(): void;
 }
 
+const TEXT_FIELD_NAME = "newMessage";
+
 const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInputHandle, Props> = (
   props,
   ref,
@@ -42,52 +44,54 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
   }));
 
   return (
-    <FlexBox className={cx(cssClass("Container"), className)} alignItems={ItemAlign.END}>
-      <TextArea
-        ref={textAreaRef}
-        className={cssClass("TextField")}
-        name="newMessage"
-        placeholder="Message"
-        value={value}
-        onChange={e => {
-          onChange(e.target.value);
-        }}
-        onKeyDown={e => {
-          // Shift+Enter is a line-break.
-          // Enter alone is an attempt to Send, unless prop is
-          //  explicitly set to have enter be a newline.
-          if (e.key === KeyCode.ENTER && !e.shiftKey && !newlineOnEnter) {
-            e.preventDefault();
-            // If something other than whitespace is in the input area, Send the message.
-            if (value.trim() !== "") {
-              onSubmit(value.trim());
+    <>
+      <label htmlFor={TEXT_FIELD_NAME} className={cssClass("TextFieldLabel")}>Send a message</label>
+      <FlexBox className={cx(cssClass("Container"), className)} alignItems={ItemAlign.END}>
+        <TextArea
+          ref={textAreaRef}
+          className={cssClass("TextField")}
+          name={TEXT_FIELD_NAME}
+          value={value}
+          onChange={e => {
+            onChange(e.target.value);
+          }}
+          onKeyDown={e => {
+            // Shift+Enter is a line-break.
+            // Enter alone is an attempt to Send, unless prop is
+            //  explicitly set to have enter be a newline.
+            if (e.key === KeyCode.ENTER && !e.shiftKey && !newlineOnEnter) {
+              e.preventDefault();
+              // If something other than whitespace is in the input area, Send the message.
+              if (value.trim() !== "") {
+                onSubmit(value.trim());
+              }
             }
+          }}
+          onBlur={onBlur}
+          autoResize
+          // The field starts with `rows + 1` rows, so
+          //  passing in 0 gets us the desired starting height.
+          rows={0}
+        />
+        <Button
+          className={cssClass("SendButton")}
+          type="primary"
+          value={
+            <>
+              <img
+                className={cssClass("SendIcon")}
+                alt="Send message"
+                src={require("./arrow_send.svg")}
+              />
+              <span className={cssClass("SendText")}>Send</span>
+            </>
           }
-        }}
-        onBlur={onBlur}
-        autoResize
-        // The field starts with `rows + 1` rows, so
-        //  passing in 0 gets us the desired starting height.
-        rows={0}
-      />
-      <Button
-        className={cssClass("SendButton")}
-        type="primary"
-        value={
-          <>
-            <img
-              className={cssClass("SendIcon")}
-              alt="Send message"
-              src={require("./arrow_send.svg")}
-            />
-            <span className={cssClass("SendText")}>Send</span>
-          </>
-        }
-        // Disable the Send if nothing but whitespace is in the input field.
-        disabled={!value.trim()}
-        onClick={() => onSubmit(value.trim())}
-      />
-    </FlexBox>
+          // Disable the Send if nothing but whitespace is in the input field.
+          disabled={!value.trim()}
+          onClick={() => onSubmit(value.trim())}
+        />
+      </FlexBox>
+    </>
   );
 };
 

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -20,6 +20,10 @@ interface Props {
   //  the consumer would have to handle the trim themselves.
   onSubmit: (message: string) => void;
   onBlur?: () => void;
+  /** Temporarily added to allow overriding the text with a translation. */
+  sendButtonText?: string;
+  /** Temporarily added to allow overriding the text with a translation. */
+  labelText?: string;
 }
 
 export interface MessagingInputHandle {
@@ -32,7 +36,16 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
   props,
   ref,
 ) => {
-  const { className, newlineOnEnter, value, onChange, onSubmit, onBlur } = props;
+  const {
+    className,
+    newlineOnEnter,
+    value,
+    onChange,
+    onSubmit,
+    onBlur,
+    sendButtonText = "Send",
+    labelText = "Send a message",
+  } = props;
   const textAreaRef = React.useRef<TextArea>(null);
 
   React.useImperativeHandle(ref, () => ({
@@ -45,7 +58,9 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
 
   return (
     <>
-      <label htmlFor={TEXT_FIELD_NAME} className={cssClass("TextFieldLabel")}>Send a message</label>
+      <label htmlFor={TEXT_FIELD_NAME} className={cssClass("TextFieldLabel")}>
+        {labelText}
+      </label>
       <FlexBox className={cx(cssClass("Container"), className)} alignItems={ItemAlign.END}>
         <TextArea
           ref={textAreaRef}
@@ -83,7 +98,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
                 alt="Send message"
                 src={require("./arrow_send.svg")}
               />
-              <span className={cssClass("SendText")}>Send</span>
+              <span className={cssClass("SendText")}>{sendButtonText}</span>
             </>
           }
           // Disable the Send if nothing but whitespace is in the input field.

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -16,6 +16,7 @@ export interface Props {
   maxLength?: number;
   minLength?: number;
   name: string;
+  id?: string;
   onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
   onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
   onFocus?: React.FocusEventHandler<HTMLTextAreaElement>;
@@ -207,10 +208,17 @@ export class TextArea extends React.Component<Props, State> {
     // note on the upper right corner
     const inputNote = this.renderNote(errorMessage);
 
+    // (a11y) The 'for' attribute of the label tag and the 'id' attribute
+    // of the textarea tag should match so screen readers can determine which
+    // label goes with which form element. If an 'id' isn't specified, we
+    // use 'name' instead for this purpose.
+    const id = this.props.id || this.props.name;
+
     const textAreaProps = {
       ["aria-invalid"]: !valid,
       className: "TextArea--input",
       disabled: this.props.disabled,
+      id,
       maxLength: this.props.maxLength,
       minLength: this.props.minLength,
       name: this.props.name,
@@ -251,9 +259,11 @@ export class TextArea extends React.Component<Props, State> {
         )}
       >
         <div className="TextArea--infoRow">
-          <label className="TextArea--label" htmlFor={this.props.name}>
-            {this.props.label}
-          </label>
+          {this.props.label && (
+            <label className="TextArea--label" htmlFor={id}>
+              {this.props.label}
+            </label>
+          )}
           <span aria-live="polite">{inputNote}</span>
         </div>
         {textarea}


### PR DESCRIPTION
**Jira:** https://clever.atlassian.net/browse/FAMBAM-541 (see ticket for design instructions/mock)

**Overview:** This PR makes a few changes to make the MessagingInput more accessible and also support translations in the FamPo.

The first commit fixes some accessibility support for `TextArea`. Previously, the underlying `textarea` would never have an `id`, which meant that labels could never properly be associated with them. Previously we used `htmlFor` with the `name` but, I don't believe that actually works. 

Instead, we make a similar change to the one Julie recently made and support using the `name` as the `id` by default. I also added support for explicitly setting an `id` since `name` and `id` do have slightly different requirements (`id` needs to be unique, `name` doesn't). I don't think there will be many cases where explicitly setting an `id` is necessary though.

We also make a change to only include the `TextArea's` internal `label` if there's any text to display. This avoids an issue where the accessibility checker complained about the underlying `textarea` in `MessagingInput` having two labels.

The second commit makes the accessibility changes for `MessagingInput` by adding an external `label` and removing the placeholder text.

The third commit makes it possible to override the text used for the label and send button. This is a temporary measure to be used in the FamPo so that we can pass translations through. In the future, we'd like to support translations inside `clever-components` so that passing them through isn't necessary.


**Screenshots/GIFs:**
<img width="853" alt="Screen Shot 2020-09-30 at 1 01 20 PM" src="https://user-images.githubusercontent.com/39533986/94733745-0eabb100-031d-11eb-80ff-1930d490ae80.png">


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [X] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component