### PR TITLE
M5G-150: Add "New" label to MessagingThreadLIstItem

### DIFF
--- a/docs/components/MessagingThreadListItemView.jsx
+++ b/docs/components/MessagingThreadListItemView.jsx
@@ -27,6 +27,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
     isRead: true,
     selected: true,
     hasAlert: false,
+    showNewLabel: false,
     hasTimestamp: true,
     unreadOrbColor: "primary_blue",
   };
@@ -38,6 +39,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
       isRead,
       selected,
       hasAlert,
+      showNewLabel,
       hasTimestamp,
       unreadOrbColor,
     } = this.state;
@@ -77,6 +79,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
               selected={selected}
               timestamp={hasTimestamp && new Date()}
               hasAlert={hasAlert}
+              showNewLabel={showNewLabel}
               alertTooltip="This is an alert"
               unreadOrbColor={unreadOrbColor}
             >
@@ -91,6 +94,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
               isRead={isRead}
               selected={selected}
               hasAlert={hasAlert}
+              showNewLabel={showNewLabel}
               unreadOrbColor={unreadOrbColor}
             />
           </ExampleCode>
@@ -109,6 +113,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
       isRead,
       selected,
       hasAlert,
+      showNewLabel,
       hasTimestamp,
       unreadOrbColor,
     } = this.state;
