### PR TITLE
Fix new_component code to parse and edit multiline statements

### DIFF
--- a/bin/new_component.sh
+++ b/bin/new_component.sh
@@ -5,3 +5,4 @@ cd "${BASH_SOURCE%/*}"
 
 NAME=$1
 ../node_modules/.bin/ts-node --project ../tsconfig.bin.json ./create_new_component.ts $NAME
+../node_modules/.bin/prettier --write ../docs/components/SideBar/SideBar.jsx

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router": "^3.0.0",
+    "recast": "^0.20.4",
     "sinon": "^1.17.3",
     "style-loader": "^0.13.0",
     "stylelint": "^7.12.0",


### PR DESCRIPTION
TL:DR; replaced regex code gen with AST code gen via recast

This [is an example of a line](https://github.com/Clever/components/pull/586/files#diff-5d864b760e32dc915a93785758ebd4d64be71b68ed646ff27a1ac966c36c9892R133) of codegen that this modified code is supposed to generate

the new_component script wasn't adding a sidebar link properly because the regex was failing on code statements that became multi-line statements via auto-formatting:
https://github.com/Clever/components/blob/e66f515115e30c864c960f45ff25bb5882e90920/docs/components/SideBar/SideBar.jsx#L110-L115

Instead of trying to figure out how to update the regex, I decided to play around with some tool I heard about but never had the chance to dive into and learn. AST code mods:
https://github.com/benjamn/recast
https://github.com/benjamn/ast-types

It turns out there are a few libraries that are popular, but recast seemed to be the one that fits the bill the most. I tried using babel, which is a slightly different library, but it mangled the formatting of the file. Recast is built to preserve as much formatting as possible, so I ended up with that. babel has nicer documentation though, which explains in more depth what this AST code mod stuff is all about:
https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md
(a simple babel tutorial https://lihautan.com/step-by-step-guide-for-writing-a-babel-transformation/)

People tend to use this AST explorer to write some simple code that's similar to what they want to transform to be able to reason about the code structure. Check it out:
https://astexplorer.net/#/gist/3fc672d80a6e82fa02103ad43fcddfbe/204ff6161580db41d958fd94bf050e04fba5acc6