### PR TITLE
Table2Beta: More Bug Fixes and Feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.62.2",
+  "version": "2.62.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table2Beta/SelectedRowsHeader.tsx
+++ b/src/Table2Beta/SelectedRowsHeader.tsx
@@ -68,7 +68,7 @@ export default function SelectedRowsHeader({
               </div>
             </>
           )}
-          {allSelected && (
+          {rowsAreSelected && allSelected && (
             <div>{`All ${contentType.plural || "rows"} selected (${selectedRows.size})`}</div>
           )}
         </FlexItem>

--- a/src/Table2Beta/Table.less
+++ b/src/Table2Beta/Table.less
@@ -48,6 +48,7 @@
 .Table2Beta--singleActions,
 .Table2Beta--singleActions--hidden {
   align-items: center;
+  margin-left: -1rem;
 }
 
 .Table2Beta--singleActions--hidden {

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -223,6 +223,8 @@ export class Table2Beta extends React.Component<Props, State> {
     if (newSelectedRows.size !== selectedRows.size) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ selectedRows: newSelectedRows });
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({ allSelected: false });
     }
   }
 


### PR DESCRIPTION
**Jira:**

https://youtu.be/2EwViQxSJJQ?t=19

**Overview:**
Moving the actions a little to the left, so they're lined up with the Action header. Also addressed a bug where, if you selected all rows in a filtered mode, and changed to a different filter, the SelectedRowsHeader would count it as selecting both all and no rows. 

**Screenshots/GIFs:**
<img width="332" alt="Screen Shot 2020-10-09 at 3 17 25 PM" src="https://user-images.githubusercontent.com/12452249/95636676-95127200-0a44-11eb-9d0c-82ac74891174.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Firefox

**Roll Out:**
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component