### PR TITLE
Remove extra CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.93.0",
+  "version": "2.93.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -9,22 +9,6 @@
   flex-shrink: 0;
 }
 
-.MessageMetadata--Message--container--right {
-  align-items: flex-end;
-}
-
-.MessageMetadata--Message--container--left {
-  align-items: flex-start;
-}
-
-.MessageMetadata--Message--container--fullWidth {
-  align-items: flex-end;
-}
-
-.MessageMetadata--Message--container--center {
-  align-items: center;
-}
-
 .MessageMetadata--Message--center {
   .margin--y--s();
   margin-left: auto;
@@ -77,6 +61,7 @@
 .MessageMetadata--Error {
   color: @alert_red;
   line-height: 1rem;
+  margin-left: auto;
   .margin--right--2xs();
   .margin--top--2xs();
   .text--smallMedium();

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -25,14 +25,7 @@ export const MessageMetadata: React.FC<
   const { className, placement, timestamp, readStatusText, children, errorMsg } = props;
   const showTimestamp = timestamp && placement !== "fullWidth";
   return (
-    <div
-      ref={ref}
-      className={classNames(
-        cssClass("Message--container"),
-        cssClass(`Message--container--${placement}`),
-        className,
-      )}
-    >
+    <div ref={ref} className={classNames(cssClass("Message--container"), className)}>
       <div className={cssClass(`Message--${placement}`)}>
         {children}
         {showTimestamp && (


### PR DESCRIPTION
**Overview:**

I added some CSS in this PR - https://github.com/Clever/components/pull/625/files?file-filters%5B%5D=.less&file-filters%5B%5D=.tsx. It works, but Jonathan and I made some changes at the same time, and message bubbles on narrow screens still can spill off the edge sometimes. I'm cutting down some of the CSS that isn't neccessary to try to get to the bottom of it. Pretty much, before this component would place error messages to the side that bubble is, but now it always floats to the right. This is the same behavior as the READ marker on the bubble. And, we only expect Error messages on "Own" messages, so that's why I felt we should keep it simpler until another use case comes up.

**Screenshots/GIFs:**

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [NA] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
