### PR TITLE
ID-48 custom errors disabled

### DIFF
--- a/docs/components/TextInput2View.jsx
+++ b/docs/components/TextInput2View.jsx
@@ -80,6 +80,7 @@ export default class TextInput2View extends React.PureComponent {
               obscurable={this.state.obscurable}
               value={this.state.value}
               initialIsInError={this.state.initialIsInError}
+              errorValidation={(value) => (value.toLowerCase() !== value ? "only lowercase" : null)}
               onChange={(e) => this.setState({ value: e.target.value })}
               size={this.state.size}
             />
@@ -181,6 +182,7 @@ export default class TextInput2View extends React.PureComponent {
               { content: "none", value: "" },
               { content: "optional", value: TextInput2Requirement.OPTIONAL },
               { content: "required", value: TextInput2Requirement.REQUIRED },
+              { content: "disabled", value: TextInput2Requirement.DISABLED },
             ]}
             value={requirement}
             onSelect={(value) => this.setState({ requirement: value })}
@@ -253,8 +255,8 @@ export default class TextInput2View extends React.PureComponent {
           },
           {
             name: "requirement",
-            type: '"required" or "optional"',
-            description: "Indicator to note if the input is required or optional",
+            type: '"required", "optional", or "disabled"',
+            description: "Indicator to note if the input is required, optional, or disabled",
             optional: true,
           },
           {
@@ -268,6 +270,12 @@ export default class TextInput2View extends React.PureComponent {
             type: "boolean",
             description: "Intialize the component in an error state",
             optional: true,
+          },
+          {
+            name: "errorValidation",
+            type: "Function",
+            description:
+              "Any custom validation that you want on the input. Returns null for no error, otherwise returns a string as an error message to be displayed",
           },
           {
             name: "value",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.72.0",
+  "version": "2.73.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput2/TextInput2.less
+++ b/src/TextInput2/TextInput2.less
@@ -116,7 +116,7 @@
   }
 }
 
