### PR TITLE
Messaging CSS fix to populate messages from bottom up instead of top down

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.69.2",
+  "version": "2.69.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -21,8 +21,8 @@ export const MessageMetadata: React.FC<
 > = React.forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) => {
   const { className, placement, timestamp, readStatusText, children } = props;
   return (
-    <div ref={ref} className={cssClass("Message--container")}>
-      <div className={classNames(cssClass(`Message--${placement}`), className)}>
+    <div ref={ref} className={classNames(cssClass("Message--container"), className)}>
+      <div className={cssClass(`Message--${placement}`)}>
         {children}
         {timestamp && (
           <span className={cssClass(`Timestamp--${placement}`)}>


### PR DESCRIPTION
**Jira:**
N/A

**Overview:**
Messaging components [change from earlier](https://github.com/Clever/components/pull/560/files#diff-2d9ffc01268d6e4cf7f077da4183b1b5eb0a7a3238da932c402ac91d0814fa64R24-R25) caused messages to float from top down instead of bottom up. This PR moves the classname prop to the outer div so that it properly applies the CSS to push messages to the bottom. 

**Screenshots/GIFs:**

**Testing:**
Manually tested in launchpad. 

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
