### PR TITLE
Temporary prop overrides to allow translations to be passed in

### DIFF
--- a/docs/components/TextInputView.jsx
+++ b/docs/components/TextInputView.jsx
@@ -173,6 +173,12 @@ export default class TextInputView extends Component {
               optional: true,
             },
             {
+              name: "hideButtonText",
+              type: "String",
+              description: "(Temporary) allows overriding the Hide button text with translations",
+              optional: true,
+            },
+            {
               name: "label",
               type: "String",
               description: "Label for input",
@@ -230,6 +236,12 @@ export default class TextInputView extends Component {
               name: "required",
               type: "Bool",
               description: "Marks input as required and adds indicator",
+              optional: true,
+            },
+            {
+              name: "showButtonText",
+              type: "String",
+              description: "(Temporary) allows overriding the Show button text with translations",
               optional: true,
             },
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.61.3",
+  "version": "2.62.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -17,6 +17,8 @@ export interface Props {
   disableAutocomplete?: boolean;
   enableShow?: boolean;
   error?: string;
+  /** Temporary prop to allow overriding the text with a translation. */
+  hideButtonText?: string;
   label?: string;
   name: string;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
@@ -28,6 +30,8 @@ export interface Props {
   placeholderCaps?: boolean;
   readOnly?: boolean;
   required?: boolean;
+  /** Temporary prop to allow overriding the text with a translation. */
+  showButtonText?: string;
   size?: Values<typeof FormElementSize>;
   type?: string;
   value?: React.ReactNode;
@@ -47,6 +51,7 @@ const propTypes = {
   disableAutocomplete: PropTypes.bool,
   enableShow: PropTypes.bool,
   error: PropTypes.string,
+  hideButtonText: PropTypes.string,
   label: PropTypes.string,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
@@ -58,6 +63,7 @@ const propTypes = {
   placeholderCaps: PropTypes.bool,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
+  showButtonText: PropTypes.string,
   size: PropTypes.oneOf(Object.values(FormElementSize)),
   type: PropTypes.string,
   value: PropTypes.node,
@@ -209,6 +215,9 @@ export class TextInput extends React.Component<Props, State> {
     // use 'name' instead for this purpose.
     const id = additionalProps.id || this.props.name;
 
+    const hideButtonText = this.props.hideButtonText || "Hide";
+    const showButtonText = this.props.showButtonText || "Show";
+
     return (
       <div
         className={classnames(
@@ -254,7 +263,7 @@ export class TextInput extends React.Component<Props, State> {
               event.stopPropagation();
             }}
           >
-            {this.state.hidden ? "Show" : "Hide"}
+            {this.state.hidden ? showButtonText : hideButtonText}
           </button>
         )}
       </div>

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -11,9 +11,10 @@ import "./TextInput.less";
 import "../less/forms.less";
 
 export interface Props {
-  disabled?: boolean;
-  disableAutocomplete?: boolean;
   autoComplete?: string;
+  disabled?: boolean;
+  className?: string;
+  disableAutocomplete?: boolean;
   enableShow?: boolean;
   error?: string;
   label?: string;
@@ -30,7 +31,6 @@ export interface Props {
   size?: Values<typeof FormElementSize>;
   type?: string;
   value?: React.ReactNode;
-  className?: string;
   [additionalProp: string]: any;
 }
 
@@ -41,10 +41,10 @@ interface State {
 }
 
 const propTypes = {
+  autoComplete: PropTypes.string,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   disableAutocomplete: PropTypes.bool,
-  autoComplete: PropTypes.string,
   enableShow: PropTypes.bool,
   error: PropTypes.string,
   label: PropTypes.string,


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FAMBAM-574

**Overview:**
This change introduces new props to allow us to override the "Show" and "Hide" button text. The change will be used for passing in translation strings, and it's only intended to be a temporary solution.

I'm open to thoughts on whether these props should be in the docs. I went ahead and added them and noted that they're intended to be temporary.

**Screenshots/GIFs:**
<img width="1086" alt="Screen Shot 2020-10-01 at 7 23 41 PM" src="https://user-images.githubusercontent.com/32328921/94882060-c8894700-041b-11eb-8f98-e49d72cd2b3e.png">
<img width="1097" alt="Screen Shot 2020-10-01 at 7 23 50 PM" src="https://user-images.githubusercontent.com/32328921/94882062-c921dd80-041b-11eb-97e0-7a200ba05ab0.png">


**Testing:**
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component