### PR TITLE
TextTruncate can handle null and undefined text inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.86.0",
+  "version": "2.86.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextTruncate/TextTruncate.tsx
+++ b/src/TextTruncate/TextTruncate.tsx
@@ -72,6 +72,13 @@ export default class TextTruncate extends React.PureComponent<Props> {
     } = this.props;
     const { truncated } = this.state;
 
+    // If text is null or undefined, return immediately
+    if (!text) {
+      return (
+        <></>
+      )
+    }
+
     if (text.length < maxCharsShown) {
       return (
         <div className={classnames(cssClass.CONTAINER, className)}>

--- a/src/TextTruncate/TextTruncate.tsx
+++ b/src/TextTruncate/TextTruncate.tsx
@@ -74,9 +74,7 @@ export default class TextTruncate extends React.PureComponent<Props> {
 
     // If text is null or undefined, return immediately
     if (!text) {
-      return (
-        <></>
-      )
+      return null;
     }
 
     if (text.length < maxCharsShown) {


### PR DESCRIPTION
**Jira:**

[PRTL-371](https://clever.atlassian.net/browse/PRTL-371)

**Overview:**
Flare 1070 was caused by a null/undefined being passed into TextTruncate. While it would make sense to avoid that happening in the first place, this change will prevent it at the component level too!

**Screenshots/GIFs:**
This is when null is passed in: 
<img width="1192" alt="Screen Shot 2021-04-07 at 4 45 33 PM" src="https://user-images.githubusercontent.com/12452249/113947972-ad2f3800-97c0-11eb-8012-61cfdfcb44f0.png">

Compared to normal: 
<img width="1183" alt="Screen Shot 2021-04-07 at 4 45 55 PM" src="https://user-images.githubusercontent.com/12452249/113947995-ba4c2700-97c0-11eb-9460-f167fdd965c2.png">


**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
