### PR TITLE
Ssoap 3005 aria role

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.69.3",
+  "version": "2.69.4",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table2Beta/HeaderCell.tsx
+++ b/src/Table2Beta/HeaderCell.tsx
@@ -41,7 +41,9 @@ export default function HeaderCell({
       width={width}
     >
       <FlexBox alignItems={ItemAlign.CENTER}>
-        <div className={cssClass.LABEL}>{children}</div>
+        <div className={cssClass.LABEL} role={sortable ? "button" : null}>
+          {children}
+        </div>
         {sortable && (
           <div>
             <SortIcons direction={activeSortDirection} className={cssClass.SORT} />


### PR DESCRIPTION
**Jira:**

https://clever.atlassian.net/browse/SSOAP-3005

**Overview:**

Added `role="button"` to Table2Beta Headers when the given header is sortable, for accessibility 

**Testing:**

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Bumped version in `package.json`
    - patch

- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
