### PR TITLE
Add guardian created account alert message to thread history

### DIFF
--- a/docs/components/MessagingThreadHistoryView.jsx
+++ b/docs/components/MessagingThreadHistoryView.jsx
@@ -28,7 +28,7 @@ function randomElement(items) {
   return items[Math.floor(Math.random() * items.length)];
 }
 
-function newMessage() {
+function newMessage(displayAlertMessageAfter = false) {
   const message = randomElement(["Hello!", "Hi!", "How are you doing?"]);
   const placement = randomElement(["left", "right"]);
   newestTime.add(6, "hours");
@@ -43,6 +43,9 @@ function newMessage() {
     timestamp: new Date(newestTime),
     index: currentMessageIndex,
     readStatusText: "Read",
+    attributes: displayAlertMessageAfter && {
+      displayAlertMessageAfter: "guardian_created_account",
+    },
   };
 }
 
@@ -103,10 +106,15 @@ export default class MessagingThreadHistoryView extends React.PureComponent {
     this.setState({ messages: [...this.state.messages, newMessage()] });
   };
 
+  addMessageWithAlert = () => {
+    this.setState({ messages: [...this.state.messages, newMessage(true)] });
+  };
+
   _renderConfig() {
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
         <Button type="primary" value="Add message" onClick={this.addMessage} />
+        <Button type="primary" value="Add message with alert" onClick={this.addMessageWithAlert} />
       </FlexBox>
     );
   }

--- a/docs/components/MessagingThreadHistoryView.jsx
+++ b/docs/components/MessagingThreadHistoryView.jsx
@@ -43,8 +43,9 @@ function newMessage(displayAlertMessageAfter = false) {
     timestamp: new Date(newestTime),
     index: currentMessageIndex,
     readStatusText: "Read",
-    attributes: displayAlertMessageAfter && {
-      displayAlertMessageAfter: "guardian_created_account",
+    displayAlertMessageAfter: displayAlertMessageAfter && {
+      icon: "check",
+      messageText: "Invite accepted! This guardian can now reply to your messages!",
     },
   };
 }

--- a/docs/components/MessagingThreadHistoryView.less
+++ b/docs/components/MessagingThreadHistoryView.less
@@ -12,6 +12,7 @@
   .border--top--l(@neutral_silver);
   .margin--top--xl;
   .padding--top--l;
+  justify-content: space-evenly;
 }
 
 .MessagingThreadHistoryView--config {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.79.1",
+  "version": "2.80.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/AlertMessage.less
+++ b/src/MessagingThreadHistory/AlertMessage.less
@@ -1,0 +1,26 @@
+@import (reference) "../less/index";
+
+.AlertMessage--Container {
+  .border--m(@neutral_silver);
+  .borderRadius--l();
+  .margin--x--xs();
+  .margin--y--xs();
+  .padding--m();
+  align-items: center;
+  color: @neutral_dark_gray;
+}
+
+.AlertMessage--Message {
+  .margin--left--m();
+}
+
+@media only screen and (max-width: @breakpointM) {
+  .AlertMessage--Container {
+    .padding--x--s();
+    .padding--y--xs();
+  }
+
+  .AlertMessage--Message {
+    .text--smallMedium();
+  }
+}

--- a/src/MessagingThreadHistory/AlertMessage.tsx
+++ b/src/MessagingThreadHistory/AlertMessage.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import * as FontAwesome from "react-fontawesome";
+
+import { FlexBox, FlexItem } from "../flex";
+
+import "./AlertMessage.less";
+
+function cssClass(element: string) {
+  return `AlertMessage--${element}`;
+}
+
+interface Props {
+  icon: string;
+  messageText: string;
+}
+
+export const AlertMessage: React.FC<Props> = React.forwardRef((props: Props) => {
+  const { icon, messageText } = props;
+  return (
+    <FlexBox className={cssClass("Container")}>
+      <FontAwesome name={icon} size="lg" />
+      <FlexItem className={cssClass("Message")} grow>
+        {messageText}
+      </FlexItem>
+    </FlexBox>
+  );
+});

--- a/src/MessagingThreadHistory/MessagingThreadHistory.less
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.less
@@ -17,10 +17,32 @@
   margin-top: auto;
 }
 
+.ThreadHistory--AlertMessage--Container {
+  .border--m(@neutral_silver);
+  .borderRadius--l();
+  .margin--x--xs();
+  .margin--y--xs();
+  .padding--m();
+  align-items: center;
+  color: @neutral_dark_gray;
+}
+
+.ThreadHistory--AlertMessage {
+  .margin--left--m();
+}
+
 // For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
   .ThreadHistory--Divider {
     margin-top: 0.75rem;
     margin-bottom: 0.75rem;
+  }
+  .ThreadHistory--AlertMessage--Container {
+    .padding--x--s();
+    .padding--y--xs();
+  }
+
+  .ThreadHistory--AlertMessage {
+    font-size: 0.875rem;
   }
 }

--- a/src/MessagingThreadHistory/MessagingThreadHistory.less
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.less
@@ -17,32 +17,10 @@
   margin-top: auto;
 }
 
