### PR TITLE
SSOAP-2859: outline for focus on Button--linkUnderlined

### DIFF
--- a/docs/components/ButtonView.jsx
+++ b/docs/components/ButtonView.jsx
@@ -41,7 +41,7 @@ export default function ButtonView() {
           <Button type="linkPlain" href="http://google.com" value="Plain Link" />
         </ExampleCode>
         <p>
-          Here is a <Button type="linkPlain" href="//google.com" value="plain link" /> with no
+          Here is a <Button type="linkPlain" href="//google.com" value="underlined plain link" underlined/> with no
           margin/padding.
           <br />
           Better suited for inline links than the regular{" "}

--- a/docs/components/ButtonView.jsx
+++ b/docs/components/ButtonView.jsx
@@ -41,8 +41,9 @@ export default function ButtonView() {
           <Button type="linkPlain" href="http://google.com" value="Plain Link" />
         </ExampleCode>
         <p>
-          Here is a <Button type="linkPlain" href="//google.com" value="underlined plain link" underlined/> with no
-          margin/padding.
+          Here is a{" "}
+          <Button type="linkPlain" href="//google.com" value="underlined plain link" underlined />{" "}
+          with no margin/padding.
           <br />
           Better suited for inline links than the regular{" "}
           <Button type="link" href="http://google.com" value="link button" />, which doesn't

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.66.2",
+  "version": "2.67.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.66.1",
+  "version": "2.66.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -178,11 +178,6 @@ button {
   &.Button--linkUnderlined {
     .border--bottom--s(@primary_blue_shade_2);
     .borderRadius--0;
-
-    &:focus {
-      outline: none;
-      transition: none;
-    }
   }
 
   &.Button--large {


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/SSOAP-2859

**Overview:**
Previously, Button--linkUnderlined had `:focus` state set to have no outline. This was a mistake, correcting this mistake

**Screenshots/GIFs:**
<img width="643" alt="Screen Shot 2020-11-24 at 5 39 16 PM" src="https://user-images.githubusercontent.com/54862564/100285056-0c349480-2f25-11eb-9c91-c607d53c0fbf.png">


**Testing:**

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - backward-compatible component feature change? Run `npm version minor`

- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
