### PR TITLE
Add onCopyClick prop to CopyContainer

### DIFF
--- a/docs/components/CopyContainerView.jsx
+++ b/docs/components/CopyContainerView.jsx
@@ -42,7 +42,7 @@ export default class CopyContainerView extends React.PureComponent {
 
         <Example title="Basic Usage:">
           <ExampleCode>
-            <CopyContainer className="my--custom--class">
+            <CopyContainer className="my--custom--class" onCopyClick={() => console.log("copied")}>
               Click the button to copy me.
             </CopyContainer>
           </ExampleCode>
@@ -87,11 +87,19 @@ export default class CopyContainerView extends React.PureComponent {
             name: "copyText",
             type: "string",
             description: "The text that should be copied to the clipboard.",
+            optional: true,
           },
           {
             name: "buttonLabel",
             type: "string",
             description: "The text that appears on the copy button.",
+            optional: true,
+          },
+          {
+            name: "onCopyClick",
+            type: "Function",
+            description: "Callback when the copy button is clicked",
+            optional: true,
           },
         ]}
         className={cssClass.PROPS}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.94.1",
+  "version": "2.95.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/CopyContainer/CopyContainer.tsx
+++ b/src/CopyContainer/CopyContainer.tsx
@@ -14,6 +14,7 @@ export interface Props {
   copyText?: string;
   buttonLabel?: string;
   className?: string;
+  onCopyClick?: () => void;
 }
 
 interface State {
@@ -25,6 +26,7 @@ const propTypes = {
   copyText: PropTypes.string,
   buttonLabel: PropTypes.string,
   className: PropTypes.string,
+  onCopyClick: PropTypes.func,
 };
 
 export const cssClass = {
@@ -48,7 +50,9 @@ export default class CopyContainer extends React.PureComponent<Props, State> {
   }
 
   _onCopy() {
+    const { onCopyClick } = this.props;
     this.setState({ copied: true });
+    if (onCopyClick) onCopyClick();
     window.setTimeout(() => this.setState({ copied: false }), 2 * 1000);
   }
 


### PR DESCRIPTION
**Jira:**
NA

**Overview:**
Add a callback to the CopyContainer for the copy button onClick event

**Screenshots/GIFs:**
https://share.getcloudapp.com/z8u6LdGw

**Testing:**
Tested by updating the docs & provided a callback using the new prop, running `make dev-server`

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
