### PR TITLE
make "add item X" work properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.74.1",
+  "version": "2.75.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MultiSelect/MultiSelect.tsx
+++ b/src/MultiSelect/MultiSelect.tsx
@@ -233,14 +233,14 @@ const MultiSelect: React.FC<Props> = ({
         {...getMenuProps()}
       >
         {isOpen &&
-          // slice out the dummy "add item X" option
-          (selectableOptions.slice(1).length === 0 && (!creatable || hasExactMatch) ? (
+          // only the dummy "add item X" option exists
+          (selectableOptions.length === 1 && (!creatable || hasExactMatch) ? (
             <li className={classNames(cssClass.NO_OPTIONS_FOUND)}>No options</li>
           ) : (
             selectableOptions.map((o, i) => {
               const isAddNewItemOption = o.value === ADD_NEW_ITEM_KEY;
               // hide the first dummy "add item X" option if not eligible
-              if (isAddNewItemOption && (inputValue.length === 0 || !creatable || hasExactMatch)) {
+              if (isAddNewItemOption && (!inputValue || !creatable || hasExactMatch)) {
                 return null;
               }
 


### PR DESCRIPTION
**Overview:**
Fix the `not found` and `create new item` case

Summary of changes:
* The `"Add X"` option now acts like a regular option item (i.e. reducers and highlighting)
* `"Add X"` will not be shown if the input value is an exact match of an existing item. Instead, it will show `no options`

**Screenshots/GIFs:**
![ID-55-multiselect-create](https://user-images.githubusercontent.com/13126257/109294626-48a4b480-77e2-11eb-8c7c-2073b961e940.gif)

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
