### PR TITLE
Remove unncessary forwardRef 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/AlertMessage.tsx
+++ b/src/MessagingThreadHistory/AlertMessage.tsx
@@ -14,8 +14,7 @@ interface Props {
   messageText: string;
 }
 
-export const AlertMessage: React.FC<Props> = React.forwardRef((props: Props) => {
-  const { icon, messageText } = props;
+export const AlertMessage: React.FC<Props> = ({ icon, messageText }: Props) => {
   return (
     <FlexBox className={cssClass("Container")}>
       <FontAwesome name={icon} size="lg" />
@@ -24,4 +23,4 @@ export const AlertMessage: React.FC<Props> = React.forwardRef((props: Props) => 
       </FlexItem>
     </FlexBox>
   );
-});
+};


### PR DESCRIPTION
**Jira:**
n/a
**Overview:**
I did this without knowing what a forwardRef was 🙈 
There are error logs in launchpad about it:
![image](https://user-images.githubusercontent.com/21094551/110737049-88579d00-81e1-11eb-8919-1ee537c05eac.png)

**Screenshots/GIFs:**

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
