### PR TITLE
Ssoap 2846 alert heading

### DIFF
--- a/docs/components/AlertBoxView.jsx
+++ b/docs/components/AlertBoxView.jsx
@@ -113,7 +113,7 @@ export default class AlertBoxView extends PureComponent {
               name: "headingLevel",
               type: "1 | 2 | 3 | 4 | 5 | 6",
               description:
-                "Heading level for the title for accessibility, should reflect the heading levels of the elements surrounding the AlertBox. Does not effect styling of the title",
+                "Heading level for the title for accessibility, should reflect the heading levels of the elements surrounding the AlertBox. Does not affect styling of the title",
               defaultValue: "3",
               optional: true,
             },

--- a/docs/components/AlertBoxView.jsx
+++ b/docs/components/AlertBoxView.jsx
@@ -109,6 +109,14 @@ export default class AlertBoxView extends PureComponent {
               defaultValue: "",
               optional: false,
             },
+            {
+              name: "headingLevel",
+              type: "1 | 2 | 3 | 4 | 5 | 6",
+              description:
+                "Heading level for the title for accessibility, should reflect the heading levels of the elements surrounding the AlertBox. Does not effect styling of the title",
+              defaultValue: "3",
+              optional: true,
+            },
           ]}
         />
       </View>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.67.0",
+  "version": "2.68.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AlertBox/AlertBox.less
+++ b/src/AlertBox/AlertBox.less
@@ -6,7 +6,7 @@
   .border--s(transparent);
 }
 
-h3.AlertBox--title {
+.AlertBox--title {
   .margin--none();
   .margin--bottom--s();
   .padding--none();

--- a/src/AlertBox/AlertBox.tsx
+++ b/src/AlertBox/AlertBox.tsx
@@ -18,6 +18,7 @@ export interface Props {
   type?: AlertBoxType;
   isClosable?: boolean;
   onClose?: () => void;
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 }
 
 const cssClass = {
@@ -63,7 +64,7 @@ export default class AlertBox extends React.PureComponent<Props> {
   }
 
   render() {
-    const { children, className, type, title, isClosable } = this.props;
+    const { children, className, type, title, isClosable, headingLevel = 3 } = this.props;
     const { isOpen } = this.state;
     if (!isOpen) {
       return null;
@@ -83,7 +84,11 @@ export default class AlertBox extends React.PureComponent<Props> {
           <FlexItem>
             {/* Use an <h3> for accessibility. Visual headings must be marked as such. The US Gov
               design system also uses <h3>s for their alert box titles */}
-            {title && <h3 className={cssClass.TITLE}>{title}</h3>}
+            {title && (
+              <div role="heading" aria-level={headingLevel} className={cssClass.TITLE}>
+                {title}
+              </div>
+            )}
             <div className={cssClass.CHILDREN}>{children}</div>
           </FlexItem>
           <FlexItem grow>

--- a/src/AlertBox/AlertBox.tsx
+++ b/src/AlertBox/AlertBox.tsx
@@ -1,6 +1,5 @@
 import * as classnames from "classnames";
 import * as React from "react";
-import * as PropTypes from "prop-types";
 
 import * as FontAwesome from "react-fontawesome";
 
@@ -31,14 +30,6 @@ const cssClass = {
   CHILDREN: "AlertBox--children",
 };
 
-const propTypes = {
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string,
-  title: PropTypes.string,
-  type: PropTypes.oneOf<AlertBoxType>(["processing", "warning", "success", "error", "info"]),
-  isClosable: PropTypes.bool,
-};
-
 const iconMap = {
   processing: "spinner",
   warning: "exclamation-triangle",
@@ -51,8 +42,6 @@ const iconMap = {
  * AlertBox is a closable, highlighted box
  */
 export default class AlertBox extends React.PureComponent<Props> {
-  static propTypes = propTypes;
-
   state = { isOpen: true };
 
   closeBox() {


### PR DESCRIPTION
**Jira:** https://clever.atlassian.net/browse/SSOAP-2846

**Overview:**
H3 does not always match the top-level heading for AlertBox, which can cause accessibility issues. Adding optional `headingLevel` prop to set the `aria-level`, with default to 3 (so existing AlertBoxes see no change).

This will be used to fix one known instance of the accessibility issue in the Student Portal

Also removing redundant PropTypes

Bumped to 2.68 because I have another pending PR to merge that will bump to 2.67 which I will merge first, and then this one

**Testing:**

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - backward-compatible component feature change? Run `npm version minor`
  
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
