### PR TITLE
Ssoap 2940 unique aria

### DIFF
--- a/docs/components/ToastStackView.jsx
+++ b/docs/components/ToastStackView.jsx
@@ -107,6 +107,7 @@ export default class ToastStackView extends React.PureComponent {
                         : undefined,
                       showCloseButton,
                       durationMS: durationOverride === "No override" ? undefined : durationOverride,
+                      closeButtonAriaLabel: `close notification: ${nextNotificationID}`,
                     },
                   ],
                   nextNotificationID: nextNotificationID + 1,

--- a/docs/components/ToastStackView.jsx
+++ b/docs/components/ToastStackView.jsx
@@ -239,6 +239,14 @@ export default class ToastStackView extends React.PureComponent {
               "The notifications to be rendered. See the table below for the fields " +
               "in a `Notification` object.",
           },
+          {
+            name: "closeButtonAriaLabel",
+            type: "string",
+            description:
+              "A custom aria-label for the 'X' close notification button. Note: It's best in terms of accessibility for aria-labels to be unique.",
+            optional: true,
+            defaultValue: "close notification",
+          },
         ]}
         className={cssClass.PROPS}
       />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.69.0",
+  "version": "2.69.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ToastStack/ToastNotification.tsx
+++ b/src/ToastStack/ToastNotification.tsx
@@ -1,6 +1,5 @@
 import * as classnames from "classnames";
 import * as FontAwesome from "react-fontawesome";
-import * as PropTypes from "prop-types";
 import * as React from "react";
 
 import { Button, Props as ButtonProps } from "../Button/Button";
@@ -24,21 +23,6 @@ export interface Props {
   type: ToastNotificationType;
   closeButtonAriaLabel?: string;
 }
-
-export const actionPropType = PropTypes.shape({
-  href: PropTypes.string,
-  onClick: PropTypes.func,
-  text: PropTypes.string.isRequired,
-});
-
-const propTypes = {
-  action: actionPropType,
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string,
-  onClose: PropTypes.func.isRequired,
-  showCloseButton: PropTypes.bool,
-  type: PropTypes.oneOf(Object.values(ToastType)).isRequired,
-};
 
 const defaultProps = {
   showCloseButton: true,
@@ -67,7 +51,6 @@ const iconMap = {
  * A building block for the <ToastStack>. Renders an individual toast notification.
  */
 export class ToastNotification extends React.PureComponent<Props> {
-  static propTypes = propTypes;
   static defaultProps = defaultProps;
 
   render() {

--- a/src/ToastStack/ToastNotification.tsx
+++ b/src/ToastStack/ToastNotification.tsx
@@ -22,6 +22,7 @@ export interface Props {
   onClose: ButtonProps["onClick"];
   showCloseButton?: boolean;
   type: ToastNotificationType;
+  closeButtonAriaLabel?: string;
 }
 
 export const actionPropType = PropTypes.shape({
@@ -70,7 +71,15 @@ export class ToastNotification extends React.PureComponent<Props> {
   static defaultProps = defaultProps;
 
   render() {
-    const { action, children, className, onClose, showCloseButton, type } = this.props;
+    const {
+      action,
+      children,
+      className,
+      onClose,
+      showCloseButton,
+      type,
+      closeButtonAriaLabel,
+    } = this.props;
 
     return (
       <FlexBox
@@ -96,7 +105,7 @@ export class ToastNotification extends React.PureComponent<Props> {
             onClick={onClose}
             type="linkPlain"
             value={<FontAwesome name="times" size="lg" />}
-            ariaLabel="close notification"
+            ariaLabel={closeButtonAriaLabel || "close notification"}
           />
         )}
       </FlexBox>

--- a/src/ToastStack/ToastStack.tsx
+++ b/src/ToastStack/ToastStack.tsx
@@ -1,12 +1,11 @@
 import * as classnames from "classnames";
-import * as PropTypes from "prop-types";
 import * as React from "react";
 import * as _ from "lodash";
 import { CSSTransitionGroup } from "react-transition-group";
 import { ToastNotification } from "./ToastNotification";
 
-import { actionPropType, ActionProps } from "./ToastNotification";
-import { ToastNotificationType, ToastType } from "./ToastType";
+import { ActionProps } from "./ToastNotification";
+import { ToastNotificationType } from "./ToastType";
 
 import "./ToastStack.less";
 
@@ -28,23 +27,6 @@ export interface Props {
   notifications?: ToastNotificationData[];
 }
 
-const propTypes = {
-  className: PropTypes.string,
-  clearNotification: PropTypes.func.isRequired,
-  defaultNotificationDurationMS: PropTypes.number,
-  notificationClassName: PropTypes.string,
-  notifications: PropTypes.arrayOf(
-    PropTypes.shape({
-      action: actionPropType,
-      content: PropTypes.node.isRequired,
-      durationMS: PropTypes.number,
-      id: PropTypes.number.isRequired,
-      showCloseButton: PropTypes.bool,
-      type: PropTypes.oneOf(Object.values(ToastType)).isRequired,
-    }),
-  ),
-};
-
 const defaultProps = {
   defaultNotificationDurationMS: 5000,
 };
@@ -60,7 +42,6 @@ const cssClass = {
  * <ToastStack> renders toast notifications and handles their enter/leave animations.
  */
 export class ToastStack extends React.PureComponent<Props> {
-  static propTypes = propTypes;
   static defaultProps = defaultProps;
 
   _finiteDuration(notification) {

--- a/src/ToastStack/ToastStack.tsx
+++ b/src/ToastStack/ToastStack.tsx
@@ -17,6 +17,7 @@ export interface ToastNotificationData {
   id: number;
   showCloseButton?: boolean;
   type: ToastNotificationType;
+  closeButtonAriaLabel?: string;
 }
 
 export interface Props {
@@ -104,6 +105,7 @@ export class ToastStack extends React.PureComponent<Props> {
           onClose={() => clearNotification(n.id)}
           showCloseButton={n.showCloseButton}
           type={n.type}
+          closeButtonAriaLabel={n.closeButtonAriaLabel}
         >
           {n.content}
         </ToastNotification>


### PR DESCRIPTION
**Jira:**

https://clever.atlassian.net/browse/SSOAP-2940

**Overview:**

followup on  https://github.com/Clever/components/pull/570 to make aria labels able to be passed in to ToastNotification

**Testing:**

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
   
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
