### PR TITLE
Fancy time

### DIFF
--- a/docs/components/MessagingThreadListItemView.jsx
+++ b/docs/components/MessagingThreadListItemView.jsx
@@ -25,6 +25,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
     status: "active",
     hasDraft: false,
     isRead: true,
+    italicizeSubtitle: false,
     selected: true,
     hasAlert: false,
     showNewLabel: false,
@@ -37,6 +38,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
       status,
       hasDraft,
       isRead,
+      italicizeSubtitle,
       selected,
       hasAlert,
       showNewLabel,
@@ -76,6 +78,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
               status={status}
               hasDraft={hasDraft}
               isRead={isRead}
+              italicizeSubtitle={italicizeSubtitle}
               selected={selected}
               timestamp={hasTimestamp && new Date()}
               hasAlert={hasAlert}
@@ -111,6 +114,7 @@ export default class MessagingThreadListItemView extends React.PureComponent {
       status,
       hasDraft,
       isRead,
+      italicizeSubtitle,
       selected,
       hasAlert,
       showNewLabel,
@@ -149,6 +153,15 @@ export default class MessagingThreadListItemView extends React.PureComponent {
             onChange={(e) => this.setState({ isRead: e.target.checked })}
           />{" "}
           Is Read
+        </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            checked={italicizeSubtitle}
+            className={cssClass.CONFIG_TOGGLE}
+            onChange={(e) => this.setState({ italicizeSubtitle: e.target.checked })}
+          />{" "}
+          Italicize Subtitle
         </label>
         <div className={cssClass.CONFIG}>
           Unread Orb Color:
@@ -253,6 +266,12 @@ export default class MessagingThreadListItemView extends React.PureComponent {
             name: "isRead",
             type: "boolean",
             description: "Whether this thread has been read.",
+            optional: true,
+          },
+          {
+            name: "italicizeSubtitle",
+            type: "boolean",
+            description: "Whether the subtitle/preview (passed via children) should be italicized.",
             optional: true,
           },
           {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.86.1",
+  "version": "2.87.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadListItem/MessagingThreadListItem.less
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.less
@@ -56,7 +56,7 @@
 }
 
 .ThreadListItem--UnreadText {
-  .text--semi-bold();
+  font-weight: 600;
 }
 
 .ThreadListItem--Indicator--Container {

--- a/src/MessagingThreadListItem/MessagingThreadListItem.less
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.less
@@ -31,18 +31,16 @@
 }
 
 .ThreadListItem--Preview {
-  font-size: 0.875rem;
+  line-height: 1rem;
   .margin--right--m();
-  .text--line-height-1();
+  .text--smallMedium();
   .text--truncate();
 }
 
-.ThreadListItem--OffText {
-  // Padding prevents italics from being slightly
-  //  cut off by overflow=hidden
+.ThreadListItem--Preview--italics {
+  // Padding prevents italics from being slightly cut off by text truncation
   .padding--right--2xs();
   .text--italic();
-  .text--truncate();
 }
 
 .ThreadListItem--Timestamp {

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -18,7 +18,7 @@ const cssClasses = {
   DETAILS_CONTAINER: "ThreadListItem--Details--Container",
   NAME: "ThreadListItem--Name",
   PREVIEW: "ThreadListItem--Preview",
-  OFF_TEXT: "ThreadListItem--OffText",
+  PREVIEW_ITALICS: "ThreadListItem--Preview--italics",
   TIMESTAMP: "ThreadListItem--Timestamp",
   TIMESTAMP_SELECTED: "ThreadListItem--Timestamp--selected",
   INDICATOR_CONTAINER: "ThreadListItem--Indicator--Container",
@@ -43,6 +43,7 @@ type Props = {
   hasDraft: boolean;
   icon: React.ReactNode;
   isRead?: boolean;
+  italicizeSubtitle?: boolean;
   offStatusText?: string;
   onClick?: (event: React.MouseEvent) => void;
   selected: boolean;
@@ -63,6 +64,7 @@ export const MessagingThreadListItem: React.FC<
     className,
     icon,
     isRead = true,
+    italicizeSubtitle,
     timestamp,
     title,
     hasDraft,
@@ -80,10 +82,14 @@ export const MessagingThreadListItem: React.FC<
   let subContentClass: string;
   if (status === "active" || !isRead) {
     subContent = _filterChildren(children);
-    subContentClass = classNames(cssClasses.PREVIEW, !isRead && cssClasses.UNREAD_TEXT);
+    subContentClass = classNames(
+      cssClasses.PREVIEW,
+      !isRead && cssClasses.UNREAD_TEXT,
+      italicizeSubtitle && cssClasses.PREVIEW_ITALICS,
+    );
   } else {
     subContent = offStatusText || "Messages are turned off";
-    subContentClass = cssClasses.OFF_TEXT;
+    subContentClass = classNames(cssClasses.PREVIEW, cssClasses.PREVIEW_ITALICS);
   }
 
   let indicatorIcon: React.ReactNode;


### PR DESCRIPTION
**Jira:**

For failed message sends and deleted messages, we need to show an italicized subtitle. This PR adds a prop to italicize the subtitle.

![Screen Shot 2021-04-07 at 6 16 14 PM](https://user-images.githubusercontent.com/26425483/113953863-96431280-97cd-11eb-8b10-9f3abfcf6331.png)
![Screen Shot 2021-04-07 at 6 17 52 PM](https://user-images.githubusercontent.com/26425483/113953865-98a56c80-97cd-11eb-9dd1-1606086bfea6.png)


Tested via Dewey local 

![Screen Shot 2021-04-07 at 6 15 28 PM](https://user-images.githubusercontent.com/26425483/113953889-a6f38880-97cd-11eb-99b7-739834da84fd.png)


**Overview:**

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
