### PR TITLE
Table2Beta: Small Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.61.2",
+  "version": "2.61.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table2Beta/SelectedRowsHeader.less
+++ b/src/Table2Beta/SelectedRowsHeader.less
@@ -13,7 +13,6 @@
   background-color: @neutral_off_white;
   color: @neutral_dark_gray;
   font-family: "Proxima Nova";
-  width: 100%;
 }
 
 .Table2Beta--selectedRowsHeader--actionsFlexbox {


### PR DESCRIPTION
**Jira:**

**Overview:**
SelectedRowsHeader no longer has to be set to 100% to work on desktop. It's difficult to test the table's performance in mobile, so 🤞 

**Screenshots/GIFs:**

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component