### PR TITLE
Fix Tooltip display for click/focus trigger combo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.68.0",
+  "version": "2.69.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.69.0",
+  "version": "2.68.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -119,6 +119,11 @@ export default class Tooltip extends React.Component<Props> {
           tabIndex: 0,
           "aria-describedby": this.id,
           className: cssClass.FOCUSABLE_TRIGGER,
+          ...(clickTrigger && {
+            onMouseDown: (e: React.SyntheticEvent) => {
+              e.preventDefault();
+            },
+          }),
           ...child.props,
         })}
       </OverlayTrigger>


### PR DESCRIPTION
**Overview:**
This version of react-bootstrap OverlayTrigger and tooltip doesn't handle click, focus triggers when used in conjunction gracefully.
When using both click and focus: user clicks the element (mousedown + mouseup events), a focus event is fired after the mousedown. This sets the shown state to true. Later once the click event is fired, i.e. after the mousedown, focus, mouseup events, a function "handleToggle" is called, which then will hide the tooltip since its already shown... by calling preventDefault the focus event from mousedown won't be fired

Ideally we update the version of react-bootstrap since the latest version fixes this but ain't nobody got time for that.

**Screenshots/GIFs:**
**before**
![Screen Recording 2020-11-25 at 03 00 46 PM](https://user-images.githubusercontent.com/6362897/100295237-fc757a00-2f3d-11eb-8bb1-d075c5bf3a89.gif)
**after**
![Screen Recording 2020-11-25 at 03 04 48 PM](https://user-images.githubusercontent.com/6362897/100295248-07c8a580-2f3e-11eb-989c-3d9b8262bce5.gif)


**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
