### PR TITLE
Messaging bubble catches up to Announcement bubble

### DIFF
--- a/docs/components/MessagingBubbleView.jsx
+++ b/docs/components/MessagingBubbleView.jsx
@@ -23,11 +23,12 @@ export default class MessagingBubbleView extends React.PureComponent {
   static cssClass = cssClass;
 
   state = {
+    hasError: false,
     theme: "ownMessage",
   };
 
   render() {
-    const { theme } = this.state;
+    const { hasError, theme } = this.state;
 
     return (
       <View
@@ -56,13 +57,25 @@ export default class MessagingBubbleView extends React.PureComponent {
 
         <Example title="Basic Usage:">
           <ExampleCode>
-            <MessagingBubble className={cssClass.BUBBLE} theme={theme}>
+            <MessagingBubble
+              errorMsg={hasError && "Message failed to send"}
+              className={cssClass.BUBBLE}
+              theme={theme}
+            >
               Hello World!
             </MessagingBubble>
-            <MessagingBubble className={cssClass.BUBBLE} theme={theme}>
+            <MessagingBubble
+              errorMsg={hasError && "Message failed to send"}
+              className={cssClass.BUBBLE}
+              theme={theme}
+            >
               Links like https://clever.com are clickable
             </MessagingBubble>
-            <MessagingBubble theme={theme} replyTo={"This is a message!"}>
+            <MessagingBubble
+              errorMsg={hasError && "Message failed to send"}
+              theme={theme}
+              replyTo={"This is a message!"}
+            >
               This is a reply to that message!
             </MessagingBubble>
           </ExampleCode>
@@ -75,7 +88,7 @@ export default class MessagingBubbleView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { theme } = this.state;
+    const { hasError, theme } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -90,6 +103,15 @@ export default class MessagingBubbleView extends React.PureComponent {
             ]}
             value={theme}
           />
+          <label className={cssClass.CONFIG_OPTIONS}>
+            <input
+              type="checkbox"
+              checked={hasError}
+              onChange={({ target }) => this.setState({ hasError: target.checked })}
+            />
+            {"   "}
+            Show error message
+          </label>
         </div>
       </FlexBox>
     );
@@ -120,7 +142,13 @@ export default class MessagingBubbleView extends React.PureComponent {
           {
             name: "replyTo",
             type: "React.ReactNode",
-            description: "Optional prop to use for message reply content",
+            description: "Optional prop to use for message reply content.",
+            optional: true,
+          },
+          {
+            name: "errorMsg",
+            type: "React.ReactNode",
+            description: "Optional prop to show an error message under a bubble.",
             optional: true,
           },
         ]}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.87.1",
+  "version": "2.88.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -7,6 +7,7 @@
   max-width: 36.5rem;
   .text--line-height-4();
   overflow-wrap: break-word;
+  position: relative;
   white-space: pre-wrap;
   word-wrap: break-word; // IE name for overflow-wrap
 }
@@ -50,6 +51,25 @@
   color: inherit;
   .text--semi-bold();
   .text--underline();
+}
+
+.MessagingBubble--Error {
+  color: @alert_red;
+  line-height: 1rem;
+  .margin--right--2xs();
+  .margin--top--2xs();
+  .text--smallMedium();
+  position: absolute;
+  top: 100%;
+  right: 0%;
+}
+
+.MessagingBubble--Error--Icon {
+  .margin--right--2xs();
+}
+
+.MessagingBubble--Error--Parent {
+  padding-bottom: 1.25rem; // line height of message + 4px for margin between message and bubble
 }
 
 // For mobile/tablet

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -1,22 +1,29 @@
 import * as React from "react";
-import * as classNames from "classnames";
+import * as FontAwesome from "react-fontawesome";
 import Linkify from "react-linkify";
+import * as cx from "classnames";
 import { matchDecorator, componentDecorator } from "./linkifyUtils";
