### PR TITLE
Table2Beta: No selection name

### DIFF
--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -492,6 +492,14 @@ export default class Table2BetaView extends React.PureComponent {
               defaultValue: '{ singular: "row", plural: "rows" }',
             },
             {
+              name: "selectedRowsHeaderContentTypeNoSelection",
+              type: "string",
+              description:
+                "Description of the content displayed when no rows are selected. Useful if you have filters that change the row types (ex: filter from all students to inactive students)",
+              optional: true,
+              defaultValue: "rows",
+            },
+            {
               name: "selectedRowsHeaderActions",
               type: "Array<ActionInput>",
               description:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.62.3",
+  "version": "2.62.4",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table2Beta/SelectedRowsHeader.tsx
+++ b/src/Table2Beta/SelectedRowsHeader.tsx
@@ -11,6 +11,7 @@ interface Props {
   className?: string;
   selectedRows: Set<any>;
   contentType?: { singular: string; plural?: string };
+  contentTypeNoSelection?: string;
   actions: Array<ActionInput>;
   allSelected: boolean;
   numDisplayedActions: number;
@@ -34,6 +35,7 @@ export default function SelectedRowsHeader({
   className,
   selectedRows,
   contentType,
+  contentTypeNoSelection,
   actions,
   numDisplayedActions,
   allSelected,
@@ -58,7 +60,7 @@ export default function SelectedRowsHeader({
     <div className={className}>
       <FlexBox grow className={cssClasses.ROW} column={compact}>
         <FlexItem className={cssClasses.SELECTED_TEXT} grow>
-          {!rowsAreSelected && <div>Select {contentType.plural || "rows"} to access tools</div>}
+          {!rowsAreSelected && <div>Select {contentTypeNoSelection || "rows"} to access tools</div>}
           {rowsAreSelected && !allSelected && (
             <>
               <div>

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -65,6 +65,7 @@ export interface Props {
   singleActions?: Array<ActionInput>;
   showSingleActionsOnHover?: boolean;
   selectedRowsHeaderContentType?: { singular: string; plural?: string };
+  selectedRowsHeaderContentTypeNoSelection?: string;
   selectedRowsHeaderActions?: Array<ActionInput>;
   numDisplayedActions?: number;
 
@@ -514,6 +515,7 @@ export class Table2Beta extends React.Component<Props, State> {
       showSingleActionsOnHover,
       visiblePageRangeSize,
       selectedRowsHeaderContentType,
+      selectedRowsHeaderContentTypeNoSelection,
       selectedRowsHeaderActions,
     } = this.props;
     const { lazy, numRows } = this.props;
@@ -549,6 +551,7 @@ export class Table2Beta extends React.Component<Props, State> {
             className={className}
             selectedRows={selectedRows}
             contentType={selectedRowsHeaderContentType}
+            contentTypeNoSelection={selectedRowsHeaderContentTypeNoSelection}
             actions={selectedRowsHeaderActions}
             numDisplayedActions={numDisplayedActions}
             allSelected={this.state.allSelected}


### PR DESCRIPTION
**Jira:**

**Overview:**
A new field has been added. When you don't have any rows selected, it can use a default name. This is useful when you have filters that change your data type, but don't want to change the initial "Select __ to access tools".

**Screenshots/GIFs:**
<img width="1082" alt="Screen Shot 2020-10-09 at 4 23 12 PM" src="https://user-images.githubusercontent.com/12452249/95639033-bc207200-0a4b-11eb-8fb7-66b507230bbf.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component