### PR TITLE
Remove unused global CSS deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,4 +22,3 @@ jobs:
     - run: make build
     - run: make test
     - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN .; fi;
-    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/s3-upload dist/css/ s3://assets.clever.com/design/; fi;


### PR DESCRIPTION
**Overview:**
Last bit of cleanup after https://github.com/Clever/components/pull/599 - needed to remove the circleci step that publishes the (unused) global CSS file to CDN

**Screenshots/GIFs:**
N/A

**Testing:**
N/A

- [N/A] Unit tests
- Manual tests: N/A

**Roll Out:**
N/A

- Before merging:
  - [N/A] Updated docs
  - [N/A] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [N/A] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [N/A] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [N/A] Deployed updated docs (`make deploy-docs`)
  - [N/A] Posted in #eng if I made a breaking change to a beta component
