### PR TITLE
Ssoap-2939: dropdown aria

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.68.3",
+  "version": "2.68.4",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/DropdownButton/DropdownButton.tsx
+++ b/src/DropdownButton/DropdownButton.tsx
@@ -144,6 +144,7 @@ export default class DropdownButton extends React.PureComponent<Props, State> {
             size={size}
             type={type}
             value={arrowTypeRender}
+            ariaLabel="toggle dropdown"
           />
         </FlexBox>
         <Overlay


### PR DESCRIPTION
**Jira:**

https://clever.atlassian.net/browse/SSOAP-2939

**Overview:**

Dropdown toggle button missing aria label, which makes it inaccessible to screenreader

Added aria label

**Screenshots/GIFs:**

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**
100

- Before merging:
  - [ ] Bumped version in `package.json` (patch)   

- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
