### PR TITLE
Fix send button height stretch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.83.0",
+  "version": "2.83.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -5,6 +5,7 @@
 }
 
 .MessagingInput--InnerContainer {
+  align-items: flex-end;
   width: 100%;
 }
 


### PR DESCRIPTION
**Jira:**

https://clever.atlassian.net/browse/MOC-73

**Overview:**

## Before -

![Screen Shot 2021-03-24 at 4 02 57 PM](https://user-images.githubusercontent.com/26425483/112395068-f5c3fd00-8cba-11eb-9264-65441cd4fc32.png)

## After -

![Screen Shot 2021-03-24 at 4 02 52 PM](https://user-images.githubusercontent.com/26425483/112395072-f9578400-8cba-11eb-9047-1048e0eacb7a.png)

Confirmed mobile looks the same as before.

![Screen Shot 2021-03-24 at 4 09 11 PM](https://user-images.githubusercontent.com/26425483/112395283-50f5ef80-8cbb-11eb-8e7f-d96221d8132c.png)


**Testing:**

Tested CSS change via inspector

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
