### PR TITLE
ID-55 select2 required

### DIFF
--- a/docs/components/MultiSelectView.jsx
+++ b/docs/components/MultiSelectView.jsx
@@ -5,16 +5,8 @@ import FontAwesome from "react-fontawesome";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import {
-  TextInput2,
-  TextInput2Requirement,
-  MultiSelect,
-  FlexBox,
-  ItemAlign,
-  SegmentedControl,
-  Label,
-} from "src";
-import { FormElementSize } from "../../src/utils/Forms";
+import { TextInput2, MultiSelect, FlexBox, ItemAlign, SegmentedControl, Label } from "src";
+import { FormElementSize, FormElementRequirement } from "../../src/utils/Forms";
 
 import "./MultiSelectView.less";
 
@@ -109,7 +101,7 @@ export default class MultiSelectView extends React.PureComponent {
             className={cssClass.CONFIG_OPTIONS}
             name="TextInput2View--labelTextInput"
             label="Label text"
-            requirement={TextInput2Requirement.REQUIRED}
+            requirement={FormElementRequirement.REQUIRED}
             onChange={(e) => this.setState({ label: e.target.value })}
             value={label}
           />
@@ -128,7 +120,7 @@ export default class MultiSelectView extends React.PureComponent {
             className={cssClass.CONFIG_OPTIONS}
             name="TextInput2View--placeholderTextInput"
             label="Placeholder text"
-            requirement={TextInput2Requirement.OPTIONAL}
+            requirement={FormElementRequirement.OPTIONAL}
             onChange={(e) => this.setState({ placeholder: e.target.value })}
             value={placeholder}
           />

--- a/docs/components/Select2View.jsx
+++ b/docs/components/Select2View.jsx
@@ -28,6 +28,8 @@ export default class Select2View extends React.PureComponent {
     label: "Select an option",
     hideLabel: false,
     clearable: true,
+    required: true,
+    initialIsInError: false,
     size: FormElementSize.MEDIUM,
   };
 
@@ -62,7 +64,6 @@ export default class Select2View extends React.PureComponent {
               name="Select2View--Select2"
               label={this.state.label}
               hideLabel={this.state.hideLabel}
-              clearable={this.state.clearable}
               options={new Array(20).fill(0).map((_, i) => ({
                 value: `Option ${i + 1}`,
                 content: (
@@ -72,6 +73,9 @@ export default class Select2View extends React.PureComponent {
                   </FlexBox>
                 ),
               }))}
+              clearable={this.state.clearable}
+              requirement={this.state.required ? "required" : ""}
+              initialIsInError={this.state.initialIsInError}
               onChange={console.log}
               size={this.state.size}
             />
@@ -84,9 +88,8 @@ export default class Select2View extends React.PureComponent {
     );
   }
 
-  // TODO: Update or remove config options.
   _renderConfig() {
-    const { label, hideLabel, clearable, size } = this.state;
+    const { label, hideLabel, clearable, required, initialIsInError, size } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -117,6 +120,24 @@ export default class Select2View extends React.PureComponent {
             onChange={(e) => this.setState({ clearable: e.target.checked })}
           />{" "}
           <span className={cssClass.CONFIG_LABEL_TEXT}>Clearable</span>
+        </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            checked={required}
+            className={cssClass.CONFIG_TOGGLE}
+            onChange={(e) => this.setState({ required: e.target.checked })}
+          />{" "}
+          <span className={cssClass.CONFIG_LABEL_TEXT}>Required</span>
+        </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            className={cssClass.CONFIG_TOGGLE}
+            checked={initialIsInError}
+            onChange={(e) => this.setState({ initialIsInError: e.target.checked })}
+          />{" "}
+          <span className={cssClass.CONFIG_LABEL_TEXT}>Initial error</span>
         </label>
         <div className={cssClass.CONFIG}>
           <span className={cssClass.CONFIG_LABEL_TEXT}>Size:</span>
@@ -177,6 +198,18 @@ export default class Select2View extends React.PureComponent {
             name: "clearable",
             type: "boolean",
             description: "If the value chosen is allowed to be clearable",
+            optional: true,
+          },
+          {
+            name: "requirement",
+            type: '"required"',
+            description: "Indicator to note if the input is required",
+            optional: true,
+          },
+          {
+            name: "initialIsInError",
+            type: "boolean",
+            description: "Intialize the component in an error state",
             optional: true,
           },
           {

--- a/docs/components/Select2View.jsx
+++ b/docs/components/Select2View.jsx
@@ -5,16 +5,8 @@ import FontAwesome from "react-fontawesome";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import {
-  TextInput2,
-  TextInput2Requirement,
-  Select2,
-  FlexBox,
-  ItemAlign,
-  SegmentedControl,
-  Label,
-} from "src";
-import { FormElementSize } from "../../src/utils/Forms";
+import { TextInput2, Select2, FlexBox, ItemAlign, SegmentedControl, Label } from "src";
+import { FormElementSize, FormElementRequirement } from "../../src/utils/Forms";
 
 import "./Select2View.less";
 
@@ -103,7 +95,7 @@ export default class Select2View extends React.PureComponent {
             className={cssClass.CONFIG_OPTIONS}
             name="TextInput2View--labelTextInput"
             label="Label text"
-            requirement={TextInput2Requirement.REQUIRED}
+            requirement={FormElementRequirement.REQUIRED}
             onChange={(e) => this.setState({ label: e.target.value })}
             value={label}
           />

--- a/docs/components/TextInput2View.jsx
+++ b/docs/components/TextInput2View.jsx
@@ -4,15 +4,8 @@ import FontAwesome from "react-fontawesome";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import {
-  TextInput2,
-  TextInput2Requirement,
-  FlexBox,
-  ItemAlign,
-  SegmentedControl,
-  Label,
-} from "src";
-import { FormElementSize } from "../../src/utils/Forms";
+import { TextInput2, FlexBox, ItemAlign, SegmentedControl, Label } from "src";
+import { FormElementSize, FormElementRequirement } from "../../src/utils/Forms";
 
 import "./TextInput2View.less";
 
@@ -37,7 +30,7 @@ export default class TextInput2View extends React.PureComponent {
     placeholder: "kstark",
     helpText: "first name and last initial",
     showIcon: false,
-    requirement: TextInput2Requirement.REQUIRED,
+    requirement: FormElementRequirement.REQUIRED,
     obscurable: false,
     initialIsInError: false,
     size: FormElementSize.MEDIUM,
@@ -113,7 +106,7 @@ export default class TextInput2View extends React.PureComponent {
             className={cssClass.CONFIG_OPTIONS}
             name="TextInput2View--labelTextInput"
             label="Label text"
-            requirement={TextInput2Requirement.REQUIRED}
+            requirement={FormElementRequirement.REQUIRED}
             onChange={(e) => this.setState({ label: e.target.value })}
             value={label}
           />
@@ -132,7 +125,7 @@ export default class TextInput2View extends React.PureComponent {
             className={cssClass.CONFIG_OPTIONS}
             name="TextInput2View--placeholderTextInput"
             label="Placeholder text"
-            requirement={TextInput2Requirement.OPTIONAL}
+            requirement={FormElementRequirement.OPTIONAL}
             onChange={(e) => this.setState({ placeholder: e.target.value })}
             value={placeholder}
           />
@@ -142,7 +135,7 @@ export default class TextInput2View extends React.PureComponent {
             className={cssClass.CONFIG_OPTIONS}
             name="TextInput2View--helpTextInput"
             label="Help text"
-            requirement={TextInput2Requirement.OPTIONAL}
+            requirement={FormElementRequirement.OPTIONAL}
             onChange={(e) => this.setState({ helpText: e.target.value })}
             value={helpText}
           />
@@ -180,9 +173,9 @@ export default class TextInput2View extends React.PureComponent {
             className={cssClass.CONFIG_OPTIONS}
             options={[
               { content: "none", value: "" },
-              { content: "optional", value: TextInput2Requirement.OPTIONAL },
-              { content: "required", value: TextInput2Requirement.REQUIRED },
-              { content: "disabled", value: TextInput2Requirement.DISABLED },
+              { content: "optional", value: FormElementRequirement.OPTIONAL },
+              { content: "required", value: FormElementRequirement.REQUIRED },
+              { content: "disabled", value: FormElementRequirement.DISABLED },
             ]}
             value={requirement}
             onSelect={(value) => this.setState({ requirement: value })}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.76.1",
+  "version": "2.77.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select2/Select2.less
+++ b/src/Select2/Select2.less
@@ -122,8 +122,8 @@
 
 .Select2--errorIcon {
   color: @alert_red;
-  display: flex;
-  align-items: center;
+  .flexbox();
+  .items--center();
 }
 
 .Select2--clearButton {

--- a/src/Select2/Select2.less
+++ b/src/Select2/Select2.less
@@ -6,8 +6,19 @@
   position: relative;
 }
 
-.Select2--label {
+.Select2--infoRow {
+  .flexbox();
+  .justify--between();
   .padding--bottom--2xs();
+  color: @neutral_medium_gray;
+  .text--small();
+
+  &--labelHidden {
+    .justify--end();
+  }
+}
+
+.Select2--label {
   color: @neutral_medium_gray;
   .text--small();
 
@@ -28,6 +39,10 @@
     border: 0;
     /* stylelint-enable */
   }
+}
+
+.Select2--infoRequirement {
+  .text--italic();
 }
 
 .Select2--selectContainer {

--- a/src/Select2/Select2.less
+++ b/src/Select2/Select2.less
@@ -52,8 +52,7 @@
   .border--m(@neutral_silver);
   .borderRadius--l();
   background-color: @neutral_white;
-  .margin--top--3xs();
-  .padding--left--xs();
+  .padding--x--s();
   box-sizing: border-box;
   transition: box-shadow @timingQuickly ease-out;
 
@@ -63,10 +62,22 @@
     .border--m(@primary_blue);
   }
 
+  &--error {
+    .border--m(@alert_red);
+  }
+
   /* stylelint-disable-next-line no-descending-specificity */
   &:hover {
     .border--m(@primary_blue);
   }
+
+  &--error:hover {
+    .border--m(@alert_red);
+  }
+}
+
+.Select2--selectContainer--focused.Select2--selectContainer--error {
+  box-shadow: 0 0 0 @size_2xs ~"@{alert_red_tint_2}80";
 }
 
 .Select2--input {
@@ -95,11 +106,6 @@
   }
 }
 
-.Select2--buttonContainer {
-  .flexbox();
-  .padding--x--s();
-}
-
 .Select2--button--reset {
   outline: none;
   border: none;
@@ -109,15 +115,23 @@
   .text--medium();
 }
 
+.Select2--trailingElement {
+  .margin--left--xs();
+  min-height: @size_2xl;
+}
+
+.Select2--errorIcon {
+  color: @alert_red;
+  display: flex;
+  align-items: center;
+}
+
 .Select2--clearButton {
   background-color: @neutral_white;
-  min-height: @size_2xl;
-  .margin--right--s();
 }
 
 .Select2--caretButton {
   background-color: @neutral_white;
-  min-height: @size_2xl;
 }
 
 .Select2--options {

--- a/src/Select2/Select2.tsx
+++ b/src/Select2/Select2.tsx
@@ -187,6 +187,10 @@ const Select2: React.FC<Props> = ({
             onClick={(e) => {
               e.stopPropagation();
               selectItem(null);
+              openMenu();
+              if (inputRef.current) {
+                inputRef.current.select();
+              }
             }}
           >
             {/* https://www.compart.com/en/unicode/U+2715 */}

--- a/src/Select2/Select2.tsx
+++ b/src/Select2/Select2.tsx
@@ -4,7 +4,7 @@ import { useState, useRef } from "react";
 import { useCombobox } from "downshift";
 import * as FontAwesome from "react-fontawesome";
 
-import { FormElementSize, formElementSizeClassName } from "../utils/Forms";
+import { FormElementSize, formElementSizeClassName, FormElementRequirement } from "../utils/Forms";
 import { Values } from "../utils/types";
 
 import "./Select2.less";
@@ -20,12 +20,17 @@ export interface Props {
   hideLabel?: boolean;
   options: Option[];
   clearable?: boolean;
+  // TODO: support all requirement types
+  requirement?: typeof FormElementRequirement.REQUIRED;
   onChange?: (value: string) => void;
   size?: Values<typeof FormElementSize>;
 }
 
 export const cssClass = {
   CONTAINER: "Select2--container",
+  INFO_ROW: "Select2--infoRow",
+  INFO_ROW_LABEL_HIDDEN: "Select2--infoRow--labelHidden",
+  INFO_REQUIREMENT: "Select2--infoRequirement",
   LABEL: "Select2--label",
   LABEL_HIDDEN: "Select2--label--hidden",
   SELECT_CONTAINER: "Select2--selectContainer",
@@ -52,6 +57,7 @@ const Select2: React.FC<Props> = ({
   hideLabel,
   options,
   clearable,
+  requirement,
   onChange,
   size,
 }) => {
@@ -115,12 +121,19 @@ const Select2: React.FC<Props> = ({
   const inputRef = useRef<HTMLInputElement>();
   return (
     <div className={classNames(cssClass.CONTAINER, formElementSizeClassName(size), className)}>
-      <label
-        className={classNames(cssClass.LABEL, hideLabel && cssClass.LABEL_HIDDEN)}
-        {...getLabelProps()}
-      >
-        {label}
-      </label>
+      <div className={classNames(cssClass.INFO_ROW, hideLabel && cssClass.INFO_ROW_LABEL_HIDDEN)}>
+        <label
+          className={classNames(cssClass.LABEL, hideLabel && cssClass.LABEL_HIDDEN)}
+          {...getLabelProps()}
+        >
+          {label}
+        </label>
+        {requirement && (
+          <label className={cssClass.INFO_REQUIREMENT} aria-live="polite" {...getLabelProps()}>
+            {requirement}
+          </label>
+        )}
+      </div>
       <div
         className={classNames(
           cssClass.SELECT_CONTAINER,

--- a/src/TextInput2/TextInput2.tsx
+++ b/src/TextInput2/TextInput2.tsx
@@ -103,21 +103,19 @@ const TextInput2: React.FC<Props> = ({
 
   return (
     <div className={classnames(cssClass.CONTAINER, formElementSizeClassName(size), className)}>
-      {
-        <div className={classnames(cssClass.INFO_ROW, hideLabel && cssClass.INFO_ROW_LABEL_HIDDEN)}>
-          <label
-            className={classnames(cssClass.LABEL, hideLabel && cssClass.LABEL_HIDDEN)}
-            htmlFor={id}
-          >
-            {label}
+      <div className={classnames(cssClass.INFO_ROW, hideLabel && cssClass.INFO_ROW_LABEL_HIDDEN)}>
+        <label
+          className={classnames(cssClass.LABEL, hideLabel && cssClass.LABEL_HIDDEN)}
+          htmlFor={id}
+        >
+          {label}
+        </label>
+        {requirement && (
+          <label className={cssClass.INFO_REQUIREMENT} aria-live="polite" htmlFor={id}>
+            {requirement}
           </label>
-          {requirement && (
-            <label className={cssClass.INFO_REQUIREMENT} aria-live="polite" htmlFor={id}>
-              {requirement}
-            </label>
-          )}
-        </div>
-      }
+        )}
+      </div>
       <div
         className={classnames(
           cssClass.INPUT_CONTAINER,

--- a/src/TextInput2/TextInput2.tsx
+++ b/src/TextInput2/TextInput2.tsx
@@ -4,16 +4,10 @@ import { useState, useEffect } from "react";
 
 import * as FontAwesome from "react-fontawesome";
 import { Button } from "../Button/Button";
-import { FormElementSize, formElementSizeClassName } from "../utils/Forms";
+import { FormElementSize, formElementSizeClassName, FormElementRequirement } from "../utils/Forms";
 import { Values } from "../utils/types";
 
 import "./TextInput2.less";
-
-export const TextInput2Requirement = {
-  OPTIONAL: "optional",
-  REQUIRED: "required",
-  DISABLED: "disabled",
-} as const;
 
 export interface Props {
   className?: string;
@@ -24,7 +18,7 @@ export interface Props {
   placeholder?: string;
   helpText?: React.ReactNode;
   icon?: React.ReactNode;
-  requirement?: Values<typeof TextInput2Requirement>;
+  requirement?: Values<typeof FormElementRequirement>;
   obscurable?: boolean;
   initialIsInError?: boolean;
   // returns an error message, null for no error
@@ -82,7 +76,7 @@ const TextInput2: React.FC<Props> = ({
   const [errorMessage, setErrorMessage] = useState(initialIsInError ? "" : null);
 
   useEffect(() => {
-    if (requirement === TextInput2Requirement.REQUIRED && value === "") {
+    if (requirement === FormElementRequirement.REQUIRED && value === "") {
       setErrorMessage(initialIsInError ? "" : null);
     }
   }, [initialIsInError]);
@@ -93,7 +87,7 @@ const TextInput2: React.FC<Props> = ({
       return;
     }
 
-    if (requirement === TextInput2Requirement.REQUIRED && value === "") {
+    if (requirement === FormElementRequirement.REQUIRED && value === "") {
       setErrorMessage("");
       return;
     }
@@ -129,7 +123,7 @@ const TextInput2: React.FC<Props> = ({
           cssClass.INPUT_CONTAINER,
           isFocused && cssClass.INPUT_CONTAINER_FOCUSED,
           errorMessage != null && cssClass.INPUT_CONTAINER_ERROR,
-          requirement === TextInput2Requirement.DISABLED && cssClass.INPUT_CONTAINER_DISABLED,
+          requirement === FormElementRequirement.DISABLED && cssClass.INPUT_CONTAINER_DISABLED,
         )}
       >
         {icon && <i className={cssClass.LEADING_ICON}>{icon}</i>}
@@ -141,7 +135,7 @@ const TextInput2: React.FC<Props> = ({
           type={inputType}
           value={value}
           placeholder={placeholder}
-          disabled={requirement === TextInput2Requirement.DISABLED}
+          disabled={requirement === FormElementRequirement.DISABLED}
           onChange={onChange}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}

--- a/src/TextInput2/index.ts
+++ b/src/TextInput2/index.ts
@@ -1,3 +1,2 @@
 import TextInput2 from "./TextInput2";
-export { TextInput2Requirement } from "./TextInput2";
 export default TextInput2;

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,6 @@ export { FamilyPortalLogo } from "./FamilyPortalLogo";
 
 import TextInput2 from "./TextInput2";
 export { TextInput2 };
-export { TextInput2Requirement } from "./TextInput2";
 
 import MultiSelect from "./MultiSelect";
 export { MultiSelect };

--- a/src/utils/Forms.ts
+++ b/src/utils/Forms.ts
@@ -13,3 +13,10 @@ export const FormElementSize = {
 export function formElementSizeClassName(size: Size) {
   return `dewey--formElementSize--${size}`;
 }
+
+export const FormElementRequirement = {
+  // may be removed in the future
+  OPTIONAL: "optional",
+  REQUIRED: "required",
+  DISABLED: "disabled",
+} as const;


### PR DESCRIPTION
Probably helpful to review commit-by-commit

**Overview:**
Support a "required" and error state. Summary of changes:
* Move the `TextInput2Requirement` enum to more generalized form utils
* add requirement option and requirement label elements to Select2
* Support error states for required prop (error and initialError)
* open menu when clear button is clicked

**Screenshots/GIFs:**

https://user-images.githubusercontent.com/13126257/109743707-ff5bb880-7b85-11eb-98e0-5a4d6d0b8c44.mov

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