-.ThreadHistory--AlertMessage--Container {
-  .border--m(@neutral_silver);
-  .borderRadius--l();
-  .margin--x--xs();
-  .margin--y--xs();
-  .padding--m();
-  align-items: center;
-  color: @neutral_dark_gray;
-}
-
-.ThreadHistory--AlertMessage {
-  .margin--left--m();
-}
-
 // For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
   .ThreadHistory--Divider {
     margin-top: 0.75rem;
     margin-bottom: 0.75rem;
-  }
-  .ThreadHistory--AlertMessage--Container {
-    .padding--x--s();
-    .padding--y--xs();
-  }
-
-  .ThreadHistory--AlertMessage {
-    font-size: 0.875rem;
   }
 }

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import { useLayoutEffect, useRef } from "react";
+import * as FontAwesome from "react-fontawesome";
 import * as classNames from "classnames";
 import * as moment from "moment";
+import { FlexBox, FlexItem } from "../flex";
 import { MessageMetadata } from "./MessageMetadata";
 import { cssClass as FlexBoxCSS } from "../flex/FlexBox";
 import { cssClass as FlexItemCSS } from "../flex/FlexItem";
@@ -12,6 +14,8 @@ const cssClasses = {
   CONTAINER: "ThreadHistory--Container",
   DIVIDER: "ThreadHistory--Divider",
   FIRST_MESSAGE: "ThreadHistory--FirstMessage",
+  ALERT_MESSAGE_CONTAINER: "ThreadHistory--AlertMessage--Container",
+  ALERT_MESSAGE: "ThreadHistory--AlertMessage",
 };
 
 // Each instance is exactly one message exchanged in this thread.
@@ -21,6 +25,7 @@ export interface MessageData {
   content: React.ReactNode;
   index: number;
   readStatusText?: string;
+  attributes: any;
 }
 
 interface Props {
@@ -144,6 +149,19 @@ function _interleaveMessagesWithDividers(
         {message.content}
       </MessageMetadata>,
     );
+    if (message.attributes?.displayAlertMessageAfter === "guardian_created_account") {
+      messagesWithDividers.push(
+        <FlexBox
+          className={cssClasses.ALERT_MESSAGE_CONTAINER}
+          key={`alertMessage-${message.index}`}
+        >
+          <FontAwesome name="check" size="lg" />
+          <FlexItem className={cssClasses.ALERT_MESSAGE} grow>
+            Invite accepted! This guardian can now reply to your messages!
+          </FlexItem>
+        </FlexBox>,
+      );
+    }
   });
 
   return messagesWithDividers;

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 import { useLayoutEffect, useRef } from "react";
-import * as FontAwesome from "react-fontawesome";
 import * as classNames from "classnames";
 import * as moment from "moment";
-import { FlexBox, FlexItem } from "../flex";
+import { AlertMessage } from "./AlertMessage";
 import { MessageMetadata } from "./MessageMetadata";
 import { cssClass as FlexBoxCSS } from "../flex/FlexBox";
 import { cssClass as FlexItemCSS } from "../flex/FlexItem";
@@ -14,8 +13,6 @@ const cssClasses = {
   CONTAINER: "ThreadHistory--Container",
   DIVIDER: "ThreadHistory--Divider",
   FIRST_MESSAGE: "ThreadHistory--FirstMessage",
-  ALERT_MESSAGE_CONTAINER: "ThreadHistory--AlertMessage--Container",
-  ALERT_MESSAGE: "ThreadHistory--AlertMessage",
 };
 
 // Each instance is exactly one message exchanged in this thread.
@@ -25,7 +22,7 @@ export interface MessageData {
   content: React.ReactNode;
   index: number;
   readStatusText?: string;
-  attributes: any;
+  displayAlertMessageAfter?: { icon: string; messageText: string };
 }
 
 interface Props {
@@ -149,17 +146,14 @@ function _interleaveMessagesWithDividers(
         {message.content}
       </MessageMetadata>,
     );
-    if (message.attributes?.displayAlertMessageAfter === "guardian_created_account") {
+    if (message.displayAlertMessageAfter) {
+      const { icon, messageText } = message.displayAlertMessageAfter;
       messagesWithDividers.push(
-        <FlexBox
-          className={cssClasses.ALERT_MESSAGE_CONTAINER}
+        <AlertMessage
           key={`alertMessage-${message.index}`}
-        >
-          <FontAwesome name="check" size="lg" />
-          <FlexItem className={cssClasses.ALERT_MESSAGE} grow>
-            Invite accepted! This guardian can now reply to your messages!
-          </FlexItem>
-        </FlexBox>,
+          icon={icon}
+          messageText={messageText}
+        />,
       );
     }
   });


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/PRTL-248

**Overview:**


**Screenshots/GIFs:**
<img width="829" alt="inviteAcceptedDewey" src="https://user-images.githubusercontent.com/21094551/110378658-b20a9b80-800a-11eb-87a7-a8729ebcbf3e.png">


**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
