### PR TITLE
ID-55 multi select allow duplicates

### DIFF
--- a/docs/components/MultiSelectView.jsx
+++ b/docs/components/MultiSelectView.jsx
@@ -208,7 +208,7 @@ export default class MultiSelectView extends React.PureComponent {
             name: "options",
             type: <code>{"Array<{ value: string, content?: ReactNode }>"}</code>,
             description:
-              "List of options to be selected. 'value' is a react node for custom rendering, but you must have a stringValue for searchability",
+              "List of options to be selected. 'value' is the string key and used for searchability, 'content' is an optional react node for custom rendering",
             optional: true,
           },
           {

--- a/docs/components/MultiSelectView.jsx
+++ b/docs/components/MultiSelectView.jsx
@@ -22,6 +22,7 @@ const cssClass = {
   CONFIG_CONTAINER: "MultiSelectView--configContainer",
   CONFIG_OPTIONS: "MultiSelectView--configOptions",
   CONFIG: "MultiSelectView--config",
+  CONFIG_LABEL_TEXT: "MultiSelectView--configLabelText",
   CONFIG_TOGGLE: "MultiSelectView--configToggle",
   CONTAINER: "MultiSelectView",
   INTRO: "MultiSelectView--intro",
@@ -36,6 +37,7 @@ export default class MultiSelectView extends React.PureComponent {
     hideLabel: false,
     placeholder: "Select or create options",
     creatable: false,
+    allowDuplicates: false,
     size: FormElementSize.MEDIUM,
   };
 
@@ -83,6 +85,7 @@ export default class MultiSelectView extends React.PureComponent {
                 ),
               }))}
               creatable={this.state.creatable}
+              allowDuplicates={this.state.allowDuplicates}
               onChange={console.log}
               size={this.state.size}
             />
@@ -97,7 +100,7 @@ export default class MultiSelectView extends React.PureComponent {
 
   // TODO:Update or remove config options.
   _renderConfig() {
-    const { label, hideLabel, placeholder, creatable, size } = this.state;
+    const { label, hideLabel, placeholder, creatable, allowDuplicates, size } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -118,7 +121,7 @@ export default class MultiSelectView extends React.PureComponent {
             checked={hideLabel}
             onChange={(e) => this.setState({ hideLabel: e.target.checked })}
           />{" "}
-          <span className={cssClass.CONFIG_TEXT}>Hide Label</span>
+          <span className={cssClass.CONFIG_LABEL_TEXT}>Hide Label</span>
         </label>
         <div className={cssClass.CONFIG}>
           <TextInput2
@@ -137,10 +140,19 @@ export default class MultiSelectView extends React.PureComponent {
             checked={creatable}
             onChange={(e) => this.setState({ creatable: e.target.checked })}
           />{" "}
-          <span className={cssClass.CONFIG_TEXT}>creatable</span>
+          <span className={cssClass.CONFIG_LABEL_TEXT}>creatable</span>
+        </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            className={cssClass.CONFIG_TOGGLE}
+            checked={allowDuplicates}
+            onChange={(e) => this.setState({ allowDuplicates: e.target.checked })}
+          />{" "}
+          <span className={cssClass.CONFIG_LABEL_TEXT}>allow duplicates</span>
         </label>
         <div className={cssClass.CONFIG}>
-          <span className={cssClass.CONFIG_TEXT}>Size:</span>
+          <span className={cssClass.CONFIG_LABEL_TEXT}>Size:</span>
           <SegmentedControl
             className={cssClass.CONFIG_OPTIONS}
             options={[
@@ -157,7 +169,6 @@ export default class MultiSelectView extends React.PureComponent {
     );
   }
 
-  // TODO: Update prop documentation.
   _renderProps() {
     return (
       <PropDocumentation

--- a/docs/components/MultiSelectView.less
+++ b/docs/components/MultiSelectView.less
@@ -14,12 +14,15 @@
   .flexbox;
   .items--center;
   .margin--bottom--m;
-  .text--caps;
-  .text--small;
 
   &:not(:last-child) {
     .margin--right--m;
   }
+}
+
+.MultiSelectView--configLabelText {
+  .text--caps;
+  .text--small;
 }
 
 label.MultiSelectView--config {

--- a/docs/components/Select2View.jsx
+++ b/docs/components/Select2View.jsx
@@ -178,7 +178,7 @@ export default class Select2View extends React.PureComponent {
             name: "options",
             type: <code>{"Array<{ value: string, content?: ReactNode }>"}</code>,
             description:
-              "List of options to be selected. 'value' is a react node for custom rendering, but you must have a stringValue for searchability",
+              "List of options to be selected. 'value' is the string key and used for searchability, 'content' is an optional react node for custom rendering",
             optional: true,
           },
           {

--- a/docs/components/Select2View.jsx
+++ b/docs/components/Select2View.jsx
@@ -151,20 +151,64 @@ export default class Select2View extends React.PureComponent {
         title="<Select2 /> Props"
         availableProps={[
           {
-            name: "children",
-            type: "React.Node",
-            description: "Select2 content.",
-          },
-          {
             name: "className",
             type: "string",
             description: "Optional additional CSS class name to apply to the container.",
             optional: true,
           },
           {
-            name: "onPerformAction",
-            type: "Function",
-            description: "Handler function for the performAction event.",
+            name: "name",
+            type: "String",
+            description:
+              "Name for input element which will also be used as the id for the label to reference",
+          },
+          {
+            name: "label",
+            type: "React Node",
+            description: "Label text",
+          },
+          {
+            name: "hideLabel",
+            type: "Boolean",
+            description:
+              "Hide label for visual purposes only (will still be available to screen readers)",
+            optional: true,
+          },
+          {
+            name: "options",
+            type: <code>{"Array<{ value: string, content?: ReactNode }>"}</code>,
+            description:
+              "List of options to be selected. 'value' is a react node for custom rendering, but you must have a stringValue for searchability",
+            optional: true,
+          },
+          {
+            name: "clearable",
+            type: "boolean",
+            description: "If the value chosen is allowed to be clearable",
+            optional: true,
+          },
+          {
+            name: "onChange",
+            type: <code>{"(value: string) => void"}</code>,
+            description: "Called when an option is selected",
+          },
+          {
+            name: "size",
+            type: "string",
+            description: (
+              <p>
+                The size of the input. One of:
+                <br />
+                {Object.keys(FormElementSize).map((size) => (
+                  <span key={size}>
+                    <code>FormElementSize.{size}</code>
+                    <br />
+                  </span>
+                ))}
+              </p>
+            ),
+            optional: true,
+            defaultValue: <code>FormElementSize.FULL_WIDTH</code>,
           },
         ]}
         className={cssClass.PROPS}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.76.0",
+  "version": "2.76.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Overview:**
Prop to allow the MultiSelect to select the same item an infinite number of times. Will be used to create password templating in our product for now. Talking with Georgia, we may come up with a better way to design this use case but for now we have decided on this MultiSelect with allowDuplicates.

Also updated the Select2 components prop docs, which I missed in https://github.com/Clever/components/pull/590

**Screenshots/GIFs:**

https://user-images.githubusercontent.com/13126257/109706808-429a3500-7b4e-11eb-9325-a1040e2d654e.mov

**Testing:**

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [x] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
