### PR TITLE
Select2 controlled

### DIFF
--- a/docs/components/MultiSelectView.jsx
+++ b/docs/components/MultiSelectView.jsx
@@ -5,7 +5,7 @@ import FontAwesome from "react-fontawesome";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import { TextInput2, MultiSelect, FlexBox, ItemAlign, SegmentedControl, Label } from "src";
+import { TextInput2, Select2, MultiSelect, FlexBox, ItemAlign, SegmentedControl, Label } from "src";
 import { FormElementSize, FormElementRequirement } from "../../src/utils/Forms";
 
 import "./MultiSelectView.less";
@@ -30,6 +30,8 @@ export default class MultiSelectView extends React.PureComponent {
     placeholder: "Select or create options",
     creatable: false,
     allowDuplicates: false,
+    values: [],
+    initialValuesSelect: "",
     size: FormElementSize.MEDIUM,
   };
 
@@ -78,7 +80,11 @@ export default class MultiSelectView extends React.PureComponent {
               }))}
               creatable={this.state.creatable}
               allowDuplicates={this.state.allowDuplicates}
-              onChange={console.log}
+              onChange={(v) => {
+                console.log(`selected: ${v.join(", ")}`);
+                this.setState({ values: v });
+              }}
+              values={this.state.values}
               size={this.state.size}
             />
           </ExampleCode>
