### PR TITLE
Table2Beta: ClassNames and allSelected fix

### DIFF
--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -471,11 +471,23 @@ export default class Table2BetaView extends React.PureComponent {
               optional: true,
             },
             {
+              name: "checkboxClassName",
+              type: "String",
+              description: "Additional classname to apply to the checkbox cells",
+              optional: true,
+            },
+            {
               name: "singleActions",
               type: "Array<ActionInput>",
               description: "An array of ActionInputs, to be present for every row",
               optional: true,
               defaultValue: "None",
+            },
+            {
+              name: "singleActionsClassName",
+              type: "String",
+              description: "Additional classname to apply to the singleActions cells",
+              optional: true,
             },
             {
               name: "showSingleActionsOnHover",

--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -18,6 +18,7 @@ const sampleActionInputs = [
     },
     title: { singular: "Launch an app" },
     icon: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg",
+    hoverIcon: "https://www.freeiconspng.com/uploads/troll-face-png-1.png",
   },
   {
     callback: () => console.log("sampleAction 2"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.63.0",
+  "version": "2.63.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table2Beta/Table.less
+++ b/src/Table2Beta/Table.less
@@ -85,6 +85,24 @@
   vertical-align: middle;
 }
 
+.Table2Beta--actions--hoverIcon {
+  display: none;
+  height: 1.5rem;
+  width: 1.25rem;
+  margin-right: 0.3125rem;
+  vertical-align: middle;
+}
+
+.Table2Beta--actions--iconContainer:hover {
+  .Table2Beta--actions--icon {
+    display: none;
+  }
+
+  .Table2Beta--actions--hoverIcon {
+    display: inline-block;
+  }
+}
+
 .Table2Beta--actions--title {
   display: inline-block;
   .text--medium;

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -217,7 +217,7 @@ export class Table2Beta extends React.Component<Props, State> {
   }
 
   componentDidUpdate() {
-    const { selectedRows } = this.state;
+    const { selectedRows, allSelected } = this.state;
     const { allRows } = this._getDisplayedData();
 
     // This occurs when a new external filter is applied.
@@ -228,11 +228,12 @@ export class Table2Beta extends React.Component<Props, State> {
         newSelectedRows.delete(item);
       }
     });
-    if (newSelectedRows.size !== selectedRows.size) {
+    const newAllSelected = (allRows && newSelectedRows.size === allRows.length) || false;
+    if (newSelectedRows.size !== selectedRows.size || allSelected !== newAllSelected) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ selectedRows: newSelectedRows });
       // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ allSelected: false });
+      this.setState({ allSelected: newAllSelected });
     }
   }
 
