### PR TITLE
BB announcement bubble polish

### DIFF
--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -78,6 +78,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
                   color={{ color: Colors.PRIMARY_BLUE_TINT_2 }}
                 />
               }
+              onReply={() => console.log("Reply!")}
               sentAtTimestamp={new Date()}
               theme={"normal"}
             >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.90.0",
+  "version": "2.90.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -9,6 +9,7 @@
 
 .NormalAnnouncementBubble--containerWithReply {
   border-radius: 2rem;
+  .margin--bottom--m();
   .padding--bottom--xl();
 }
 
@@ -73,7 +74,7 @@ button.NormalAnnouncementBubble--menuIconContainer {
   .text--line-height-4();
   white-space: pre-wrap;
   word-wrap: break-word; // IE version
-  word-wrap: break-all; // Safari version
+  word-break: break-all; // Safari version
   overflow-wrap: anywhere;
 
   .LinkifyUtils--Link,
@@ -88,6 +89,7 @@ button.NormalAnnouncementBubble--replyButton {
   background-color: #ffdf7f;
   border: 0;
   border-radius: 1.5rem;
+  .boxShadow--medium();
   height: 2rem;
   padding: 0;
   width: 6.625rem;
@@ -104,6 +106,7 @@ button.NormalAnnouncementBubble--replyButton {
   &:active {
     /* stylelint-disable-next-line declaration-property-value-whitelist */
     background-color: #fed559;
+    .boxShadow--heavy();
   }
 }
 

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -101,6 +101,11 @@ button.NormalAnnouncementBubble--replyButton {
   position: absolute;
   top: 100%;
 
+  img {
+    height: 0.8125rem; // 13px
+    width: 0.9375rem; // 15px
+  }
+
   &:hover,
   &:focus,
   &:active {

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -55,7 +55,7 @@
   // Handle whitespace characters
   white-space: pre-wrap;
   word-wrap: break-word; // IE version
-  word-wrap: break-all; // Safari version
+  word-break: break-all; // Safari version
   overflow-wrap: anywhere;
 }
 

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -63,4 +63,9 @@
   .MessageMetadata--Message--container {
     .margin--y--2xs();
   }
+
+  .MessageMetadata--Message--fullWidth {
+    // Extra margin between bubbles for fullWidth messages
+    margin: 0.25rem 0;
+  }
 }


### PR DESCRIPTION
https://clever.atlassian.net/browse/M5G-234

**Overview:**

1. Fix word break on safari: change word-wrap: break-all to word-break: break-all
2. ^ Also for QuotedAnnouncementBubble
3. Add box-shadow medium to Reply button; box-shadow heavy on hover
4. Add margin below Reply bubbles to compensate for Reply button
5. Add extra space between fullWidth bubbles on mobile

**Screenshots/GIFs:**

My cloudapp isn't working so i can't record screenshots :( 

Old w/o the extra margin for the Reply button - 
![Screen Shot 2021-04-13 at 10 18 39 AM](https://user-images.githubusercontent.com/26425483/114596290-50120700-9c44-11eb-810a-1da15b9c5415.png)

w/ margin
![Screen Shot 2021-04-13 at 10 18 46 AM](https://user-images.githubusercontent.com/26425483/114596367-6a4be500-9c44-11eb-8664-b38edd48ec5e.png)

Old w/o the extra margin on mobile
![Screen Shot 2021-04-13 at 12 20 57 PM](https://user-images.githubusercontent.com/26425483/114608697-cd447880-9c52-11eb-9e0f-198d8990ba43.png)

w/ margin
![Screen Shot 2021-04-13 at 12 20 52 PM](https://user-images.githubusercontent.com/26425483/114608690-cae21e80-9c52-11eb-8f2a-54355d96ca2a.png)

Reply button w/ drop shadow
![Screen Shot 2021-04-13 at 12 21 56 PM](https://user-images.githubusercontent.com/26425483/114608737-d9303a80-9c52-11eb-978b-45e8ce3179c2.png)


**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
