### PR TITLE
Remove extra styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.65.1",
+  "version": "2.65.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -15,24 +15,18 @@
   margin-right: auto;
   .flexbox();
   .text--center();
-  // Without this, messages 'bunch up' on Safari.
-  flex-shrink: 0;
 }
 
 .MessageMetadata--Message--right {
   .flexbox();
   flex-direction: row-reverse;
   align-items: center;
-  // Without this, messages 'bunch up' on Safari.
-  flex-shrink: 0;
 }
 
 .MessageMetadata--Message--left {
   .flexbox();
   flex-direction: row;
   align-items: center;
-  // Without this, messages 'bunch up' on Safari.
-  flex-shrink: 0;
 }
 
 .MessageMetadata--Timestamp--right {


### PR DESCRIPTION
**Jira:**
N/A

**Overview:**
This PR removes some styles that are extra/unnecessary after adding the flex-shrink: 0 property in the outer div container in https://github.com/Clever/components/pull/561, as noted by Nikhil!

**Screenshots/GIFs:**

**Testing:**
Manually inspected in Safari and saw no visual difference/shrinking when the "flex-shrink: 0"  property on the center, left, and right divs were checked on and off. 

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