@@ -583,10 +584,10 @@ export class Table2Beta extends React.Component<Props, State> {
                 <HeaderCell>
                   <Checkbox
                     checked={selectedRows.size > 0}
-                    partial={selectedRows.size < (displayedData || allRows).length}
+                    partial={selectedRows.size < allRows.length}
                     onChange={(newState) => {
                       if (selectedRows.size === 0) {
-                        selectedRows = new Set(displayedData || allRows);
+                        selectedRows = new Set(allRows);
                         this.setState({ allSelected: true });
                       } else {
                         selectedRows.clear();

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -39,6 +39,7 @@ export interface ActionInput {
   callback(selectedRows: Set<any>): void;
   title: { singular: React.ReactNode; plural?: React.ReactNode };
   icon?: string;
+  hoverIcon?: string;
 }
 
 export interface Props {
@@ -63,7 +64,9 @@ export interface Props {
   noDataContent?: React.ReactNode;
   selectable?: boolean;
   singleActions?: Array<ActionInput>;
+  checkboxClassName?: string;
   showSingleActionsOnHover?: boolean;
+  singleActionsClassName?: string;
   selectedRowsHeaderContentType?: { singular: string; plural?: string };
   selectedRowsHeaderContentTypeNoSelection?: string;
   selectedRowsHeaderActions?: Array<ActionInput>;
@@ -112,7 +115,9 @@ const propTypes = {
   rowClassNameFn: PropTypes.func,
   noDataContent: PropTypes.node,
   selectable: PropTypes.bool,
+  checkboxClassName: PropTypes.string,
   singleActions: PropTypes.array,
+  singleActionsClassName: PropTypes.string,
   showSingleActionsOnHover: PropTypes.bool,
 
   // these must all be set together
@@ -147,6 +152,8 @@ export const cssClass = {
   SINGLE_ACTIONS: "Table2Beta--singleActions",
   SINGLE_ACTION_TRIGGER: "Table2Beta--singleActionTrigger",
   ACTION_ICON: "Table2Beta--actions--icon",
+  ACTION_ICON_CONTAINER: "Table2Beta--actions--iconContainer",
+  ACTION_HOVER_ICON: "Table2Beta--actions--hoverIcon",
   ACTION_TITLE: "Table2Beta--actions--title",
   ACTION_MENU: "Table2Beta--actions--menu",
   ACTION_MENU_ITEM: "Table2Beta--actions--menu--item",
@@ -445,9 +452,14 @@ export class Table2Beta extends React.Component<Props, State> {
           type="link"
           value={
             <>
-              {singleActions[0].icon && (
-                <img className={cssClass.ACTION_ICON} src={singleActions[0].icon} />
-              )}
+              <span className={singleActions[0].hoverIcon && cssClass.ACTION_ICON_CONTAINER}>
+                {singleActions[0].icon && (
+                  <img className={cssClass.ACTION_ICON} src={singleActions[0].icon} />
+                )}
+                {singleActions[0].hoverIcon && (
+                  <img className={cssClass.ACTION_HOVER_ICON} src={singleActions[0].hoverIcon} />
+                )}
+              </span>
               <div className={cssClass.ACTION_TITLE}>{singleActions[0].title.singular}</div>
             </>
           }
@@ -462,9 +474,14 @@ export class Table2Beta extends React.Component<Props, State> {
             type="link"
             value={
               <>
-                {singleActions[0].icon && (
-                  <img className={cssClass.ACTION_ICON} src={singleActions[0].icon} />
-                )}
+                <span className={singleActions[0].hoverIcon && cssClass.ACTION_ICON_CONTAINER}>
+                  {singleActions[0].icon && (
+                    <img className={cssClass.ACTION_ICON} src={singleActions[0].icon} />
+                  )}
+                  {singleActions[0].hoverIcon && (
+                    <img className={cssClass.ACTION_HOVER_ICON} src={singleActions[0].hoverIcon} />
+                  )}
+                </span>
                 <div className={cssClass.ACTION_TITLE}>{singleActions[0].title.singular}</div>
               </>
             }
@@ -511,8 +528,10 @@ export class Table2Beta extends React.Component<Props, State> {
       noDataContent,
       numDisplayedActions,
       selectable,
+      checkboxClassName,
       singleActions,
       showSingleActionsOnHover,
+      singleActionsClassName,
       visiblePageRangeSize,
       selectedRowsHeaderContentType,
       selectedRowsHeaderContentTypeNoSelection,
@@ -629,7 +648,7 @@ export class Table2Beta extends React.Component<Props, State> {
                   }
                 >
                   {selectable && (
-                    <Cell>
+                    <Cell className={checkboxClassName}>
                       <Checkbox
                         checked={selectedRows.has(rowData)}
                         onChange={(newState) => {
@@ -661,9 +680,10 @@ export class Table2Beta extends React.Component<Props, State> {
                   {selectable && (
                     <Cell noWrap>
                       <div
-                        className={
-                          cssClass.SINGLE_ACTIONS + (showSingleActionsOnHover ? "--hidden" : "")
-                        }
+                        className={classnames(
+                          cssClass.SINGLE_ACTIONS + (showSingleActionsOnHover ? "--hidden" : ""),
+                          singleActionsClassName,
+                        )}
                       >
                         {this._singleActionsRender(rowData)}
                       </div>

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -228,7 +228,7 @@ export class Table2Beta extends React.Component<Props, State> {
         newSelectedRows.delete(item);
       }
     });
-    const newAllSelected = (allRows && newSelectedRows.size === allRows.length) || false;
+    const newAllSelected = !!(allRows && newSelectedRows.size === allRows.length);
     if (newSelectedRows.size !== selectedRows.size || allSelected !== newAllSelected) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ selectedRows: newSelectedRows });


### PR DESCRIPTION
**Jira:**

**Overview:**
Checkboxes and SingleActions can now take in custom styles. A bug was fixed in allSelected, where changing to a bigger data set via filter was not setting allSelected to the proper value. 

**Screenshots/GIFs:**
<img width="1130" alt="Screen Shot 2020-10-12 at 4 18 21 PM" src="https://user-images.githubusercontent.com/12452249/95798328-8e833500-0ca6-11eb-9150-a65b16372c67.png">
<img width="1112" alt="Screen Shot 2020-10-12 at 4 18 34 PM" src="https://user-images.githubusercontent.com/12452249/95798336-9511ac80-0ca6-11eb-840a-0b669cffdbf2.png">

**Testing:**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Firefox

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component