### PR TITLE
SSOAP-2940: add aria label to ToastNotification close button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.68.2",
+  "version": "2.68.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ToastStack/ToastNotification.tsx
+++ b/src/ToastStack/ToastNotification.tsx
@@ -96,6 +96,7 @@ export class ToastNotification extends React.PureComponent<Props> {
             onClick={onClose}
             type="linkPlain"
             value={<FontAwesome name="times" size="lg" />}
+            ariaLabel="close notification"
           />
         )}
       </FlexBox>


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/SSOAP-2940

**Overview:**
Add `aria-label` to ToastNotification close button to make it readable by screen readers

**Testing:**

Manually confirmed aria label is present on correct element

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**
100

- Before merging:
  - [x] Bumped version in `package.json`
    - New component or backward-compatible component feature change? Run `npm version minor`
   
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
