### PR TITLE
Push the label into the MessageInput--Container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.61.0",
+  "version": "2.61.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -2,7 +2,11 @@
 
 .MessagingInput--Container {
   position: relative;
+}
+
+.MessagingInput--InnerContainer {
   .margin--top--2xs();
+  width: 100%;
 }
 
 .MessagingInput--TextFieldLabel {

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -5,12 +5,12 @@
 }
 
 .MessagingInput--InnerContainer {
-  .margin--top--2xs();
   width: 100%;
 }
 
 .MessagingInput--TextFieldLabel {
   color: @neutral_medium_gray;
+  .margin--bottom--2xs();
 }
 
 .MessagingInput--TextField {

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -57,11 +57,11 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
   }));
 
   return (
-    <>
+    <FlexBox className={cx(cssClass("Container"), className)} column alignItems={ItemAlign.START}>
       <label htmlFor={TEXT_FIELD_NAME} className={cssClass("TextFieldLabel")}>
         {labelText}
       </label>
-      <FlexBox className={cx(cssClass("Container"), className)} alignItems={ItemAlign.END}>
+      <FlexBox className={cssClass("InnerContainer")}>
         <TextArea
           ref={textAreaRef}
           className={cssClass("TextField")}
@@ -106,7 +106,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
           onClick={() => onSubmit(value.trim())}
         />
       </FlexBox>
-    </>
+    </FlexBox>
   );
 };
 


### PR DESCRIPTION
**Overview:** A small fix for #545, this makes the label part of the container. Before this change, the label was getting spaced in unexpected ways because only the container gets a style applied when a `className` is passed in.

**Screenshots/GIFs:**
<img width="858" alt="Screen Shot 2020-09-30 at 3 40 55 PM" src="https://user-images.githubusercontent.com/39533986/94747470-d368ac80-0333-11eb-9b67-6ac7ba871196.png">


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component