### PR TITLE
Fix timestamp positioning when no content preview is provided

### DIFF
--- a/docs/components/MessagingThreadListItemView.jsx
+++ b/docs/components/MessagingThreadListItemView.jsx
@@ -72,8 +72,11 @@ export default class MessagingThreadListItemView extends React.PureComponent {
             <MessagingThreadListItem
               icon={<Icon name="smiley-face" />}
               title="Smiley Dude"
+              status={status}
               hasDraft={hasDraft}
+              isRead={isRead}
               selected={selected}
+              timestamp={new Date()}
             />
           </ExampleCode>
           {this._renderConfig()}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.61.2",
+  "version": "2.61.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadListItem/MessagingThreadListItem.less
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.less
@@ -47,6 +47,7 @@
 
 .ThreadListItem--Timestamp {
   margin-left: auto;
+  margin-right: none;
   .text--nowrap();
   font-size: 0.875rem;
   .text--line-height-1();
@@ -66,6 +67,12 @@
   margin-left: auto;
   // Size is fixed so that the preview text cuts off at the same
   //  point for messages w/ or w/o drafts/new messages indicators
+  width: @size_s;
+}
+
+.ThreadListItem--Indicator--Container--Inline {
+  .flexShrink(0);
+  .margin--left--m();
   width: @size_s;
 }
 

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -19,6 +19,7 @@ const cssClasses = {
   TIMESTAMP: "ThreadListItem--Timestamp",
   TIMESTAMP_SELECTED: "ThreadListItem--Timestamp--selected",
   INDICATOR_CONTAINER: "ThreadListItem--Indicator--Container",
+  INDICATOR_CONTAINER_INLINE: "ThreadListItem--Indicator--Container--Inline",
   DRAFT_INDICATOR: "ThreadListItem--DraftIndicator",
   UNREAD_ORB: "ThreadListItem--UnreadOrb",
   UNREAD_TEXT: "ThreadListItem--UnreadText",
@@ -67,8 +68,13 @@ export const MessagingThreadListItem: React.FC<
     subContentClass = cssClasses.OFF_TEXT;
   }
 
-  const indicator = (
-    <FlexBox className={cssClasses.INDICATOR_CONTAINER} justify={Justify.END}>
+  const hasIndicator = !isRead || (status === "active" && hasDraft);
+  const indicatorClass = subContent
+    ? cssClasses.INDICATOR_CONTAINER
+    : cssClasses.INDICATOR_CONTAINER_INLINE;
+
+  const indicator = hasIndicator && (
+    <FlexBox className={indicatorClass} justify={Justify.END}>
       {!isRead ? (
         <div className={cssClasses.UNREAD_ORB} />
       ) : (


### PR DESCRIPTION
**Overview:**

We are implementing progressive loading of the MessagesPage which will mean for all threads we will no longer have a message to render a preview in the thread list. However we will have a timestamp of the last message, and we want to show that without a preview. But the timestamp positioning was incorrect in such a case. This fixes it.

**Screenshots/GIFs:**

Before:
![Screen Shot 2020-10-01 at 2 20 27 PM](https://user-images.githubusercontent.com/10870634/94866260-d62ad680-03f3-11eb-9aee-fc1ad585ba3b.png)

After:
![Screen Shot 2020-10-01 at 2 33 56 PM](https://user-images.githubusercontent.com/10870634/94866268-daef8a80-03f3-11eb-917b-dbfa7c27d6e7.png)

With an indicator:
![Screen Shot 2020-10-01 at 2 34 05 PM](https://user-images.githubusercontent.com/10870634/94866284-e0e56b80-03f3-11eb-87f7-7afdc3b5d839.png)
![Screen Shot 2020-10-01 at 2 35 09 PM](https://user-images.githubusercontent.com/10870634/94866291-e347c580-03f3-11eb-8655-a0c4492220fe.png)

**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`

- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)