### PR TITLE
Fix shrinking of messages on safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.65.0",
+  "version": "2.65.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -5,6 +5,8 @@
   flex-direction: column;
   .margin--y--m();
   .margin--x--xs();
+  // Without this, messages 'bunch up' on Safari.
+  flex-shrink: 0;
 }
 
 .MessageMetadata--Message--center {


### PR DESCRIPTION
**Jira:**
N/A

**Overview:**
This fixes some bunching up of messages that we noticed on Safari. 

**Screenshots/GIFs:**

using npm link in family portal: 

Before:
![image](https://user-images.githubusercontent.com/21094551/97508021-cd1e1e00-193b-11eb-8782-999a1195454e.png)

After:
![image](https://user-images.githubusercontent.com/21094551/97507546-a14e6880-193a-11eb-9b79-7db92ffbe21c.png)

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