@@ -91,7 +97,15 @@ export default class MultiSelectView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { label, hideLabel, placeholder, creatable, allowDuplicates, size } = this.state;
+    const {
+      label,
+      initialValuesSelect,
+      hideLabel,
+      placeholder,
+      creatable,
+      allowDuplicates,
+      size,
+    } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -103,6 +117,28 @@ export default class MultiSelectView extends React.PureComponent {
             requirement={FormElementRequirement.REQUIRED}
             onChange={(e) => this.setState({ label: e.target.value })}
             value={label}
+          />
+        </div>
+        <div className={cssClass.CONFIG}>
+          <Select2
+            className={cssClass.CONFIG_OPTIONS}
+            name="TextInput2View--labelTextInput"
+            label="Initial selected values"
+            options={[
+              { value: "Option 1, Option 2" },
+              { value: "Option 2, Option 4" },
+              { value: "Option 4, Option 20" },
+              { value: "Option 1, Option 10, Option 11, Option 12" },
+            ]}
+            clearable
+            value={initialValuesSelect}
+            onChange={(v) => {
+              this.setState({
+                initialValuesSelect: v,
+                values: v.split(", "),
+              });
+            }}
+            size={FormElementSize.MEDIUM}
           />
         </div>
         <label className={cssClass.CONFIG}>
@@ -210,11 +246,16 @@ export default class MultiSelectView extends React.PureComponent {
             optional: true,
           },
           {
+            name: "values",
+            type: "string[]",
+            description:
+              "Set the selected values as a controlled component (also helpful for default states)",
+          },
+          {
             name: "onChange",
-            type: (
-              <code>{"(selectedItems: { value: string, content?: ReactNode }[]) => void"}</code>
-            ),
-            description: "Called when an option is selected",
+            type: <code>{"(selectedItems: string[]) => void"}</code>,
+            description:
+              "Called when an option is selected which contains an array of select values",
           },
           {
             name: "size",

--- a/docs/components/MultiSelectView.jsx
+++ b/docs/components/MultiSelectView.jsx
@@ -135,7 +135,7 @@ export default class MultiSelectView extends React.PureComponent {
             onChange={(v) => {
               this.setState({
                 initialValuesSelect: v,
-                values: v.split(", "),
+                values: (v || "").split(", "),
               });
             }}
             size={FormElementSize.MEDIUM}

--- a/docs/components/Select2View.jsx
+++ b/docs/components/Select2View.jsx
@@ -30,12 +30,11 @@ export default class Select2View extends React.PureComponent {
     clearable: true,
     required: true,
     initialIsInError: false,
+    value: null,
     size: FormElementSize.MEDIUM,
   };
 
   render() {
-    const { optionToggle1 } = this.state;
-
     return (
       <View className={cssClass.CONTAINER} title="Select2" sourcePath="src/Select2/Select2.tsx">
         <header className={cssClass.INTRO}>
@@ -76,7 +75,11 @@ export default class Select2View extends React.PureComponent {
               clearable={this.state.clearable}
               requirement={this.state.required ? "required" : ""}
               initialIsInError={this.state.initialIsInError}
-              onChange={console.log}
+              onChange={(v) => {
+                console.log(`selected: ${v}`);
+                this.setState({ value: v });
+              }}
+              value={this.state.value}
               size={this.state.size}
             />
           </ExampleCode>
@@ -89,7 +92,7 @@ export default class Select2View extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { label, hideLabel, clearable, required, initialIsInError, size } = this.state;
+    const { label, value, hideLabel, clearable, required, initialIsInError, size } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -101,6 +104,20 @@ export default class Select2View extends React.PureComponent {
             requirement={FormElementRequirement.REQUIRED}
             onChange={(e) => this.setState({ label: e.target.value })}
             value={label}
+          />
+        </div>
+        <div className={cssClass.CONFIG}>
+          <span className={cssClass.CONFIG_LABEL_TEXT}>Controlled selected value:</span>
+          <SegmentedControl
+            className={cssClass.CONFIG_OPTIONS}
+            options={[
+              { content: "Empty", value: "" },
+              { content: "Option 1", value: "Option 1" },
+              { content: "Option 4", value: "Option 4" },
+              { content: "Option 20", value: "Option 20" },
+            ]}
+            value={value}
+            onSelect={(v) => this.setState({ value: v })}
           />
         </div>
         <label className={cssClass.CONFIG}>
@@ -150,7 +167,7 @@ export default class Select2View extends React.PureComponent {
               { content: "full-width", value: FormElementSize.FULL_WIDTH },
             ]}
             value={size}
-            onSelect={(value) => this.setState({ size: value })}
+            onSelect={(v) => this.setState({ size: v })}
           />
         </div>
       </FlexBox>
@@ -211,6 +228,12 @@ export default class Select2View extends React.PureComponent {
             type: "boolean",
             description: "Intialize the component in an error state",
             optional: true,
+          },
+          {
+            name: "value",
+            type: "string",
+            description:
+              "Set the selected value as a controlled component (also helpful for default states)",
           },
           {
             name: "onChange",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.93.2",
+  "version": "2.94.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MultiSelect/MultiSelect.tsx
+++ b/src/MultiSelect/MultiSelect.tsx
@@ -29,7 +29,8 @@ export interface Props {
   // NOTE: might be a little wonky since the downshift library might not fully support it
   // it's also a fringe use case of this MultiSelect that we may want to remove in the future
   allowDuplicates?: boolean;
-  onChange?: (options: Option[]) => void;
+  values: string[];
+  onChange: (options: string[]) => void;
   size?: Values<typeof FormElementSize>;
 }
 
@@ -96,6 +97,7 @@ const MultiSelect: React.FC<Props> = ({
   placeholder,
   // we will manage the options in state since options are creatable
   options: initialOptions,
+  values,
   creatable,
   allowDuplicates,
   onChange,
@@ -103,18 +105,12 @@ const MultiSelect: React.FC<Props> = ({
 }) => {
   const [options, setOptions] = useState(initialOptions);
   const [inputValue, setInputValue] = useState("");
-  const {
-    getSelectedItemProps,
-    getDropdownProps,
-    addSelectedItem,
-    removeSelectedItem,
-    setSelectedItems,
-    selectedItems,
-  } = useMultipleSelection<Option>({
+  const { getSelectedItemProps, getDropdownProps, selectedItems } = useMultipleSelection<Option>({
     itemToString: (o) => (o ? o.value : ""),
+    selectedItems: (values || []).map((v) => options.find((o) => o.value === v)).filter((v) => !!v),
     onSelectedItemsChange: (change) => {
       if (onChange) {
-        onChange(change.selectedItems);
+        onChange(change.selectedItems.map((o) => o.value));
       }
     },
   });
@@ -176,7 +172,7 @@ const MultiSelect: React.FC<Props> = ({
               newOption = { value: inputValue };
               setOptions([...options, newOption]);
             }
-            addSelectedItem(newOption);
+            onChange([...selectedItems, newOption].map((o) => o.value));
           }
           break;
         case useCombobox.stateChangeTypes.InputBlur:
@@ -226,11 +222,11 @@ const MultiSelect: React.FC<Props> = ({
                 className={cssClass.SELECTED_ITEM_BUTTON}
                 onClick={(e) => {
                   e.stopPropagation();
-                  if (allowDuplicates) {
-                    setSelectedItems([...selectedItems.slice(0, i), ...selectedItems.slice(i + 1)]);
-                  } else {
-                    removeSelectedItem(item);
-                  }
+                  onChange(
+                    [...selectedItems.slice(0, i), ...selectedItems.slice(i + 1)].map(
+                      (o) => o.value,
+                    ),
+                  );
                   if (inputRef.current) {
                     inputRef.current.select();
                   }

--- a/src/Select2/Select2.tsx
+++ b/src/Select2/Select2.tsx
@@ -103,10 +103,6 @@ const Select2: React.FC<Props> = ({
             inputValue: selectedItem ? selectedItem.value : "",
           };
         }
-        case useCombobox.stateChangeTypes.InputChange:
-          break;
-        case useCombobox.stateChangeTypes.ControlledPropUpdatedSelectedItem:
-          break;
         default:
           break;
       }


### PR DESCRIPTION
**Overview:**
Make Select2 and MultiSelect controlled components. Which will help with sharing state across components as well as setting default values.

**Screenshots/GIFs:**

https://user-images.githubusercontent.com/13126257/114940438-b179d780-9df6-11eb-8d46-4547fa69341e.mov

https://user-images.githubusercontent.com/13126257/114940511-c8202e80-9df6-11eb-9fc1-edb8a64679b4.mov

**Testing:**

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
