### PR TITLE
FEE new font size mixins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.69.4",
+  "version": "2.70.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/less/type-size.less
+++ b/src/less/type-size.less
@@ -6,6 +6,7 @@
 @type_small: @size_s;
 @type_small_medium: 0.875rem; // 14px
 @type_medium: @size_m;
+@type_medium_large: 1.125rem; // 18px
 @type_large: @size_l;
 @type_huge: @size_xl;
 @type_gargantuan: @size_2xl;
@@ -25,6 +26,10 @@
 
 .text--medium {
   font-size: @type_medium;
+}
+
+.text--mediumLarge {
+  font-size: @type_medium_large;
 }
 
 .text--large {

--- a/src/less/type-size.less
+++ b/src/less/type-size.less
@@ -4,6 +4,7 @@
 // Type Size Variables
 @type_tiny: 0.625rem;
 @type_small: @size_s;
+@type_small_medium: 0.875rem; // 14px
 @type_medium: @size_m;
 @type_large: @size_l;
 @type_huge: @size_xl;
@@ -16,6 +17,10 @@
 
 .text--small {
   font-size: @type_small;
+}
+
+.text--smallMedium {
+  font-size: @type_small_medium;
 }
 
 .text--medium {


### PR DESCRIPTION
**Jira:** N/A

**Overview:** We [chatted in frontend guild](https://clever.atlassian.net/wiki/spaces/ENG/pages/1847525510/2021-01-21+Frontend+Guild+meeting+notes) that due to design's increased usage of 14px and 18px font sizes, it makes sense to formally encode them in Dewey as mixins! We had some discussion around potential names, and decided in a poll that we'd go with `.text--smallMedium` for 14px (between small and medium). When discussing 18px (between medium and large), we felt it made sense to stick with the convention and go with `.text--mediumLarge`.

There was some discussion about whether these names made sense when we may want to support 20px size as well, but we decided to punt on that since it doesn't seem as important (it wasn't listed as a size in design's [WIP Dewey 2.0 guidelines](https://www.figma.com/file/IBVNvo2dI221k4Dye4Hg0S/Dewey-2.0-WIP?node-id=21222%3A1)). We also acknowledged that we may want to completely rename things when Dewey 2.0 comes around and recalibrate what small, medium, and large are.

**Screenshots/GIFs:** N/A

**Testing:** I did not test this... but it seems straightforward 😅 

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [X] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
