### PR TITLE
TextInput & TextArea: adding aria-label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.62.4",
+  "version": "2.62.5",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -216,6 +216,7 @@ export class TextArea extends React.Component<Props, State> {
 
     const textAreaProps = {
       ["aria-invalid"]: !valid,
+      ["aria-label"]: this.props.label,
       className: "TextArea--input",
       disabled: this.props.disabled,
       id,

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -251,6 +251,7 @@ export class TextInput extends React.Component<Props, State> {
           type={type}
           value={this.props.value as any}
           aria-invalid={!valid}
+          aria-label={this.props.label}
         />
         {this.props.enableShow && (
           <button


### PR DESCRIPTION
**Jira:** [DISC-1938](https://clever.atlassian.net/browse/DISC-1938)

**Overview:**

* adds aria-label to TextInput & TextArea

* label already exists & `for` that matches `id` on the TextInput/TextArea, but we failed [this audit](https://axeauditor.dequecloud.com/test-run/d1345326-b1e2-11ea-9de3-9b75a7b5960a/issue/f470570e-b796-11ea-9f9d-57f78cb91373?sortField=ordinal&sortDir=asc&filter%5Bseverity%5D%5B0%5D=4&filter%5Bseverity%5D%5B1%5D=5&filter%5Bpage_number%5D=18&row=0). I speculate because the label is hidden when no text has been entered yet (a placeholder is displayed, but the placeholder doesn't match these accessibility rules). adding `aria-label` was one of their suggested fixes & it covers this gap in accessibility

**Screenshots/GIFs:**

![Screen Shot 2020-10-09 at 1 47 20 PM](https://user-images.githubusercontent.com/13992076/95630481-c2582380-0a36-11eb-9734-74bd5d019959.png)
![Screen Shot 2020-10-09 at 1 47 09 PM](https://user-images.githubusercontent.com/13992076/95630542-e61b6980-0a36-11eb-9abf-d2159bc250c0.png)



**Testing:**
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE10

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component