### PR TITLE
Failure is a part of messaging

### DIFF
--- a/docs/components/MessagingBubbleView.jsx
+++ b/docs/components/MessagingBubbleView.jsx
@@ -23,12 +23,11 @@ export default class MessagingBubbleView extends React.PureComponent {
   static cssClass = cssClass;
 
   state = {
-    hasError: false,
     theme: "ownMessage",
   };
 
   render() {
-    const { hasError, theme } = this.state;
+    const { theme } = this.state;
 
     return (
       <View
@@ -57,25 +56,13 @@ export default class MessagingBubbleView extends React.PureComponent {
 
         <Example title="Basic Usage:">
           <ExampleCode>
-            <MessagingBubble
-              errorMsg={hasError ? "Message failed to send" : ""}
-              className={cssClass.BUBBLE}
-              theme={theme}
-            >
+            <MessagingBubble className={cssClass.BUBBLE} theme={theme}>
               Hello World!
             </MessagingBubble>
-            <MessagingBubble
-              errorMsg={hasError ? "Message failed to send" : ""}
-              className={cssClass.BUBBLE}
-              theme={theme}
-            >
+            <MessagingBubble className={cssClass.BUBBLE} theme={theme}>
               Links like https://clever.com are clickable
             </MessagingBubble>
-            <MessagingBubble
-              errorMsg={hasError ? "Message failed to send" : ""}
-              theme={theme}
-              replyTo={"This is a message!"}
-            >
+            <MessagingBubble theme={theme} replyTo={"This is a message!"}>
               This is a reply to that message!
             </MessagingBubble>
           </ExampleCode>
@@ -88,7 +75,7 @@ export default class MessagingBubbleView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { hasError, theme } = this.state;
+    const { theme } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -103,15 +90,6 @@ export default class MessagingBubbleView extends React.PureComponent {
             ]}
             value={theme}
           />
-          <label className={cssClass.CONFIG_OPTIONS}>
-            <input
-              type="checkbox"
-              checked={hasError}
-              onChange={({ target }) => this.setState({ hasError: target.checked })}
-            />
-            {"   "}
-            Show error message
-          </label>
         </div>
       </FlexBox>
     );
@@ -143,12 +121,6 @@ export default class MessagingBubbleView extends React.PureComponent {
             name: "replyTo",
             type: "React.ReactNode",
             description: "Optional prop to use for message reply content.",
-            optional: true,
-          },
-          {
-            name: "errorMsg",
-            type: "React.ReactNode",
-            description: "Optional prop to show an error message under a bubble.",
             optional: true,
           },
         ]}

