### PR TITLE
Add Read Receipts to Messaging components

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,13 +5,15 @@
 **Screenshots/GIFs:**
 
 **Testing:**
+
 - [ ] Unit tests
 - Manual tests:
   - [ ] Chrome
   - [ ] Safari
-  - [ ] IE10
+  - [ ] IE11
 
 **Roll Out:**
+
 - Before merging:
   - [ ] Updated docs
   - [ ] Bumped version in `package.json`

--- a/docs/components/MessagingThreadHistoryView.jsx
+++ b/docs/components/MessagingThreadHistoryView.jsx
@@ -42,6 +42,7 @@ function newMessage() {
     placement,
     timestamp: new Date(newestTime),
     index: currentMessageIndex,
+    isRead: true,
   };
 }
 
@@ -57,10 +58,11 @@ export default class MessagingThreadHistoryView extends React.PureComponent {
       newMessage(),
       newMessage(),
     ],
+    showReadStatus: true,
   };
 
   render() {
-    const { messages } = this.state;
+    const { messages, showReadStatus } = this.state;
 
     return (
       <View
@@ -88,7 +90,11 @@ export default class MessagingThreadHistoryView extends React.PureComponent {
 
         <Example title="Basic Usage:">
           <ExampleCode>
-            <MessagingThreadHistory threadID="abc" messages={messages} />
+            <MessagingThreadHistory
+              threadID="abc"
+              messages={messages}
+              showReadStatus={showReadStatus}
+            />
           </ExampleCode>
           {this._renderConfig()}
         </Example>
@@ -103,8 +109,18 @@ export default class MessagingThreadHistoryView extends React.PureComponent {
   };
 
   _renderConfig() {
+    const { showReadStatus } = this.state;
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            checked={showReadStatus}
+            className={cssClass.CONFIG_TOGGLE}
+            onChange={(e) => this.setState({ showReadStatus: e.target.checked })}
+          />{" "}
+          Show Read Status
+        </label>
         <Button type="primary" value="Add message" onClick={this.addMessage} />
       </FlexBox>
     );

--- a/docs/components/MessagingThreadHistoryView.jsx
+++ b/docs/components/MessagingThreadHistoryView.jsx
@@ -42,7 +42,7 @@ function newMessage() {
     placement,
     timestamp: new Date(newestTime),
     index: currentMessageIndex,
-    isRead: true,
+    readStatusText: "Read",
   };
 }
 
@@ -58,11 +58,10 @@ export default class MessagingThreadHistoryView extends React.PureComponent {
       newMessage(),
       newMessage(),
     ],
-    showReadStatus: true,
   };
 
   render() {
-    const { messages, showReadStatus } = this.state;
+    const { messages } = this.state;
 
     return (
       <View
@@ -90,11 +89,7 @@ export default class MessagingThreadHistoryView extends React.PureComponent {
 
         <Example title="Basic Usage:">
           <ExampleCode>
-            <MessagingThreadHistory
-              threadID="abc"
-              messages={messages}
-              showReadStatus={showReadStatus}
-            />
+            <MessagingThreadHistory threadID="abc" messages={messages} />
           </ExampleCode>
           {this._renderConfig()}
         </Example>
@@ -109,18 +104,8 @@ export default class MessagingThreadHistoryView extends React.PureComponent {
   };
 
   _renderConfig() {
-    const { showReadStatus } = this.state;
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
-        <label className={cssClass.CONFIG}>
-          <input
-            type="checkbox"
-            checked={showReadStatus}
-            className={cssClass.CONFIG_TOGGLE}
-            onChange={(e) => this.setState({ showReadStatus: e.target.checked })}
-          />{" "}
-          Show Read Status
-        </label>
         <Button type="primary" value="Add message" onClick={this.addMessage} />
       </FlexBox>
     );

--- a/docs/components/MessagingThreadHistoryView.less
+++ b/docs/components/MessagingThreadHistoryView.less
@@ -17,9 +17,10 @@
 .MessagingThreadHistoryView--config {
   .flexbox;
   .items--center;
-  .margin--bottom--m;
   .text--caps;
   .text--small;
+  .margin--xs();
+  display: inline-block;
 
   &:not(:last-child) {
     .margin--right--m;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.64.0",
+  "version": "2.65.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -1,7 +1,14 @@
 @import (reference) "../less/index";
 
+.MessageMetadata--Message--container {
+  .flexbox();
+  flex-direction: column;
+  .margin--y--m();
+  .margin--x--xs();
+}
+
 .MessageMetadata--Message--center {
-  .margin--y--l();
+  .margin--y--s();
   margin-left: auto;
   margin-right: auto;
   .flexbox();
@@ -11,8 +18,6 @@
 }
 
 .MessageMetadata--Message--right {
-  .margin--y--m();
-  .margin--x--xs();
   .flexbox();
   flex-direction: row-reverse;
   align-items: center;
@@ -21,8 +26,6 @@
 }
 
 .MessageMetadata--Message--left {
-  .margin--y--m();
-  .margin--x--xs();
   .flexbox();
   flex-direction: row;
   align-items: center;
@@ -44,6 +47,12 @@
   .margin--left--xs();
   .text--line-height-1();
   white-space: nowrap;
+}
+
+.MessageMetadata--ReadReceipt {
+  .padding--top--2xs();
+  text-align: right;
+  color: @neutral_medium_gray;
 }
 
 // For mobile/tablet

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -57,15 +57,7 @@
 
 // For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
-  .MessageMetadata--Message--center {
-    .margin--y--m();
-  }
-
-  .MessageMetadata--Message--right {
-    .margin--y--2xs();
-  }
-
-  .MessageMetadata--Message--left {
+  .MessageMetadata--Message--container {
     .margin--y--2xs();
   }
 }

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -12,21 +12,25 @@ interface Props {
   className?: string;
   placement: "left" | "right" | "center";
   timestamp?: Date;
+  showReadStatus?: boolean;
   children: React.ReactNode;
 }
 
 export const MessageMetadata: React.FC<
   Props & { ref?: React.Ref<HTMLDivElement> }
 > = React.forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) => {
-  const { className, placement, timestamp, children } = props;
+  const { className, placement, timestamp, showReadStatus, children } = props;
   return (
-    <div ref={ref} className={classNames(cssClass(`Message--${placement}`), className)}>
-      {children}
-      {timestamp && (
-        <span className={cssClass(`Timestamp--${placement}`)}>
-          {_formatDateForTimestamp(timestamp)}
-        </span>
-      )}
+    <div className={cssClass("Message--container")}>
+      <div ref={ref} className={classNames(cssClass(`Message--${placement}`), className)}>
+        {children}
+        {timestamp && (
+          <span className={cssClass(`Timestamp--${placement}`)}>
+            {_formatDateForTimestamp(timestamp)}
+          </span>
+        )}
+      </div>
+      {showReadStatus && <div className={cssClass("ReadReceipt")}>Read</div>}
     </div>
   );
 });

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -12,14 +12,14 @@ interface Props {
   className?: string;
   placement: "left" | "right" | "center";
   timestamp?: Date;
-  showReadStatus?: boolean;
+  readStatusText?: string;
   children: React.ReactNode;
 }
 
 export const MessageMetadata: React.FC<
   Props & { ref?: React.Ref<HTMLDivElement> }
 > = React.forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) => {
-  const { className, placement, timestamp, showReadStatus, children } = props;
+  const { className, placement, timestamp, readStatusText, children } = props;
   return (
     <div ref={ref} className={cssClass("Message--container")}>
       <div className={classNames(cssClass(`Message--${placement}`), className)}>
@@ -30,7 +30,7 @@ export const MessageMetadata: React.FC<
           </span>
         )}
       </div>
-      {showReadStatus && <div className={cssClass("ReadReceipt")}>Read</div>}
+      {readStatusText && <div className={cssClass("ReadReceipt")}>{readStatusText}</div>}
     </div>
   );
 });

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -21,8 +21,8 @@ export const MessageMetadata: React.FC<
 > = React.forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) => {
   const { className, placement, timestamp, showReadStatus, children } = props;
   return (
-    <div className={cssClass("Message--container")}>
-      <div ref={ref} className={classNames(cssClass(`Message--${placement}`), className)}>
+    <div ref={ref} className={cssClass("Message--container")}>
+      <div className={classNames(cssClass(`Message--${placement}`), className)}>
         {children}
         {timestamp && (
           <span className={cssClass(`Timestamp--${placement}`)}>

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -20,14 +20,13 @@ export interface MessageData {
   timestamp?: Date;
   content: React.ReactNode;
   index: number;
-  isRead?: boolean;
+  readStatusText?: string;
 }
 
 interface Props {
   className?: string;
   threadID: string;
   messages: MessageData[];
-  showReadStatus?: boolean;
 }
 
 const SCROLL_BUFFER = 200;
@@ -47,7 +46,7 @@ function isOwnMessage(message: MessageData) {
 
 export const MessagingThreadHistory = React.forwardRef(
   (
-    { className, threadID, messages, showReadStatus }: Props,
+    { className, threadID, messages }: Props,
     containerRef: React.MutableRefObject<HTMLDivElement>,
   ) => {
     // ----------- Scroll position references
@@ -90,11 +89,7 @@ export const MessagingThreadHistory = React.forwardRef(
 
     // ----------- Render
 
-    const messagesWithDividers = _interleaveMessagesWithDividers(
-      messages,
-      lastMessageRef,
-      showReadStatus,
-    );
+    const messagesWithDividers = _interleaveMessagesWithDividers(messages, lastMessageRef);
 
     return (
       <div
@@ -116,7 +111,6 @@ export const MessagingThreadHistory = React.forwardRef(
 function _interleaveMessagesWithDividers(
   messages: MessageData[],
   lastMessageRef: React.MutableRefObject<HTMLDivElement>,
-  showReadStatus: boolean,
 ) {
   // Interleave dividers (e.g. "Today," "Yesterday", "May 20") with messages.
   const messagesWithDividers: React.ReactNode[] = [];
@@ -143,7 +137,7 @@ function _interleaveMessagesWithDividers(
         ref={i === messages.length - 1 ? lastMessageRef : undefined}
         placement={message.placement}
         timestamp={message.timestamp}
-        showReadStatus={showReadStatus && message.isRead && isOwnMessage(message)}
+        readStatusText={isOwnMessage(message) && message.readStatusText}
         // First message needs 'auto' top margin to have messages fill container from bottom -> top
         className={i === 0 ? cssClasses.FIRST_MESSAGE : undefined}
       >

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -20,12 +20,14 @@ export interface MessageData {
   timestamp?: Date;
   content: React.ReactNode;
   index: number;
+  isRead?: boolean;
 }
 
 interface Props {
   className?: string;
   threadID: string;
   messages: MessageData[];
+  showReadStatus?: boolean;
 }
 
 const SCROLL_BUFFER = 200;
@@ -45,7 +47,7 @@ function isOwnMessage(message: MessageData) {
 
 export const MessagingThreadHistory = React.forwardRef(
   (
-    { className, threadID, messages }: Props,
+    { className, threadID, messages, showReadStatus }: Props,
     containerRef: React.MutableRefObject<HTMLDivElement>,
   ) => {
     // ----------- Scroll position references
@@ -88,7 +90,11 @@ export const MessagingThreadHistory = React.forwardRef(
 
     // ----------- Render
 
-    const messagesWithDividers = _interleaveMessagesWithDividers(messages, lastMessageRef);
+    const messagesWithDividers = _interleaveMessagesWithDividers(
+      messages,
+      lastMessageRef,
+      showReadStatus,
+    );
 
     return (
       <div
@@ -110,6 +116,7 @@ export const MessagingThreadHistory = React.forwardRef(
 function _interleaveMessagesWithDividers(
   messages: MessageData[],
   lastMessageRef: React.MutableRefObject<HTMLDivElement>,
+  showReadStatus: boolean,
 ) {
   // Interleave dividers (e.g. "Today," "Yesterday", "May 20") with messages.
   const messagesWithDividers: React.ReactNode[] = [];
@@ -136,6 +143,7 @@ function _interleaveMessagesWithDividers(
         ref={i === messages.length - 1 ? lastMessageRef : undefined}
         placement={message.placement}
         timestamp={message.timestamp}
+        showReadStatus={showReadStatus && message.isRead && isOwnMessage(message)}
         // First message needs 'auto' top margin to have messages fill container from bottom -> top
         className={i === 0 ? cssClasses.FIRST_MESSAGE : undefined}
       >


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/FAMBAM-490

**Overview:**
This PR adds read receipts to the messaging components.

**Screenshots/GIFs:**
Design Mocks:
![image](https://user-images.githubusercontent.com/21094551/96654359-f9a8b900-12ef-11eb-85a1-cf064e8454f1.png)

Mobile:
![image](https://user-images.githubusercontent.com/21094551/97042294-a6b84700-1525-11eb-9230-d292824bea24.png)


Web:
![image](https://user-images.githubusercontent.com/21094551/97042478-f434b400-1525-11eb-8a8e-045c95715d96.png)


**Testing:**
- [ ] Unit tests
- Manual tests: (Tested by pointing local fampo at local clever-components server)
 - [x] Styling without read receipts remains the same
 - [x] Mobile
  - [x] Chrome
  - [x] Safari
  - [x] IE11

**Roll Out:**
- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)