+import { FlexBox } from "..";
 
 import "./MessagingBubble.less";
 
 const cssClasses = {
+  CONTAINER: "MessagingBubble--Container",
   MESSAGE_BASE: "MessagingBubble--Message",
   MESSAGE_OWN: "MessagingBubble--Message--Own",
   MESSAGE_OTHER: "MessagingBubble--Message--Other",
   MESSAGE_REPLY_OWN: "MessagingBubble--Message--Reply--Own",
   MESSAGE_REPLY_OTHER: "MessagingBubble--Message--Reply--Other",
   MESSAGE_REPLY_PARENT: "MessagingBubble--Message--Reply--Parent",
+  ERROR: "MessagingBubble--Error",
+  ERROR_ICON: "MessagingBubble--Error--Icon",
+  ERROR_PARENT: "MessagingBubble--Error--Parent",
 };
 
 interface Props {
   className?: string;
   children: React.ReactNode;
+  errorMsg?: React.ReactNode;
   replyTo?: React.ReactNode;
   theme: "ownMessage" | "otherMessage";
 }
@@ -24,33 +31,48 @@ interface Props {
 export const MessagingBubble: React.FC<Props> = ({
   className,
   children,
+  errorMsg,
   theme,
   replyTo,
 }: Props) => {
   return (
-    <div
-      className={classNames(
-        cssClasses.MESSAGE_BASE,
-        theme === "ownMessage" ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
-        className,
-        replyTo && cssClasses.MESSAGE_REPLY_PARENT,
-      )}
-    >
-      {replyTo && (
-        <div
-          className={classNames(
-            cssClasses.MESSAGE_BASE,
-            theme === "ownMessage" ? cssClasses.MESSAGE_REPLY_OWN : cssClasses.MESSAGE_REPLY_OTHER,
-          )}
-        >
-          <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
-            {replyTo}
-          </Linkify>
-        </div>
-      )}
-      <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
-        {children}
-      </Linkify>
+    <div className={errorMsg && cssClasses.ERROR_PARENT}>
+      <div
+        className={cx(
+          cssClasses.MESSAGE_BASE,
+          theme === "ownMessage" ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
+          className,
+          replyTo && cssClasses.MESSAGE_REPLY_PARENT,
+        )}
+      >
+        {replyTo && (
+          <div
+            className={cx(
+              cssClasses.MESSAGE_BASE,
+              theme === "ownMessage"
+                ? cssClasses.MESSAGE_REPLY_OWN
+                : cssClasses.MESSAGE_REPLY_OTHER,
+            )}
+          >
+            <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
+              {replyTo}
+            </Linkify>
+          </div>
+        )}
+        <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
+          {children}
+        </Linkify>
+        {errorMsg && formErrorContainer(errorMsg)}
+      </div>
     </div>
   );
 };
+
+function formErrorContainer(errorMsg: React.ReactNode): JSX.Element {
+  return (
+    <FlexBox className={cssClasses.ERROR} grow alignItems="center" justify="start">
+      <FontAwesome className={cssClasses.ERROR_ICON} name="exclamation-circle " />
+      {errorMsg}
+    </FlexBox>
+  );
+}


### PR DESCRIPTION

**Jira:**
https://clever.atlassian.net/browse/M5G-217

**Overview:**
This PR adds an optional prop for an error message for a bubble. It's a little funky but i didn't want to break our current implementation and this seemed safe. 

It uses absolute positioning and adds extra padding to the bubble = to height of the message plus the margin between the message and the bubble to ensure that the space from one bubble to the next stays the same whether there is an error message or not
.

**Screenshots/GIFs:**

Figma mocks -
![Screen Shot 2021-04-09 at 3 33 40 PM](https://user-images.githubusercontent.com/26425483/114247015-f90ce900-9948-11eb-926b-9ceb082b155d.png)

With errors:

![Screen Shot 2021-04-09 at 3 32 49 PM](https://user-images.githubusercontent.com/26425483/114247231-759fc780-9949-11eb-9202-8e3f4c451b27.png)

Without errors:
![Screen Shot 2021-04-09 at 3 32 52 PM](https://user-images.githubusercontent.com/26425483/114247234-77698b00-9949-11eb-8367-a49a54f2162a.png)


**Testing:**

Will test more after pulling into launchpad

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
