### PR TITLE
v2.68.6 - SSOAP-2927 - DropdownButton now accepts ariaLabelSecondaryButton prop

### DIFF
--- a/docs/components/DropdownButtonView.jsx
+++ b/docs/components/DropdownButtonView.jsx
@@ -312,6 +312,11 @@ export default class DropdownButtonView extends Component {
           title="<DropdownButton.Option /> Props"
           availableProps={[
             {
+              name: "ariaLabelSecondaryButton",
+              type: "string",
+              description: "The aria-label for the option button.",
+            },
+            {
               name: "children",
               type: "React Node",
               description: "The label for the option button.",

--- a/docs/components/DropdownButtonView.jsx
+++ b/docs/components/DropdownButtonView.jsx
@@ -145,6 +145,7 @@ export default class DropdownButtonView extends Component {
           <FlexBox alignItems={ItemAlign.CENTER}>
             <ExampleCode>
               <DropdownButton
+                ariaLabelSecondaryButton="Region options"
                 disabled={disabled}
                 label={
                   <div>
@@ -176,6 +177,7 @@ export default class DropdownButtonView extends Component {
         <Example title="With Fixed Width:">
           <ExampleCode>
             <DropdownButton
+              ariaLabelSecondaryButton="Long label options"
               className={cssClass.DROPDOWN_WIDTH_400PX}
               disabled={disabled}
               label="A really really long label"
@@ -195,6 +197,7 @@ export default class DropdownButtonView extends Component {
         <Example title="With HREFs:">
           <ExampleCode>
             <DropdownButton
+              ariaLabelSecondaryButton="EdTech websites"
               disabled={disabled}
               label="EdTech News"
               href="http://google.com/search?q=edtech+news"
@@ -218,6 +221,7 @@ export default class DropdownButtonView extends Component {
           <p>If no options are available, no toggle is rendered with the primary action.</p>
           <ExampleCode>
             <DropdownButton
+              ariaLabelSecondaryButton="no_button_will_be_there"
               disabled={disabled}
               label="Primary action"
               size={size}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.68.5",
+  "version": "2.68.6",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/DropdownButton/DropdownButton.tsx
+++ b/src/DropdownButton/DropdownButton.tsx
@@ -104,7 +104,15 @@ export default class DropdownButton extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { ariaLabelSecondaryButton, children, className, disabled, size, type, arrowType } = this.props;
+    const {
+      ariaLabelSecondaryButton,
+      children,
+      className,
+      disabled,
+      size,
+      type,
+      arrowType,
+    } = this.props;
     const passthroughProps = _.omit(
       this.props,
       Object.keys(propTypes) as (keyof typeof propTypes)[],

--- a/src/DropdownButton/DropdownButton.tsx
+++ b/src/DropdownButton/DropdownButton.tsx
@@ -19,6 +19,7 @@ import "./Caret.less";
 import "./DropdownButton.less";
 
 export interface Props {
+  ariaLabelSecondaryButton?: string;
   children?: ChildrenOf<typeof Option>;
   className?: string;
   disabled?: boolean;
@@ -36,6 +37,7 @@ interface State {
 }
 
 const propTypes = {
+  ariaLabelSecondaryButton: PropTypes.string,
   children: MorePropTypes.oneOrManyOf(MorePropTypes.instanceOfComponent(Option)),
   className: PropTypes.string,
   disabled: PropTypes.bool,
@@ -102,7 +104,7 @@ export default class DropdownButton extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { children, className, disabled, size, type, arrowType } = this.props;
+    const { ariaLabelSecondaryButton, children, className, disabled, size, type, arrowType } = this.props;
     const passthroughProps = _.omit(
       this.props,
       Object.keys(propTypes) as (keyof typeof propTypes)[],
@@ -144,7 +146,7 @@ export default class DropdownButton extends React.PureComponent<Props, State> {
             size={size}
             type={type}
             value={arrowTypeRender}
-            ariaLabel="toggle dropdown"
+            ariaLabel={ariaLabelSecondaryButton}
           />
         </FlexBox>
         <Overlay


### PR DESCRIPTION
**Jira:**

[SSOAP-2927](https://clever.atlassian.net/browse/SSOAP-2927)

**Overview:**

DropdownButton now accepts ariaLabelSecondaryButton proputton prop as aria-label for the secondary/dropdown button.

Generally, no two buttons should have the same `aria-label` on a page, as this makes them indistinguishable when using a screen-reader. Consequently, we have to avoid hard-coding `aria-labels`s in components and generally leave it up to the consumer, unless there's an excellent way to programmatically generally a unique `aria-label`.

**Screenshots/GIFs:**

![Screen Shot 2020-12-08 at 2 46 33 PM](https://user-images.githubusercontent.com/57963785/101550497-43169b80-3964-11eb-9c35-7717444a1683.png)

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
