### PR TITLE
ID-48 TextInput2 trailing elements

### DIFF
--- a/docs/components/TextInput2View.jsx
+++ b/docs/components/TextInput2View.jsx
@@ -37,7 +37,9 @@ export default class TextInput2View extends React.PureComponent {
     placeholder: "example placeholder",
     helpText: "example help text",
     showIcon: false,
-    requirement: TextInput2Requirement.OPTIONAL,
+    requirement: TextInput2Requirement.REQUIRED,
+    obscurable: false,
+    initialIsInError: false,
     size: FormElementSize.MEDIUM,
   };
 
@@ -75,7 +77,9 @@ export default class TextInput2View extends React.PureComponent {
               helpText={this.state.helpText}
               placeholder={this.state.placeholder}
               requirement={this.state.requirement}
+              obscurable={this.state.obscurable}
               value={this.state.value}
+              initialIsInError={this.state.initialIsInError}
               onChange={(e) => this.setState({ value: e.target.value })}
               size={this.state.size}
             />
@@ -89,7 +93,17 @@ export default class TextInput2View extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { label, hideLabel, placeholder, helpText, showIcon, requirement, size } = this.state;
+    const {
+      label,
+      hideLabel,
+      placeholder,
+      helpText,
+      showIcon,
+      requirement,
+      obscurable,
+      initialIsInError,
+      size,
+    } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -140,6 +154,24 @@ export default class TextInput2View extends React.PureComponent {
             onChange={(e) => this.setState({ showIcon: e.target.checked })}
           />{" "}
           <span className={cssClass.CONFIG_TEXT}>Show Icon</span>
+        </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            className={cssClass.CONFIG_TOGGLE}
+            checked={obscurable}
+            onChange={(e) => this.setState({ obscurable: e.target.checked })}
+          />{" "}
+          <span className={cssClass.CONFIG_TEXT}>Obscurable</span>
+        </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            className={cssClass.CONFIG_TOGGLE}
+            checked={initialIsInError}
+            onChange={(e) => this.setState({ initialIsInError: e.target.checked })}
+          />{" "}
+          <span className={cssClass.CONFIG_TEXT}>Initial error</span>
         </label>
         <div className={cssClass.CONFIG}>
           <span className={cssClass.CONFIG_TEXT}>Requirement:</span>
@@ -199,6 +231,7 @@ export default class TextInput2View extends React.PureComponent {
             type: "Boolean",
             description:
               "Hide label for visual purposes only (will still be available to screen readers)",
+            optional: true,
           },
           {
             name: "placeholder",
@@ -222,6 +255,18 @@ export default class TextInput2View extends React.PureComponent {
             name: "requirement",
             type: '"required" or "optional"',
             description: "Indicator to note if the input is required or optional",
+            optional: true,
+          },
+          {
+            name: "obscurable",
+            type: "boolean",
+            description: "Obscure input with hide/show toggle",
+            optional: true,
+          },
+          {
+            name: "initialIsInError",
+            type: "boolean",
+            description: "Intialize the component in an error state",
             optional: true,
           },
           {

--- a/docs/components/TextInput2View.less
+++ b/docs/components/TextInput2View.less
@@ -16,7 +16,7 @@
   .margin--bottom--m;
 
   &:not(:last-child) {
-    .margin--right--m;
+    .margin--x--xs;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.71.0",
+  "version": "2.72.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput2/TextInput2.less
+++ b/src/TextInput2/TextInput2.less
@@ -59,6 +59,7 @@
   .borderRadius--l();
   background-color: @neutral_white;
   .padding--x--xs();
+  box-sizing: border-box;
 
   &--focused {
     box-shadow: 0 0 0 @size_2xs ~"@{primary_blue_tint_2}80";

--- a/src/TextInput2/TextInput2.less
+++ b/src/TextInput2/TextInput2.less
@@ -48,31 +48,58 @@
 
 .TextInput2--leadingIcon {
   color: @neutral_medium_gray;
-  .padding--left--xs();
+  .margin--right--2xs();
+}
+
+.TextInput2--inputContainer {
+  width: 100%;
+  .inlineFlexbox();
+  .items--baseline();
+  .border--s(@neutral_silver);
+  .borderRadius--l();
+  background-color: @neutral_white;
+  .padding--x--xs();
+
+  &--focused {
+    box-shadow: 0 0 0 @size_2xs ~"@{primary_blue_tint_2}80";
+
+    .border--s(@primary_blue);
+  }
+
+  &--error {
+    .border--s(@alert_red);
+  }
+
+  /* stylelint-disable-next-line no-descending-specificity */
+  &:hover {
+    .border--s(@primary_blue);
+  }
+  /*
+    error border is always on, so override the hover state
+  */
+  /* stylelint-disable-next-line no-descending-specificity */
+  &--error:hover {
+    .border--s(@alert_red);
+  }
+}
+
+.TextInput2--inputContainer--focused.TextInput2--inputContainer--error {
+  box-shadow: 0 0 0 @size_2xs ~"@{alert_red_tint_2}80";
 }
 
 .TextInput2--input {
   border: none;
   outline: none;
+  .borderRadius--l();
   width: 100%;
+  height: @size_2xl;
   font-family: "Proxima Nova";
   .text--medium();
   line-height: @size_l;
-  .padding--left--xs();
 
   &::placeholder {
     //&::-webkit-input-placeholder, &::-moz-placeholder, &:-ms-input-placeholder {
     color: @neutral_gray;
-  }
-
-  &--focused {
-    .border--s(@primary_blue);
-    box-shadow: 0 0 0 @size_2xs ~"@{primary_blue_tint_2}80";
-  }
-
-  &--error {
-    .border--s(@alert_red);
-    box-shadow: 0 0 0 @size_2xs ~"@{alert_red_tint_2}80";
   }
 }
 
@@ -86,22 +113,9 @@
   }
 }
 
-.TextInput2--inputContainer {
-  width: 100%;
-  .inlineFlexbox();
-  .items--baseline();
-  .padding--y--2xs();
-  .border--s(@neutral_silver);
-  .borderRadius--l();
-  background-color: @neutral_white;
-
-  &:hover {
-    .border--s(@primary_blue);
-  }
-
-  &--error:hover {
-    .border--s(@alert_red);
-  }
+.TextInput2--errorIcon {
+  color: @alert_red;
+  .margin--left--xs();
 }
 
 .Button.TextInput2--hideShowButton {

--- a/src/TextInput2/TextInput2.less
+++ b/src/TextInput2/TextInput2.less
@@ -103,3 +103,7 @@
     .border--s(@alert_red);
   }
 }
+
+.Button.TextInput2--hideShowButton {
+  .margin--left--xs();
+}

--- a/src/TextInput2/TextInput2.tsx
+++ b/src/TextInput2/TextInput2.tsx
@@ -2,6 +2,7 @@ import * as classnames from "classnames";
 import * as React from "react";
 import { useState } from "react";
 
+import { Button } from "../Button/Button";
 import { FormElementSize, formElementSizeClassName } from "../utils/Forms";
 import { Values } from "../utils/types";
 
@@ -22,6 +23,7 @@ export interface Props {
   helpText?: React.ReactNode;
   icon?: React.ReactNode;
   requirement?: Values<typeof TextInput2Requirement>;
+  obscurable?: boolean;
   value: string;
   onChange: React.ChangeEventHandler<HTMLInputElement>;
   size?: Values<typeof FormElementSize>;
@@ -39,6 +41,7 @@ export const cssClass = {
   INPUT: "TextInput2--input",
   INPUT_FOCUSED: "TextInput2--input--focused",
   HELP_TEXT: "TextInput2--helpText",
+  HIDE_SHOW: "TextInput2--hideShowButton",
 };
 
 /*
@@ -53,12 +56,16 @@ const TextInput2: React.FC<Props> = ({
   helpText,
   icon,
   requirement,
+  obscurable,
   value,
   onChange,
   size,
 }) => {
   const id = name;
   const [isFocused, setIsFocused] = useState(false);
+
+  const [isObscured, setIsObscured] = useState(true);
+  const inputType = obscurable && isObscured ? "password" : "text";
 
   return (
     <div className={classnames(cssClass.CONTAINER, formElementSizeClassName(size), className)}>
@@ -84,13 +91,21 @@ const TextInput2: React.FC<Props> = ({
           name={id}
           className={cssClass.INPUT}
           role="textbox"
-          type={"text"}
+          type={inputType}
           value={value}
           placeholder={placeholder}
           onChange={onChange}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
         />
+        {obscurable && (
+          <Button
+            className={cssClass.HIDE_SHOW}
+            type="linkPlain"
+            onClick={(e) => setIsObscured(!isObscured)}
+            value={isObscured ? "Show" : "Hide"}
+          />
+        )}
       </div>
       {!!helpText && <div className={cssClass.HELP_TEXT}>{helpText}</div>}
     </div>

--- a/src/TextInput2/TextInput2.tsx
+++ b/src/TextInput2/TextInput2.tsx
@@ -1,7 +1,8 @@
 import * as classnames from "classnames";
 import * as React from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
+import * as FontAwesome from "react-fontawesome";
 import { Button } from "../Button/Button";
 import { FormElementSize, formElementSizeClassName } from "../utils/Forms";
 import { Values } from "../utils/types";
@@ -18,12 +19,13 @@ export interface Props {
   name: string;
   label: React.ReactNode;
   // label is required for a11y purposes, so provide an option to hide it visually
-  hideLabel: boolean;
+  hideLabel?: boolean;
   placeholder?: string;
   helpText?: React.ReactNode;
   icon?: React.ReactNode;
   requirement?: Values<typeof TextInput2Requirement>;
   obscurable?: boolean;
+  initialIsInError?: boolean;
   value: string;
   onChange: React.ChangeEventHandler<HTMLInputElement>;
   size?: Values<typeof FormElementSize>;
@@ -38,9 +40,11 @@ export const cssClass = {
   LABEL_HIDDEN: "TextInput2--label--hidden",
   LEADING_ICON: "TextInput2--leadingIcon",
   INPUT_CONTAINER: "TextInput2--inputContainer",
+  INPUT_CONTAINER_FOCUSED: "TextInput2--inputContainer--focused",
+  INPUT_CONTAINER_ERROR: "TextInput2--inputContainer--error",
   INPUT: "TextInput2--input",
-  INPUT_FOCUSED: "TextInput2--input--focused",
   HELP_TEXT: "TextInput2--helpText",
+  ERROR_ICON: "TextInput2--errorIcon",
   HIDE_SHOW: "TextInput2--hideShowButton",
 };
 
@@ -56,6 +60,7 @@ const TextInput2: React.FC<Props> = ({
   helpText,
   icon,
   requirement,
+  initialIsInError,
   obscurable,
   value,
   onChange,
@@ -66,6 +71,28 @@ const TextInput2: React.FC<Props> = ({
 
   const [isObscured, setIsObscured] = useState(true);
   const inputType = obscurable && isObscured ? "password" : "text";
+
+  const [isInError, setIsInError] = useState(initialIsInError);
+
+  useEffect(() => {
+    if (requirement === TextInput2Requirement.REQUIRED && value === "") {
+      setIsInError(initialIsInError);
+    }
+  }, [initialIsInError]);
+
+  useEffect(() => {
+    // don't show error if nothing has happened yet
+    if (!isFocused && !isInError) {
+      return;
+    }
+
+    if (requirement === TextInput2Requirement.REQUIRED && value === "") {
+      setIsInError(true);
+      return;
+    }
+
+    setIsInError(false);
+  }, [value, isFocused]);
 
   return (
     <div className={classnames(cssClass.CONTAINER, formElementSizeClassName(size), className)}>
@@ -78,13 +105,19 @@ const TextInput2: React.FC<Props> = ({
             {label}
           </label>
           {!!requirement && (
-            <span className={cssClass.INFO_REQUIREMENT} aria-live="polite">
+            <label className={cssClass.INFO_REQUIREMENT} aria-live="polite" htmlFor={id}>
               {requirement}
-            </span>
+            </label>
           )}
         </div>
       }
-      <div className={classnames(cssClass.INPUT_CONTAINER, isFocused && cssClass.INPUT_FOCUSED)}>
+      <div
+        className={classnames(
+          cssClass.INPUT_CONTAINER,
+          isFocused && cssClass.INPUT_CONTAINER_FOCUSED,
+          isInError && cssClass.INPUT_CONTAINER_ERROR,
+        )}
+      >
         {icon && <i className={cssClass.LEADING_ICON}>{icon}</i>}
         <input
           id={id}
@@ -98,6 +131,7 @@ const TextInput2: React.FC<Props> = ({
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
         />
+        {isInError && <FontAwesome className={cssClass.ERROR_ICON} name="exclamation-circle" />}
         {obscurable && (
           <Button
             className={cssClass.HIDE_SHOW}
@@ -113,6 +147,7 @@ const TextInput2: React.FC<Props> = ({
 };
 
 TextInput2.defaultProps = {
+  initialIsInError: false,
   size: FormElementSize.FULL_WIDTH,
 };
 


### PR DESCRIPTION
**Overview:**
Continuation of https://github.com/Clever/components/pull/586 implementing new features:
* obscure hide/show functionality
* basic `required` error states

**Screenshots/GIFs:**
![TextInput2-obscured](https://user-images.githubusercontent.com/13126257/108565604-cf750100-72b9-11eb-8e5a-7312f2dfc161.gif)
![TextInput2-required-error](https://user-images.githubusercontent.com/13126257/108567877-e7e71a80-72bd-11eb-8dd4-065e0090794b.gif)

**Testing:**

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component