### PR TITLE
SSOAP-2824, SSOAP-2829 - The blue dot that denotes an unread thread needs an aria-label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.69.1",
+  "version": "2.69.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -70,7 +70,7 @@ export const MessagingThreadListItem: React.FC<
   const indicator = (
     <FlexBox className={cssClasses.INDICATOR_CONTAINER} justify={Justify.END}>
       {!isRead ? (
-        <div className={cssClasses.UNREAD_ORB} />
+        <div aria-label={`Unread messages in thread ${title}`} className={cssClasses.UNREAD_ORB} />
       ) : (
         status === "active" && hasDraft && <DraftPencilIcon />
       )}


### PR DESCRIPTION
**Jira:**

[SSOAP-2824 (Teacher UI)](https://clever.atlassian.net/browse/SSOAP-2824)
[SSOAP-2829 (Student UI)](https://clever.atlassian.net/browse/SSOAP-2829)

**Overview:**

The blue dot that denotes that a thread has unread messages requires a descriptive, unique aria-label (informative CSS images require a text alternative).

**Testing:**

`make dev-server` with MacOS screen-reader (VoiceOver).

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

:100:

- Before merging:
  - [n/a] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