@@ -178,6 +183,15 @@ export default class MessagingThreadListItemView extends React.PureComponent {
         <label className={cssClass.CONFIG}>
           <input
             type="checkbox"
+            checked={showNewLabel}
+            className={cssClass.CONFIG_TOGGLE}
+            onChange={(e) => this.setState({ showNewLabel: e.target.checked })}
+          />{" "}
+          Show "New" Label
+        </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
             checked={hasTimestamp}
             className={cssClass.CONFIG_TOGGLE}
             onChange={(e) => this.setState({ hasTimestamp: e.target.checked })}
@@ -216,6 +230,13 @@ export default class MessagingThreadListItemView extends React.PureComponent {
             type: "boolean",
             description:
               "Whether this thread has an alert message. This indicator will take precedence over the unread indicator",
+            optional: true,
+          },
+          {
+            name: "showNewLabel",
+            type: "boolean",
+            description:
+              'Whether this thread has a "New" Label. This indicator will take precedence over the hasAlert indicator',
             optional: true,
           },
           {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.84.1",
+  "version": "2.85.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadListItem/MessagingThreadListItem.less
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.less
@@ -69,6 +69,12 @@
   width: @size_s;
 }
 
+.ThreadListItem--NewLabel--Container {
+  .flexShrink(0);
+  margin-left: auto;
+  // todo: Handle width with preview text cutoff, etc;
+}
+
 .ThreadListItem--UnreadOrb {
   height: @size_xs;
   width: @size_xs;

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -6,6 +6,7 @@ import * as FontAwesome from "react-fontawesome";
 import { FlexBox, FlexItem, ItemAlign, Justify } from "../index";
 import { DraftPencilIcon } from "./DraftPencilIcon";
 import { Tooltip } from "../Tooltip";
+import { Label } from "src/Label";
 
 import "./MessagingThreadListItem.less";
 
@@ -21,6 +22,7 @@ const cssClasses = {
   TIMESTAMP: "ThreadListItem--Timestamp",
   TIMESTAMP_SELECTED: "ThreadListItem--Timestamp--selected",
   INDICATOR_CONTAINER: "ThreadListItem--Indicator--Container",
+  NEW_LABEL_CONTAINER: "ThreadListItem--NewLabel--Container",
   DRAFT_INDICATOR: "ThreadListItem--DraftIndicator",
   UNREAD_ORB: "ThreadListItem--UnreadOrb",
   UNREAD_TEXT: "ThreadListItem--UnreadText",
@@ -50,6 +52,7 @@ type Props = {
   hasAlert?: boolean;
   alertTooltip?: string;
   unreadOrbColor?: UnreadOrbColor;
+  showNewLabel?: boolean;
 };
 
 export const MessagingThreadListItem: React.FC<
@@ -70,6 +73,7 @@ export const MessagingThreadListItem: React.FC<
     hasAlert,
     alertTooltip,
     unreadOrbColor,
+    showNewLabel,
   } = props;
 
   let subContent: React.ReactNode;
@@ -83,36 +87,45 @@ export const MessagingThreadListItem: React.FC<
   }
 
   let indicatorIcon: React.ReactNode;
-  if (hasAlert) {
-    indicatorIcon = alertTooltip ? (
-      <Tooltip
-        content={alertTooltip}
-        placement={Tooltip.Placement.BOTTOM}
-        textAlign={Tooltip.Align.CENTER}
-      >
+  let indicator: React.ReactNode;
+  if (showNewLabel) {
+    indicator = (
+      <FlexBox className={cssClasses.NEW_LABEL_CONTAINER} justify={Justify.END}>
+        {showNewLabel && <Label color={"success"}>New</Label>}
+      </FlexBox>
+    );
+  } else {
+    if (hasAlert) {
+      indicatorIcon = alertTooltip ? (
+        <Tooltip
+          content={alertTooltip}
+          placement={Tooltip.Placement.BOTTOM}
+          textAlign={Tooltip.Align.CENTER}
+        >
+          <FontAwesome name="exclamation-triangle" />
+        </Tooltip>
+      ) : (
         <FontAwesome name="exclamation-triangle" />
-      </Tooltip>
-    ) : (
-      <FontAwesome name="exclamation-triangle" />
+      );
+    } else if (!isRead) {
+      indicatorIcon = (
+        <div
+          aria-label={`Unread messages in thread ${title}`}
+          className={classNames(
+            cssClasses.UNREAD_ORB,
+            unreadOrbColor && unreadOrbColorClasses[unreadOrbColor],
+          )}
+        />
+      );
+    } else if (status === "active" && hasDraft) {
+      indicatorIcon = <DraftPencilIcon />;
+    }
+    indicator = (
+      <FlexBox className={cssClasses.INDICATOR_CONTAINER} justify={Justify.END}>
+        {indicatorIcon}
+      </FlexBox>
     );
-  } else if (!isRead) {
-    indicatorIcon = (
-      <div
-        aria-label={`Unread messages in thread ${title}`}
-        className={classNames(
-          cssClasses.UNREAD_ORB,
-          unreadOrbColor && unreadOrbColorClasses[unreadOrbColor],
-        )}
-      />
-    );
-  } else if (status === "active" && hasDraft) {
-    indicatorIcon = <DraftPencilIcon />;
   }
-  const indicator = (
-    <FlexBox className={cssClasses.INDICATOR_CONTAINER} justify={Justify.END}>
-      {indicatorIcon}
-    </FlexBox>
-  );
 
   const isIndicatorAlignedWithSubContent = subContent && timestamp;
 

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -6,7 +6,7 @@ import * as FontAwesome from "react-fontawesome";
 import { FlexBox, FlexItem, ItemAlign, Justify } from "../index";
 import { DraftPencilIcon } from "./DraftPencilIcon";
 import { Tooltip } from "../Tooltip";
-import { Label } from "src/Label";
+import Label from "../Label/Label";
 
 import "./MessagingThreadListItem.less";
 

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -127,7 +127,9 @@ export const MessagingThreadListItem: React.FC<
     );
   }
 
-  const isIndicatorAlignedWithSubContent = subContent && timestamp;
+  // "New" Label overrides timestamp
+  const showTimestamp = timestamp && !showNewLabel;
+  const isIndicatorAlignedWithSubContent = subContent && showTimestamp;
 
   return (
     <div ref={ref}>
@@ -154,7 +156,7 @@ export const MessagingThreadListItem: React.FC<
                   selected && cssClasses.TIMESTAMP_SELECTED,
                 )}
               >
-                {timestamp && _formatDateForTimestamp(timestamp)}
+                {showTimestamp && _formatDateForTimestamp(timestamp)}
               </div>
             )}
           </FlexBox>


### PR DESCRIPTION
**Jira:** https://clever.atlassian.net/browse/M5G-150

**Overview:**

Adding `showNewLabel` prop to `<MessagingThreadListItem>`. When this is true, it overrides all other notifications showing, including alert, unread, timestamp, etc. As of now, the New label should only be shown on the placeholder announcement thread for a teacher, so none of the other notifications should ever be showing at the same time.

**Screenshots/GIFs:**

<img width="1037" alt="Screen Shot 2021-04-06 at 2 18 50 PM" src="https://user-images.githubusercontent.com/54862564/113780137-9ebf1e80-96e3-11eb-8b78-ba93011dc537.png">


**Testing:**

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Edge

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - New component or backward-compatible component feature change? Run `npm version minor`
  
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
