### PR TITLE
M5 g 241 quoted bubble

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.91.0",
+  "version": "2.92.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -39,16 +39,16 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
     don't attempt to read the entire hidden message. This only works for plain-string children */
   let content = children;
   if (!isExpanded && typeof content === "string") {
-    let previewLength = 100;
-    let firstLineBreak = content.indexOf("\n");
+    const previewLength = 100;
+    const firstLineBreak = content.indexOf("\n");
     /* If we have a line break and the first line of text is shorter than the preview length
      and another line in the body of text, we should preserve the line break in the preview 
      and adjust the preview width accordingly */
     if (firstLineBreak > -1 && firstLineBreak < previewLength - 1) {
       const allLines = content.split("\n");
       const firstLine = allLines[0];
-      const longestLine = allLines.reduce((longestLine, line) =>
-        longestLine.length > line.length ? longestLine : line,
+      const longestLine = allLines.reduce((longest, current) =>
+        longest.length > current.length ? longest : current,
       );
 
       content = _.padEnd(firstLine, longestLine.length, "\xa0");

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { useState } from "react";
 import * as cx from "classnames";
 import Linkify from "react-linkify";
+import * as _ from "lodash";
 import { FlexBox, Button } from "../";
 import { formatDateForTimestamp } from "./NormalAnnouncementBubble";
 import { componentDecorator, matchDecorator } from "../MessagingBubble/linkifyUtils";
@@ -34,11 +35,26 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
 }: Props) => {
   const [isExpanded, setisExpanded] = useState(false);
 
-  // If the content is not expanded, limit the message length so that screen readers
-  // don't attempt to read the entire hidden message. This only works for plain-string children
+  /* If the content is not expanded, limit the message length so that screen readers
+    don't attempt to read the entire hidden message. This only works for plain-string children */
   let content = children;
   if (!isExpanded && typeof content === "string") {
-    content = content.substring(0, 300);
+    let previewLength = 100;
+    let firstLineBreak = content.indexOf("\n");
+    /* If we have a line break and the first line of text is shorter than the preview length
+     and another line in the body of text, we should preserve the line break in the preview 
+     and adjust the preview width accordingly */
+    if (firstLineBreak > -1 && firstLineBreak < previewLength - 1) {
+      const allLines = content.split("\n");
+      const firstLine = allLines[0];
+      const longestLine = allLines.reduce((longestLine, line) =>
+        longestLine.length > line.length ? longestLine : line,
+      );
+
+      content = _.padEnd(firstLine, longestLine.length, "\xa0");
+    } else {
+      content = content.substring(0, previewLength);
+    }
   }
 
   const buttonText = isExpanded ? "Show less" : "Show more";

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -47,7 +47,6 @@
   .MessagingBubble--Message {
     font-size: 0.875rem;
     line-height: 1rem;
-    .padding--xs();
     // This improves how long words/links are broken on Chrome mobile and doesn't affect Safari
     overflow-wrap: anywhere;
   }


### PR DESCRIPTION
**Jira:**
[M5G-241](https://clever.atlassian.net/browse/M5G-241?atlOrigin=eyJpIjoiYzVlMTZlNDUwYWEwNDJmMjkxNThhN2JmNGE2OWE4NjgiLCJwIjoiaiJ9)

**Overview:**
Fixing an issue where the quoted announcement bubble is expanding too much when not in preview mode due to the fact that we're not respecting line breaks. Since we have no easy way to compute the expected length for this case, modifying the truncation logic in the component to help handle this.

(Also sneaking in a small unrelated MessagingBubble css tweak)

**Screenshots/GIFs:**
![Screen Shot 2021-04-13 at 6 17 48 PM](https://user-images.githubusercontent.com/29630673/114629130-08ac6a80-9c86-11eb-9c90-68dc589d8942.png)
![Screen Shot 2021-04-13 at 6 18 05 PM](https://user-images.githubusercontent.com/29630673/114629133-09450100-9c86-11eb-85ff-b372070b2b32.png)
![Screen Shot 2021-04-13 at 6 18 14 PM](https://user-images.githubusercontent.com/29630673/114629134-09450100-9c86-11eb-81c1-be3100b39c63.png)

**Testing:**

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