--- a/docs/components/MessagingThreadHistoryView.jsx
+++ b/docs/components/MessagingThreadHistoryView.jsx
@@ -31,6 +31,7 @@ function randomElement(items) {
 function newMessage(displayAlertMessageAfter = false) {
   const message = randomElement(["Hello!", "Hi!", "How are you doing?"]);
   const placement = randomElement(["left", "right"]);
+  const errorMsg = message === "Hi!" && placement === "right" ? "Message failed to send" : "";
   newestTime.add(6, "hours");
   currentMessageIndex++;
   return {
@@ -42,7 +43,8 @@ function newMessage(displayAlertMessageAfter = false) {
     placement,
     timestamp: new Date(newestTime),
     index: currentMessageIndex,
-    readStatusText: "Read",
+    readStatusText: errorMsg ? "" : "Read",
+    errorMsg,
     displayAlertMessageAfter: displayAlertMessageAfter && {
       icon: "check",
       messageText: "Invite accepted! This guardian can now reply to your messages!",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.90.1",
+  "version": "2.91.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/AnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/AnnouncementBubble.tsx
@@ -45,7 +45,6 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
         <NormalAnnouncementBubble
           theme="normal"
           className={props.className}
-          errorMsg={props.errorMsg}
           onDelete={props.onDelete}
           onReply={props.onReply}
           repliesDisabledMsg={props.repliesDisabledMsg}

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -142,19 +142,6 @@ button.NormalAnnouncementBubble--replyButton {
   color: @neutral_dark_gray;
 }
 
-.NormalAnnouncementBubble--errorMsg {
-  color: @alert_red;
-  line-height: 1rem;
-  margin-left: auto;
-  .margin--right--2xs();
-  .margin--top--xs();
-  .text--smallMedium();
-}
-
-.NormalAnnouncementBubble--errorIcon {
-  .margin--right--2xs();
-}
-
 @media only screen and (max-width: @breakpointM) {
   .NormalAnnouncementBubble--container {
     .padding--s();

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as FontAwesome from "react-fontawesome";
 import * as moment from "moment";
 import * as cx from "classnames";
 import Linkify from "react-linkify";
@@ -16,7 +15,6 @@ export interface Props {
   theme: "normal";
   children: React.ReactNode;
   className?: string;
-  errorMsg?: React.ReactNode;
   onDelete?: () => void;
   onReply?: () => void;
   repliesDisabledMsg?: string;
@@ -28,7 +26,6 @@ export interface Props {
 export const NormalAnnouncementBubble: React.FC<Props> = ({
   children,
   className,
-  errorMsg,
   onDelete,
   onReply,
   repliesDisabledMsg,
@@ -40,26 +37,23 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
   const replyButton = formReplyButton(onReply, repliesDisabledMsg);
 
   return (
-    <FlexBox grow column>
-      <FlexBox
-        grow
-        column
-        className={cx(cssClass("container"), onReply && cssClass("containerWithReply"), className)}
-      >
-        <FlexBox>
-          <div className={cssClass("senderIcon")}>{senderIcon}</div>
-          <FlexBox column alignItems="start" justify="center">
-            <div className={cssClass("senderName")}>{senderName}</div>
-            <div className={cssClass("timestamp")}>{formatDateForTimestamp(sentAtTimestamp)}</div>
-          </FlexBox>
-          {deleteMenu}
+    <FlexBox
+      grow
+      column
+      className={cx(cssClass("container"), onReply && cssClass("containerWithReply"), className)}
+    >
+      <FlexBox>
+        <div className={cssClass("senderIcon")}>{senderIcon}</div>
+        <FlexBox column alignItems="start" justify="center">
+          <div className={cssClass("senderName")}>{senderName}</div>
+          <div className={cssClass("timestamp")}>{formatDateForTimestamp(sentAtTimestamp)}</div>
         </FlexBox>
-        <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
-          <div className={cssClass("messageBody")}>{children}</div>
-        </Linkify>
-        {replyButton}
+        {deleteMenu}
       </FlexBox>
-      {errorMsg && formErrorContainer(errorMsg)}
+      <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
+        <div className={cssClass("messageBody")}>{children}</div>
+      </Linkify>
+      {replyButton}
     </FlexBox>
   );
 };
@@ -147,15 +141,6 @@ function DisabledReplyButton({ disabledMsg }: { disabledMsg: string }): JSX.Elem
         </FlexBox>
       </Tooltip>
     </Button>
-  );
-}
-
-function formErrorContainer(errorMsg: React.ReactNode): JSX.Element {
-  return (
-    <FlexBox className={cssClass("errorMsg")} grow alignItems="center" justify="start">
-      <FontAwesome className={cssClass("errorIcon")} name="exclamation-circle " />
-      {errorMsg}
-    </FlexBox>
   );
 }
 

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -7,7 +7,6 @@
   max-width: 32.5rem;
   .text--line-height-4();
   overflow-wrap: break-word;
-  position: relative;
   white-space: pre-wrap;
   word-wrap: break-word; // IE name for overflow-wrap
 }
@@ -41,25 +40,6 @@
   border-radius: 0.3125rem;
   color: @neutral_black;
   .margin--bottom--s();
-}
-
-.MessagingBubble--Error {
-  color: @alert_red;
-  line-height: 1rem;
-  .margin--right--2xs();
-  .margin--top--2xs();
-  .text--smallMedium();
-  position: absolute;
-  top: 100%;
-  right: 0%;
-}
-
-.MessagingBubble--Error--Icon {
-  .margin--right--2xs();
-}
-
-.MessagingBubble--Error--Parent {
-  padding-bottom: 1.25rem; // line height of message + 4px for margin between message and bubble
 }
 
 // For mobile/tablet

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -1,29 +1,22 @@
 import * as React from "react";
-import * as FontAwesome from "react-fontawesome";
 import Linkify from "react-linkify";
 import * as cx from "classnames";
 import { matchDecorator, componentDecorator } from "./linkifyUtils";
-import { FlexBox } from "..";
 
 import "./MessagingBubble.less";
 
 const cssClasses = {
-  CONTAINER: "MessagingBubble--Container",
   MESSAGE_BASE: "MessagingBubble--Message",
   MESSAGE_OWN: "MessagingBubble--Message--Own",
   MESSAGE_OTHER: "MessagingBubble--Message--Other",
   MESSAGE_REPLY_OWN: "MessagingBubble--Message--Reply--Own",
   MESSAGE_REPLY_OTHER: "MessagingBubble--Message--Reply--Other",
   MESSAGE_REPLY_PARENT: "MessagingBubble--Message--Reply--Parent",
-  ERROR: "MessagingBubble--Error",
-  ERROR_ICON: "MessagingBubble--Error--Icon",
-  ERROR_PARENT: "MessagingBubble--Error--Parent",
 };
 
 interface Props {
   className?: string;
   children: React.ReactNode;
-  errorMsg?: React.ReactNode;
   replyTo?: React.ReactNode;
   theme: "ownMessage" | "otherMessage";
 }
@@ -31,48 +24,33 @@ interface Props {
 export const MessagingBubble: React.FC<Props> = ({
   className,
   children,
-  errorMsg,
   theme,
   replyTo,
 }: Props) => {
   return (
-    <div className={errorMsg && cssClasses.ERROR_PARENT}>
-      <div
-        className={cx(
-          cssClasses.MESSAGE_BASE,
-          theme === "ownMessage" ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
-          className,
-          replyTo && cssClasses.MESSAGE_REPLY_PARENT,
-        )}
-      >
-        {replyTo && (
-          <div
-            className={cx(
-              cssClasses.MESSAGE_BASE,
-              theme === "ownMessage"
-                ? cssClasses.MESSAGE_REPLY_OWN
-                : cssClasses.MESSAGE_REPLY_OTHER,
-            )}
-          >
-            <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
-              {replyTo}
-            </Linkify>
-          </div>
-        )}
-        <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
-          {children}
-        </Linkify>
-        {errorMsg && formErrorContainer(errorMsg)}
-      </div>
+    <div
+      className={cx(
+        cssClasses.MESSAGE_BASE,
+        theme === "ownMessage" ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
+        className,
+        replyTo && cssClasses.MESSAGE_REPLY_PARENT,
+      )}
+    >
+      {replyTo && (
+        <div
+          className={cx(
+            cssClasses.MESSAGE_BASE,
+            theme === "ownMessage" ? cssClasses.MESSAGE_REPLY_OWN : cssClasses.MESSAGE_REPLY_OTHER,
+          )}
+        >
+          <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
+            {replyTo}
+          </Linkify>
+        </div>
+      )}
+      <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
+        {children}
+      </Linkify>
     </div>
   );
 };
-
-function formErrorContainer(errorMsg: React.ReactNode): JSX.Element {
-  return (
-    <FlexBox className={cssClasses.ERROR} grow alignItems="center" justify="start">
-      <FontAwesome className={cssClasses.ERROR_ICON} name="exclamation-circle " />
-      {errorMsg}
-    </FlexBox>
-  );
-}

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -9,6 +9,22 @@
   flex-shrink: 0;
 }
 
+.MessageMetadata--Message--container--right {
+  align-items: flex-end;
+}
+
+.MessageMetadata--Message--container--left {
+  align-items: flex-start;
+}
+
+.MessageMetadata--Message--container--fullWidth {
+  align-items: flex-end;
+}
+
+.MessageMetadata--Message--container--center {
+  align-items: center;
+}
+
 .MessageMetadata--Message--center {
   .margin--y--s();
   margin-left: auto;
@@ -56,6 +72,18 @@
   .padding--top--2xs();
   text-align: right;
   color: @neutral_medium_gray;
+}
+
+.MessageMetadata--Error {
+  color: @alert_red;
+  line-height: 1rem;
+  .margin--right--2xs();
+  .margin--top--2xs();
+  .text--smallMedium();
+}
+
+.MessageMetadata--Error--Icon {
+  .margin--right--2xs();
 }
 
 // For mobile/tablet

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import * as classNames from "classnames";
 import * as moment from "moment";
+import * as FontAwesome from "react-fontawesome";
+import { FlexBox } from "../";
 
 import "./MessageMetadata.less";
 
@@ -13,16 +15,24 @@ interface Props {
   placement: "left" | "right" | "center" | "fullWidth";
   timestamp?: Date;
   readStatusText?: string;
+  errorMsg?: string;
   children: React.ReactNode;
 }
 
 export const MessageMetadata: React.FC<
   Props & { ref?: React.Ref<HTMLDivElement> }
 > = React.forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) => {
-  const { className, placement, timestamp, readStatusText, children } = props;
+  const { className, placement, timestamp, readStatusText, children, errorMsg } = props;
   const showTimestamp = timestamp && placement !== "fullWidth";
   return (
-    <div ref={ref} className={classNames(cssClass("Message--container"), className)}>
+    <div
+      ref={ref}
+      className={classNames(
+        cssClass("Message--container"),
+        cssClass(`Message--container--${placement}`),
+        className,
+      )}
+    >
       <div className={cssClass(`Message--${placement}`)}>
         {children}
         {showTimestamp && (
@@ -32,6 +42,7 @@ export const MessageMetadata: React.FC<
         )}
       </div>
       {readStatusText && <div className={cssClass("ReadReceipt")}>{readStatusText}</div>}
+      {errorMsg && formErrorContainer(errorMsg)}
     </div>
   );
 });
@@ -40,4 +51,13 @@ export const MessageMetadata: React.FC<
 //  Always returns "xx:xx <AM/PM>" format.
 function _formatDateForTimestamp(date: Date): string {
   return moment(date).format("h:mm A");
+}
+
+function formErrorContainer(errorMsg: React.ReactNode): JSX.Element {
+  return (
+    <FlexBox className={cssClass("Error")} grow alignItems="center" justify="start">
+      <FontAwesome className={cssClass("Error--Icon")} name="exclamation-circle " />
+      {errorMsg}
+    </FlexBox>
+  );
 }

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -23,6 +23,7 @@ export interface MessageData {
   index: number;
   readStatusText?: string;
   displayAlertMessageAfter?: { icon: string; messageText: string };
+  errorMsg?: string;
 }
 
 interface Props {
@@ -144,6 +145,7 @@ function _interleaveMessagesWithDividers(
         readStatusText={isOwnMessage(message) && message.readStatusText}
         // First message needs 'auto' top margin to have messages fill container from bottom -> top
         className={i === 0 ? cssClasses.FIRST_MESSAGE : undefined}
+        errorMsg={message.errorMsg}
       >
         {message.content}
       </MessageMetadata>,


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/M5G-228

**Overview:**
This PR adds in errorMsg functionality to DMs by centralizing the logic for `MessagingBubble` and `AnnouncementBubble`. Instead of the errorMsg being a prop on those components, it is a prop on `MessageData/MessageMetadata`. This means we don't need to duplicate the logic, plus conceptually an error message is similar to a timestamp, so it makes sense for it to be a prop on the metadata instead of the bubbles themselves.

**Screenshots/GIFs:**

Desktop student - 
![Screen Shot 2021-04-13 at 1 29 00 PM](https://user-images.githubusercontent.com/26425483/114617323-d6d2de00-9c5c-11eb-9991-d4859b0dd731.png)

Desktop teacher -

![Screen Shot 2021-04-13 at 1 27 06 PM](https://user-images.githubusercontent.com/26425483/114617405-ef42f880-9c5c-11eb-92e2-b974628e4efc.png)

Mobile teacher -
![Screen Shot 2021-04-13 at 1 26 57 PM](https://user-images.githubusercontent.com/26425483/114617425-f5d17000-9c5c-11eb-9e76-d68a108ea1d2.png)

Announcement error messages still show -
![Screen Shot 2021-04-13 at 1 26 44 PM](https://user-images.githubusercontent.com/26425483/114617452-fe29ab00-9c5c-11eb-9dfd-71cac137f1bc.png)

Dewey View shows error messages randomly - 

![Screen Shot 2021-04-13 at 1 11 49 PM](https://user-images.githubusercontent.com/26425483/114617477-05e94f80-9c5d-11eb-9496-5b9e7e24d72a.png)


**Testing:**

Tested in Dewey local and Launchpad local

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