-.TextInput2--helpText {
+.TextInput2--footerText {
   color: @neutral_medium_gray;
   .text--small();
   .padding--top--2xs();

--- a/src/TextInput2/TextInput2.less
+++ b/src/TextInput2/TextInput2.less
@@ -82,6 +82,14 @@
   &--error:hover {
     .border--s(@alert_red);
   }
+
+  &--disabled {
+    .border--s(@neutral_silver);
+  }
+
+  &--disabled:hover {
+    .border--s(@neutral_silver);
+  }
 }
 
 .TextInput2--inputContainer--focused.TextInput2--inputContainer--error {
@@ -97,6 +105,10 @@
   font-family: "Proxima Nova";
   .text--medium();
   line-height: @size_l;
+
+  &:disabled {
+    background-color: @neutral_white;
+  }
 
   &::placeholder {
     //&::-webkit-input-placeholder, &::-moz-placeholder, &:-ms-input-placeholder {

--- a/src/TextInput2/TextInput2.tsx
+++ b/src/TextInput2/TextInput2.tsx
@@ -12,6 +12,7 @@ import "./TextInput2.less";
 export const TextInput2Requirement = {
   OPTIONAL: "optional",
   REQUIRED: "required",
+  DISABLED: "disabled",
 } as const;
 
 export interface Props {
@@ -42,6 +43,7 @@ export const cssClass = {
   INPUT_CONTAINER: "TextInput2--inputContainer",
   INPUT_CONTAINER_FOCUSED: "TextInput2--inputContainer--focused",
   INPUT_CONTAINER_ERROR: "TextInput2--inputContainer--error",
+  INPUT_CONTAINER_DISABLED: "TextInput2--inputContainer--disabled",
   INPUT: "TextInput2--input",
   HELP_TEXT: "TextInput2--helpText",
   ERROR_ICON: "TextInput2--errorIcon",
@@ -127,6 +129,7 @@ const TextInput2: React.FC<Props> = ({
           type={inputType}
           value={value}
           placeholder={placeholder}
+          disabled={requirement === TextInput2Requirement.DISABLED}
           onChange={onChange}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}

--- a/src/TextInput2/TextInput2.tsx
+++ b/src/TextInput2/TextInput2.tsx
@@ -27,6 +27,8 @@ export interface Props {
   requirement?: Values<typeof TextInput2Requirement>;
   obscurable?: boolean;
   initialIsInError?: boolean;
+  // returns an error message, null for no error
+  errorValidation?: (value: string) => string | null;
   value: string;
   onChange: React.ChangeEventHandler<HTMLInputElement>;
   size?: Values<typeof FormElementSize>;
@@ -45,7 +47,8 @@ export const cssClass = {
   INPUT_CONTAINER_ERROR: "TextInput2--inputContainer--error",
   INPUT_CONTAINER_DISABLED: "TextInput2--inputContainer--disabled",
   INPUT: "TextInput2--input",
-  HELP_TEXT: "TextInput2--helpText",
+  FOOTER_TEXT: "TextInput2--footerText",
+  ERROR_MESSAGE: "TextInput2--footerText--error",
   ERROR_ICON: "TextInput2--errorIcon",
   HIDE_SHOW: "TextInput2--hideShowButton",
 };
@@ -63,6 +66,7 @@ const TextInput2: React.FC<Props> = ({
   icon,
   requirement,
   initialIsInError,
+  errorValidation,
   obscurable,
   value,
   onChange,
@@ -74,26 +78,33 @@ const TextInput2: React.FC<Props> = ({
   const [isObscured, setIsObscured] = useState(true);
   const inputType = obscurable && isObscured ? "password" : "text";
 
-  const [isInError, setIsInError] = useState(initialIsInError);
+  // empty string is an error state with no message (e.g. required)
+  const [errorMessage, setErrorMessage] = useState(initialIsInError ? "" : null);
 
   useEffect(() => {
     if (requirement === TextInput2Requirement.REQUIRED && value === "") {
-      setIsInError(initialIsInError);
+      setErrorMessage(initialIsInError ? "" : null);
     }
   }, [initialIsInError]);
 
   useEffect(() => {
     // don't show error if nothing has happened yet
-    if (!isFocused && !isInError) {
+    if (!isFocused && errorMessage === null) {
       return;
     }
 
     if (requirement === TextInput2Requirement.REQUIRED && value === "") {
-      setIsInError(true);
+      setErrorMessage("");
       return;
     }
 
-    setIsInError(false);
+    const newErrorMessage = errorValidation(value);
+    if (newErrorMessage) {
+      setErrorMessage(newErrorMessage);
+      return;
+    }
+
+    setErrorMessage(null);
   }, [value, isFocused]);
 
   return (
@@ -106,7 +117,7 @@ const TextInput2: React.FC<Props> = ({
           >
             {label}
           </label>
-          {!!requirement && (
+          {requirement && (
             <label className={cssClass.INFO_REQUIREMENT} aria-live="polite" htmlFor={id}>
               {requirement}
             </label>
@@ -117,7 +128,8 @@ const TextInput2: React.FC<Props> = ({
         className={classnames(
           cssClass.INPUT_CONTAINER,
           isFocused && cssClass.INPUT_CONTAINER_FOCUSED,
-          isInError && cssClass.INPUT_CONTAINER_ERROR,
+          errorMessage != null && cssClass.INPUT_CONTAINER_ERROR,
+          requirement === TextInput2Requirement.DISABLED && cssClass.INPUT_CONTAINER_DISABLED,
         )}
       >
         {icon && <i className={cssClass.LEADING_ICON}>{icon}</i>}
@@ -134,7 +146,9 @@ const TextInput2: React.FC<Props> = ({
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
         />
-        {isInError && <FontAwesome className={cssClass.ERROR_ICON} name="exclamation-circle" />}
+        {errorMessage != null && (
+          <FontAwesome className={cssClass.ERROR_ICON} name="exclamation-circle" />
+        )}
         {obscurable && (
           <Button
             className={cssClass.HIDE_SHOW}
@@ -144,13 +158,18 @@ const TextInput2: React.FC<Props> = ({
           />
         )}
       </div>
-      {!!helpText && <div className={cssClass.HELP_TEXT}>{helpText}</div>}
+      {(errorMessage || helpText) && (
+        <div className={classnames(cssClass.FOOTER_TEXT, errorMessage && cssClass.ERROR_MESSAGE)}>
+          {errorMessage || helpText}
+        </div>
+      )}
     </div>
   );
 };
 
 TextInput2.defaultProps = {
   initialIsInError: false,
+  errorValidation: () => null,
   size: FormElementSize.FULL_WIDTH,
 };
 


### PR DESCRIPTION
**Overview:**
Continuation of https://github.com/Clever/components/pull/586 implementing new features:
* `disabled` requirement state
* custom validation and error messages

**Screenshots/GIFs:**
![TextInput2-disabled](https://user-images.githubusercontent.com/13126257/108579312-2d661080-72db-11eb-9c01-aa9b1cc48a19.gif)
![TextInput2-custom-error](https://user-images.githubusercontent.com/13126257/108579317-30610100-72db-11eb-98c4-6bf32108d0be.gif)

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
