### PR TITLE
Support full width items in messaging thread history

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.83.1",
+  "version": "2.84.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "@types/classnames": "^2.2.3",
+    "@types/classnames": "~2.2.3",
     "@types/linkify-it": "^2.1.0",
     "@types/lodash": "^4.14.165",
     "@types/prop-types": "^15.5.1",
-    "classnames": "^2.2.5",
+    "classnames": "~2.2.5",
     "core-js": "^2.4.1",
     "downshift": "^6.1.0",
     "focus-trap-react": "^6.0.0",

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -29,6 +29,13 @@
   align-items: center;
 }
 
+.MessageMetadata--Message--fullWidth {
+  .flexbox();
+  width: 100%;
+  flex-direction: row;
+  align-items: center;
+}
+
 .MessageMetadata--Timestamp--right {
   color: @neutral_medium_gray;
   font-size: 0.875rem;

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -10,7 +10,7 @@ function cssClass(element: string) {
 
 interface Props {
   className?: string;
-  placement: "left" | "right" | "center";
+  placement: "left" | "right" | "center" | "fullWidth";
   timestamp?: Date;
   readStatusText?: string;
   children: React.ReactNode;
@@ -20,11 +20,12 @@ export const MessageMetadata: React.FC<
   Props & { ref?: React.Ref<HTMLDivElement> }
 > = React.forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) => {
   const { className, placement, timestamp, readStatusText, children } = props;
+  const showTimestamp = timestamp && placement !== "fullWidth";
   return (
     <div ref={ref} className={classNames(cssClass("Message--container"), className)}>
       <div className={cssClass(`Message--${placement}`)}>
         {children}
-        {timestamp && (
+        {showTimestamp && (
           <span className={cssClass(`Timestamp--${placement}`)}>
             {_formatDateForTimestamp(timestamp)}
           </span>

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -17,7 +17,7 @@ const cssClasses = {
 
 // Each instance is exactly one message exchanged in this thread.
 export interface MessageData {
-  placement: "left" | "right" | "center";
+  placement: "left" | "right" | "center" | "fullWidth";
   timestamp?: Date;
   content: React.ReactNode;
   index: number;


### PR DESCRIPTION
**Jira:**

https://clever.atlassian.net/browse/M5G-144

**Overview:**

This PR adds a "fullWidth" option to MessagingMetadata to support the "fullWidth" announcement bubble.

**Screenshots/GIFs:**

<img width="1312" alt="Screen Shot 2021-04-05 at 9 20 04 AM" src="https://user-images.githubusercontent.com/26425483/113597324-64c12000-95f0-11eb-9d29-40a948ff5da4.png">


**Testing:**

Will test more thoroughly when AnnouncementBubble is ready. This is an isolated change so it won't affect anything currently being used.

- [ ] Unit tests
- Manual tests:
  - [X] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs NA
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
