### PR TITLE
Ssoap accessibility fixes nov 2020 - color contrast issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.65.2",
+  "version": "2.66.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AlertBox/AlertBox.less
+++ b/src/AlertBox/AlertBox.less
@@ -94,6 +94,6 @@ h3.AlertBox--title {
   }
 
   &:focus {
-    outline: @borderRadiusM solid @primary_blue_tint_2;
+    outline: @borderRadiusM solid @accent_purple_shade_2;
   }
 }

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -167,12 +167,7 @@ button {
   }
 
   &.Button--linkPlain {
-    color: @primary_blue;
-
-    &:hover,
-    &:active {
-      color: @primary_blue_shade_2;
-    }
+    color: @primary_blue_shade_2;
 
     &:focus {
       outline: @borderRadiusM solid fade(@primary_blue_tint_2, 50%);
@@ -181,13 +176,8 @@ button {
   }
 
   &.Button--linkUnderlined {
-    .border--bottom--s(@primary_blue);
+    .border--bottom--s(@primary_blue_shade_2);
     .borderRadius--0;
-
-    &:hover,
-    &:active {
-      .border--bottom--s(@primary_blue_shade_2);
-    }
 
     &:focus {
       outline: none;

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -170,7 +170,7 @@ button {
     color: @primary_blue_shade_2;
 
     &:focus {
-      outline: @borderRadiusM solid fade(@primary_blue_tint_2, 50%);
+      outline: @borderRadiusM solid @accent_purple_shade_2;
       transition: none;
     }
   }


### PR DESCRIPTION
**Jira:**

[SSOAP-2851](https://clever.atlassian.net/browse/SSOAP-2851)
[SSOAP-2844](https://clever.atlassian.net/browse/SSOAP-2844)

**Overview:**

Just some changes to colors, to address accessibility issues. A broader pattern of these changes may be forthcoming pending some design meetings, but these more specific, small-scale changes are already approved.

**Screenshots/GIFs:**

![Screen Shot 2020-11-23 at 12 15 59 PM](https://user-images.githubusercontent.com/57963785/100010865-c5f4ff00-2d85-11eb-8882-acfec5b9f278.png)
![Screen Shot 2020-11-23 at 12 16 41 PM](https://user-images.githubusercontent.com/57963785/100010868-c7262c00-2d85-11eb-8976-8fa1744fb1b1.png)
![Screen Shot 2020-11-23 at 12 16 11 PM](https://user-images.githubusercontent.com/57963785/100010866-c7262c00-2d85-11eb-923a-21a07a342be6.png)

**Testing:**

- [N/A] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari

**Roll Out:**

- Before merging:
  - [N/A] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
