### PR TITLE
Remove unused prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.79.0",
+  "version": "2.79.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -137,9 +137,7 @@ export const MessagingThreadListItem: React.FC<
             </FlexBox>
           )}
         </FlexItem>
-        <FlexItem alignItems={ItemAlign.CENTER}>
-          {!isIndicatorAlignedWithSubContent && indicator}
-        </FlexItem>
+        <FlexItem>{!isIndicatorAlignedWithSubContent && indicator}</FlexItem>
       </FlexBox>
     </div>
   );


### PR DESCRIPTION
**Jira:**
n/a

**Overview:**
Removes an unused alignItems prop on non-FlexBox component. I was wondering why we were seeing this error in launchpad.
Don't check the git blame 🙈 
![image](https://user-images.githubusercontent.com/21094551/110667124-cd96b300-817e-11eb-9773-c31c63abf37c.png)

**Screenshots/GIFs:**
Manually tested, looks the same 

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
