### PR TITLE
Add tooltip to alert icon for mesaging thread list item

### DIFF
--- a/docs/components/MessagingThreadListItemView.jsx
+++ b/docs/components/MessagingThreadListItemView.jsx
@@ -68,6 +68,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
               selected={selected}
               timestamp={hasTimestamp && new Date()}
               hasAlert={hasAlert}
+              alertTooltip="This is an alert"
             >
               This is some content!
             </MessagingThreadListItem>
@@ -160,6 +161,12 @@ export default class MessagingThreadListItemView extends React.PureComponent {
       <PropDocumentation
         title="<MessagingThreadListItem /> Props"
         availableProps={[
+          {
+            name: "alertTooltip",
+            type: "string",
+            description: "Tooltip message to display for alert indicator",
+            optional: true,
+          },
           {
             name: "children",
             type: "React.Node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.78.0",
+  "version": "2.79.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -5,6 +5,7 @@ import * as FontAwesome from "react-fontawesome";
 
 import { FlexBox, FlexItem, ItemAlign, Justify } from "../index";
 import { DraftPencilIcon } from "./DraftPencilIcon";
+import { Tooltip } from "../Tooltip";
 
 import "./MessagingThreadListItem.less";
 
@@ -40,6 +41,7 @@ type Props = {
   timestamp?: Date;
   title: string;
   hasAlert?: boolean;
+  alertTooltip?: string;
 };
 
 export const MessagingThreadListItem: React.FC<
@@ -58,6 +60,7 @@ export const MessagingThreadListItem: React.FC<
     offStatusText,
     onClick,
     hasAlert,
+    alertTooltip,
   } = props;
 
   let subContent: React.ReactNode;
@@ -72,7 +75,17 @@ export const MessagingThreadListItem: React.FC<
 
   let indicatorIcon: React.ReactNode;
   if (hasAlert) {
-    indicatorIcon = <FontAwesome name="exclamation-triangle" />;
+    indicatorIcon = alertTooltip ? (
+      <Tooltip
+        content={alertTooltip}
+        placement={Tooltip.Placement.BOTTOM}
+        textAlign={Tooltip.Align.CENTER}
+      >
+        <FontAwesome name="exclamation-triangle" />
+      </Tooltip>
+    ) : (
+      <FontAwesome name="exclamation-triangle" />
+    );
   } else if (!isRead) {
     indicatorIcon = (
       <div aria-label={`Unread messages in thread ${title}`} className={cssClasses.UNREAD_ORB} />


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/PRTL-241

**Overview:**
Adds a tooltip to the alert icon for the messaging thread list item. 

Mocks here:
![image](https://user-images.githubusercontent.com/21094551/109999446-148c3080-7cc7-11eb-9ab8-696e8cd66b93.png)

**Screenshots/GIFs:**
<img width="343" alt="Screen Shot 2021-03-04 at 6 56 51 AM" src="https://user-images.githubusercontent.com/21094551/109999398-06d6ab00-7cc7-11eb-8ed4-193453d53f53.png">


**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
