### PR TITLE
Modify MessagingThreadListItem to optionally display an alert icon

### DIFF
--- a/docs/components/MessagingThreadListItemView.jsx
+++ b/docs/components/MessagingThreadListItemView.jsx
@@ -27,10 +27,11 @@ export default class MessagingThreadListItemView extends React.PureComponent {
     isRead: true,
     selected: true,
     hasAlert: false,
+    hasTimestamp: true,
   };
 
   render() {
-    const { status, hasDraft, isRead, selected, hasAlert } = this.state;
+    const { status, hasDraft, isRead, selected, hasAlert, hasTimestamp } = this.state;
 
     return (
       <View
@@ -65,7 +66,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
               hasDraft={hasDraft}
               isRead={isRead}
               selected={selected}
-              timestamp={new Date()}
+              timestamp={hasTimestamp && new Date()}
               hasAlert={hasAlert}
             >
               This is some content!
@@ -89,7 +90,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { status, hasDraft, isRead, selected, hasAlert } = this.state;
+    const { status, hasDraft, isRead, selected, hasAlert, hasTimestamp } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -140,6 +141,15 @@ export default class MessagingThreadListItemView extends React.PureComponent {
             onChange={(e) => this.setState({ hasAlert: e.target.checked })}
           />{" "}
           Has Alert
+        </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            checked={hasTimestamp}
+            className={cssClass.CONFIG_TOGGLE}
+            onChange={(e) => this.setState({ hasTimestamp: e.target.checked })}
+          />{" "}
+          Has Timestamp
         </label>
       </FlexBox>
     );

--- a/docs/components/MessagingThreadListItemView.jsx
+++ b/docs/components/MessagingThreadListItemView.jsx
@@ -26,10 +26,11 @@ export default class MessagingThreadListItemView extends React.PureComponent {
     hasDraft: false,
     isRead: true,
     selected: true,
+    hasAlert: false,
   };
 
   render() {
-    const { status, hasDraft, isRead, selected } = this.state;
+    const { status, hasDraft, isRead, selected, hasAlert } = this.state;
 
     return (
       <View
@@ -65,6 +66,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
               isRead={isRead}
               selected={selected}
               timestamp={new Date()}
+              hasAlert={hasAlert}
             >
               This is some content!
             </MessagingThreadListItem>
@@ -72,8 +74,10 @@ export default class MessagingThreadListItemView extends React.PureComponent {
             <MessagingThreadListItem
               icon={<Icon name="smiley-face" />}
               title="Smiley Dude"
+              status={status}
               hasDraft={hasDraft}
               selected={selected}
+              hasAlert={hasAlert}
             />
           </ExampleCode>
           {this._renderConfig()}
@@ -85,7 +89,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { status, hasDraft, isRead, selected } = this.state;
+    const { status, hasDraft, isRead, selected, hasAlert } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -128,6 +132,15 @@ export default class MessagingThreadListItemView extends React.PureComponent {
           />{" "}
           Selected
         </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            checked={hasAlert}
+            className={cssClass.CONFIG_TOGGLE}
+            onChange={(e) => this.setState({ hasAlert: e.target.checked })}
+          />{" "}
+          Has Alert
+        </label>
       </FlexBox>
     );
   }
@@ -147,6 +160,13 @@ export default class MessagingThreadListItemView extends React.PureComponent {
             name: "className",
             type: "string",
             description: "Optional additional CSS class name to apply to the container.",
+            optional: true,
+          },
+          {
+            name: "hasAlert",
+            type: "boolean",
+            description:
+              "Whether this thread has an alert message. This indicator will take precedence over the unread indicator",
             optional: true,
           },
           {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.74.1",
+  "version": "2.75.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -86,6 +86,8 @@ export const MessagingThreadListItem: React.FC<
     </FlexBox>
   );
 
+  const isIndicatorAlignedWithSubContent = subContent && timestamp;
+
   return (
     <div ref={ref}>
       <FlexBox
@@ -114,16 +116,17 @@ export const MessagingThreadListItem: React.FC<
                 {timestamp && _formatDateForTimestamp(timestamp)}
               </div>
             )}
-            {!subContent && indicator}
           </FlexBox>
           {subContent && (
             <FlexBox alignItems={ItemAlign.CENTER}>
               <div className={subContentClass}>{subContent}</div>
-              {timestamp && indicator}
+              {isIndicatorAlignedWithSubContent && indicator}
             </FlexBox>
           )}
         </FlexItem>
-        <FlexItem alignItems={ItemAlign.CENTER}>{subContent && !timestamp && indicator}</FlexItem>
+        <FlexItem alignItems={ItemAlign.CENTER}>
+          {!isIndicatorAlignedWithSubContent && indicator}
+        </FlexItem>
       </FlexBox>
     </div>
   );

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as classNames from "classnames";
 import * as moment from "moment";
+import * as FontAwesome from "react-fontawesome";
 
 import { FlexBox, FlexItem, ItemAlign, Justify } from "../index";
 import { DraftPencilIcon } from "./DraftPencilIcon";
@@ -38,6 +39,7 @@ type Props = {
   status?: Status;
   timestamp?: Date;
   title: string;
+  hasAlert?: boolean;
 };
 
 export const MessagingThreadListItem: React.FC<
@@ -55,6 +57,7 @@ export const MessagingThreadListItem: React.FC<
     status = "active",
     offStatusText,
     onClick,
+    hasAlert,
   } = props;
 
   let subContent: React.ReactNode;
@@ -67,13 +70,19 @@ export const MessagingThreadListItem: React.FC<
     subContentClass = cssClasses.OFF_TEXT;
   }
 
+  let indicatorIcon: React.ReactNode;
+  if (hasAlert) {
+    indicatorIcon = <FontAwesome name="exclamation-triangle" />;
+  } else if (!isRead) {
+    indicatorIcon = (
+      <div aria-label={`Unread messages in thread ${title}`} className={cssClasses.UNREAD_ORB} />
+    );
+  } else if (status === "active" && hasDraft) {
+    indicatorIcon = <DraftPencilIcon />;
+  }
   const indicator = (
     <FlexBox className={cssClasses.INDICATOR_CONTAINER} justify={Justify.END}>
-      {!isRead ? (
-        <div aria-label={`Unread messages in thread ${title}`} className={cssClasses.UNREAD_ORB} />
-      ) : (
-        status === "active" && hasDraft && <DraftPencilIcon />
-      )}
+      {indicatorIcon}
     </FlexBox>
   );
 
@@ -110,10 +119,11 @@ export const MessagingThreadListItem: React.FC<
           {subContent && (
             <FlexBox alignItems={ItemAlign.CENTER}>
               <div className={subContentClass}>{subContent}</div>
-              {indicator}
+              {timestamp && indicator}
             </FlexBox>
           )}
         </FlexItem>
+        <FlexItem alignItems={ItemAlign.CENTER}>{subContent && !timestamp && indicator}</FlexItem>
       </FlexBox>
     </div>
   );


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/PRTL-241

**Overview:**
Teachers Inviting Guardians aka teavites project:
We want to display an alert icon in the thread list for contacts whose invites have expired or been rejected, so that the teacher knows to take action.
![image](https://user-images.githubusercontent.com/21094551/109539202-e49a1e80-7a75-11eb-8410-fda4dbdb9063.png)


**Screenshots/GIFs:**
<img width="262" alt="Screen Shot 2021-02-28 at 5 25 56 PM" src="https://user-images.githubusercontent.com/21094551/109539111-c502f600-7a75-11eb-8dba-a0bbac8c4a8f.png">

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
