### PR TITLE
ID-55 cleanup creatable option for MultiSelect

### DIFF
--- a/docs/components/MultiSelectView.jsx
+++ b/docs/components/MultiSelectView.jsx
@@ -90,7 +90,6 @@ export default class MultiSelectView extends React.PureComponent {
     );
   }
 
-  // TODO:Update or remove config options.
   _renderConfig() {
     const { label, hideLabel, placeholder, creatable, allowDuplicates, size } = this.state;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.77.0",
+  "version": "2.78.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MultiSelect/MultiSelect.tsx
+++ b/src/MultiSelect/MultiSelect.tsx
@@ -28,7 +28,7 @@ export interface Props {
   // allow the multi-select pick items an unlimited number of times
   // NOTE: might be a little wonky since the downshift library might not fully support it
   // it's also a fringe use case of this MultiSelect that we may want to remove in the future
-  allowDuplicates: boolean;
+  allowDuplicates?: boolean;
   onChange?: (options: Option[]) => void;
   size?: Values<typeof FormElementSize>;
 }

--- a/src/MultiSelect/MultiSelect.tsx
+++ b/src/MultiSelect/MultiSelect.tsx
@@ -10,7 +10,8 @@ import { Values } from "../utils/types";
 
 import "./MultiSelect.less";
 
-const ADD_NEW_ITEM_KEY = "MultiSelect--addNewItem";
+// export for testing
+export const ADD_NEW_ITEM_KEY = "MultiSelect--addNewItem";
 
 // value represents the searchable text of the option
 type Option = { value: string; content?: React.ReactNode };
@@ -50,7 +51,8 @@ export const cssClass = {
   NO_OPTIONS_FOUND: "MultiSelect--notFound",
 };
 
-function getSelectableOptions(
+// export for testing
+export function getSelectableOptions(
   options: Option[],
   selectedItems: Option[],
   inputValue: string,
@@ -59,13 +61,20 @@ function getSelectableOptions(
   const selectedValues = new Set<string>(selectedItems.map((si) => si.value));
   const inputLowerCase = inputValue.toLocaleLowerCase();
 
-  const selectableOptions = options.filter(
-    (o) =>
-      !selectedValues.has(o.value) &&
-      (inputValue === "" || o.value.toLocaleLowerCase().includes(inputLowerCase)),
-  );
+  let hasExactMatch = false;
+  const selectableOptions = options.filter((o) => {
+    const optionLowerCase = o.value.toLocaleLowerCase();
+    // small performance optimization to process exact match within the same iterator
+    if (optionLowerCase === inputLowerCase) {
+      hasExactMatch = true;
+    }
 
-  const hasExactMatch = options.some((o) => o.value.toLocaleLowerCase() === inputLowerCase);
+    return (
+      !selectedValues.has(o.value) &&
+      (inputValue === "" || optionLowerCase.includes(inputLowerCase))
+    );
+  });
+
   const creatableOption = [];
   if (creatable && !!inputValue && !hasExactMatch && selectableOptions.length === 0) {
     // add a dummy "add item X" placeholder

--- a/src/MultiSelect/MultiSelect_test.tsx
+++ b/src/MultiSelect/MultiSelect_test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { shallow } from "enzyme";
 
-import MultiSelect, { cssClass } from "./MultiSelect";
+import MultiSelect, { cssClass, getSelectableOptions, ADD_NEW_ITEM_KEY } from "./MultiSelect";
 
 describe("MultiSelect", () => {
   afterEach(() => {
@@ -44,4 +44,103 @@ describe("MultiSelect", () => {
     expect(onPerformActionMock).toHaveBeenCalledWith("action performed");
   });
   */
+
+  describe("getSelectableOptions", () => {
+    describe("not creatable", () => {
+      it("returns original options when nothing is selected", () => {
+        const options = [
+          { value: "testOption1" },
+          { value: "testOption2" },
+          { value: "testOption3" },
+          { value: "testOption4" },
+        ];
+        const results = getSelectableOptions(options, [], "", false);
+        expect(results).toEqual(options);
+      });
+
+      it("filters out selected options", () => {
+        const options = [
+          { value: "testOption1" },
+          { value: "testOption2" },
+          { value: "testOption3" },
+          { value: "testOption4" },
+        ];
+        const results = getSelectableOptions(options, options, "", false);
+        expect(results).toEqual([]);
+      });
+
+      it("filters out options based on typed input", () => {
+        const options = [
+          { value: "testOption1" },
+          { value: "testOption2" },
+          { value: "filtered1" },
+          { value: "filtered2" },
+        ];
+        const results = getSelectableOptions(options, [], "option", false);
+        expect(results).toEqual(options.slice(0, 2));
+      });
+
+      it("filters out selected options and typed input", () => {
+        const options = [
+          { value: "testOption1" },
+          { value: "testOption2" },
+          { value: "filtered1" },
+          { value: "filtered2" },
+        ];
+        const results = getSelectableOptions(options, [{ value: "testOption2" }], "option", false);
+        expect(results).toEqual([{ value: "testOption1" }]);
+      });
+    });
+
+    describe("creatable", () => {
+      it("adds ADD_ITEM option when something unique is typed", () => {
+        const options = [
+          { value: "testOption1" },
+          { value: "testOption2" },
+          { value: "testOption3" },
+          { value: "testOption4" },
+        ];
+        const results = getSelectableOptions(options, [], "uniqueText", true);
+        expect(results).toEqual([{ value: ADD_NEW_ITEM_KEY }]);
+      });
+
+      it("does not add ADD_ITEM option when exact match is typed and item is selectable", () => {
+        const options = [
+          { value: "testOption1" },
+          { value: "testOption2" },
+          { value: "testOption3" },
+          { value: "testOption4" },
+        ];
+        const results = getSelectableOptions(options, [], "testOption1", true);
+        expect(results).toEqual([{ value: "testOption1" }]);
+      });
+
+      it("does not add ADD_ITEM option when exact match is typed and item is already selected", () => {
+        const options = [
+          { value: "testOption1" },
+          { value: "testOption2" },
+          { value: "testOption3" },
+          { value: "testOption4" },
+        ];
+        const results = getSelectableOptions(
+          options,
+          [{ value: "testOption1" }],
+          "testOption1",
+          true,
+        );
+        expect(results).toEqual([]);
+      });
+
+      it("does not add ADD_ITEM option when all items filtered but no input value", () => {
+        const options = [
+          { value: "testOption1" },
+          { value: "testOption2" },
+          { value: "testOption3" },
+          { value: "testOption4" },
+        ];
+        const results = getSelectableOptions(options, options, "", true);
+        expect(results).toEqual([]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
**Overview:**
Always adding the `Add item X` option and filtering it out caused some weird behavior with downshift, so I fixed it so that we only add it to the selectable options if it needs to be shown. The code is hopefully cleaner as well.

(also made allowDuplicates prop optional which was introduced here https://github.com/Clever/components/pull/596)

**Screenshots/GIFs:**
There's a bug where using the keyboard to try to navigate down to an item generates an error in downshift because the "Add Item X" item is not visible:

https://user-images.githubusercontent.com/13126257/109747687-76944b00-7b8c-11eb-99e7-a7864163d17b.mov

It works properly now:

https://user-images.githubusercontent.com/13126257/109747937-dc80d280-7b8c-11eb-9c9c-e7c3f943a096.mov

**Testing:**

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
