### PR TITLE
Center button label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.68.7",
+  "version": "2.68.8",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -152,7 +152,7 @@ button {
   &.Button--small {
     font-size: 0.875rem;
     .text--semi-bold;
-    padding: 0.438rem @size_s @size_2xs;
+    padding: 0.388rem @size_s 0.3rem;
   }
 
   &.Button--regular {


### PR DESCRIPTION
**Jira:**

**Overview:**
For buttons, the labels are not vertically centered. It's not an issue for bigger buttons. But for the small button, it's very easy to tell the label is too close to the bottom.

This PR 
- [x] updated padding to move label up

**Screenshots/GIFs:**

Before:
<img width="231" alt="Screen Shot 2020-12-09 at 10 33 35 AM" src="https://user-images.githubusercontent.com/50892039/101650581-161cc400-3a0a-11eb-9aca-ea2229e88981.png">

After:
<img width="268" alt="Screen Shot 2020-12-09 at 10 31 56 AM" src="https://user-images.githubusercontent.com/50892039/101650588-1917b480-3a0a-11eb-94cf-0606269f7358.png">

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
