### PR TITLE
M5G-154: unread orb color

### DIFF
--- a/docs/components/MessagingThreadListItemView.jsx
+++ b/docs/components/MessagingThreadListItemView.jsx
@@ -28,10 +28,19 @@ export default class MessagingThreadListItemView extends React.PureComponent {
     selected: true,
     hasAlert: false,
     hasTimestamp: true,
+    unreadOrbColor: "primary_blue",
   };
 
   render() {
-    const { status, hasDraft, isRead, selected, hasAlert, hasTimestamp } = this.state;
+    const {
+      status,
+      hasDraft,
+      isRead,
+      selected,
+      hasAlert,
+      hasTimestamp,
+      unreadOrbColor,
+    } = this.state;
 
     return (
       <View
@@ -69,6 +78,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
               timestamp={hasTimestamp && new Date()}
               hasAlert={hasAlert}
               alertTooltip="This is an alert"
+              unreadOrbColor={unreadOrbColor}
             >
               This is some content!
             </MessagingThreadListItem>
@@ -78,8 +88,10 @@ export default class MessagingThreadListItemView extends React.PureComponent {
               title="Smiley Dude"
               status={status}
               hasDraft={hasDraft}
+              isRead={isRead}
               selected={selected}
               hasAlert={hasAlert}
+              unreadOrbColor={unreadOrbColor}
             />
           </ExampleCode>
           {this._renderConfig()}
@@ -91,7 +103,15 @@ export default class MessagingThreadListItemView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { status, hasDraft, isRead, selected, hasAlert, hasTimestamp } = this.state;
+    const {
+      status,
+      hasDraft,
+      isRead,
+      selected,
+      hasAlert,
+      hasTimestamp,
+      unreadOrbColor,
+    } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -125,6 +145,18 @@ export default class MessagingThreadListItemView extends React.PureComponent {
           />{" "}
           Is Read
         </label>
+        <div className={cssClass.CONFIG}>
+          Unread Orb Color:
+          <SegmentedControl
+            className={cssClass.CONFIG_OPTIONS}
+            onSelect={(value) => this.setState({ unreadOrbColor: value })}
+            options={[
+              { content: "Blue", value: "primary_blue" },
+              { content: "Teal", value: "accent_teal" },
+            ]}
+            value={unreadOrbColor}
+          />
+        </div>
         <label className={cssClass.CONFIG}>
           <input
             type="checkbox"
@@ -235,6 +267,14 @@ export default class MessagingThreadListItemView extends React.PureComponent {
             name: "title",
             type: "string",
             description: "The title of this thread",
+          },
+          {
+            name: "unreadOrbColor",
+            type: "'primary_blue' | 'accent_teal'",
+            description:
+              "The color of the unread message orb. Currently primary_blue is used for the teacher messaging UI, and accent_teal is used for students and guardians",
+            defaultValue: "primary_blue",
+            optional: true,
           },
         ]}
         className={cssClass.PROPS}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.80.1",
+  "version": "2.81.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadListItem/MessagingThreadListItem.less
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.less
@@ -75,6 +75,7 @@
   border-radius: 50%;
   background-color: @primary_blue;
 }
+
 .ThreadListItem--UnreadOrb.ThreadListItem--UnreadOrb--PrimaryBlue {
   background-color: @primary_blue;
 }

--- a/src/MessagingThreadListItem/MessagingThreadListItem.less
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.less
@@ -75,3 +75,10 @@
   border-radius: 50%;
   background-color: @primary_blue;
 }
+.ThreadListItem--UnreadOrb.ThreadListItem--UnreadOrb--PrimaryBlue {
+  background-color: @primary_blue;
+}
+
+.ThreadListItem--UnreadOrb.ThreadListItem--UnreadOrb--AccentTeal {
+  background-color: @accent_teal;
+}

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -26,9 +26,11 @@ const cssClasses = {
   UNREAD_TEXT: "ThreadListItem--UnreadText",
 };
 
-const unreadOrbColorClasses = {
-  primary_blue: "ThreadListItem--UnreadOrb--PrimaryBlue",
+type UnreadOrbColor = "accent_teal" | "primary_blue";
+
+const unreadOrbColorClasses: Record<UnreadOrbColor, String> = {
   accent_teal: "ThreadListItem--UnreadOrb--AccentTeal",
+  primary_blue: "ThreadListItem--UnreadOrb--PrimaryBlue",
 };
 
 export type Status = "active" | "off";
@@ -47,7 +49,7 @@ type Props = {
   title: string;
   hasAlert?: boolean;
   alertTooltip?: string;
-  unreadOrbColor?: "accent_teal" | "primary_blue";
+  unreadOrbColor?: UnreadOrbColor;
 };
 
 export const MessagingThreadListItem: React.FC<

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -26,6 +26,11 @@ const cssClasses = {
   UNREAD_TEXT: "ThreadListItem--UnreadText",
 };
 
+const unreadOrbColorClasses = {
+  primary_blue: "ThreadListItem--UnreadOrb--PrimaryBlue",
+  accent_teal: "ThreadListItem--UnreadOrb--AccentTeal",
+};
+
 export type Status = "active" | "off";
 
 type Props = {
@@ -42,6 +47,7 @@ type Props = {
   title: string;
   hasAlert?: boolean;
   alertTooltip?: string;
+  unreadOrbColor?: "accent_teal" | "primary_blue";
 };
 
 export const MessagingThreadListItem: React.FC<
@@ -61,6 +67,7 @@ export const MessagingThreadListItem: React.FC<
     onClick,
     hasAlert,
     alertTooltip,
+    unreadOrbColor,
   } = props;
 
   let subContent: React.ReactNode;
@@ -88,7 +95,13 @@ export const MessagingThreadListItem: React.FC<
     );
   } else if (!isRead) {
     indicatorIcon = (
-      <div aria-label={`Unread messages in thread ${title}`} className={cssClasses.UNREAD_ORB} />
+      <div
+        aria-label={`Unread messages in thread ${title}`}
+        className={classNames(
+          cssClasses.UNREAD_ORB,
+          unreadOrbColor && unreadOrbColorClasses[unreadOrbColor],
+        )}
+      />
     );
   } else if (status === "active" && hasDraft) {
     indicatorIcon = <DraftPencilIcon />;


### PR DESCRIPTION
**Jira:**

https://clever.atlassian.net/browse/M5G-154

**Overview:**

Updating `MessagingThreadListItem` to have an optional `unreadOrbColor` prop, which can be set to either "primary_blue" or "accent_teal". Teal will be used in student and guardian messaging, and teacher messaging will remain blue. Blue remains the default color

I added a SegmentedControl to the config options to select blue or teal, which is visible in the example when "is_read" is false

**Screenshots/GIFs:**

<img width="1033" alt="Screen Shot 2021-03-19 at 4 29 14 PM" src="https://user-images.githubusercontent.com/54862564/111851519-b5d2d380-88d0-11eb-9852-4662f965f06c.png">
<img width="1054" alt="Screen Shot 2021-03-19 at 4 30 43 PM" src="https://user-images.githubusercontent.com/54862564/111851522-b8352d80-88d0-11eb-81ac-895490d65acc.png">

**Testing:**

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Edge

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json` **(Minor)**

- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
