### PR TITLE
M5G-242: add messageTruncated prop to (Quoted)AnnouncementBubble

### DIFF
--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -100,7 +100,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
                 />
               }
               sentAtTimestamp={new Date()}
-              messageTruncated
+              isMessageTruncated
             >
               This can go inside of other components, like the MessagingBubble or MessagingInput!
               The content expands and hides when the button is clicked. Links like

--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -100,10 +100,18 @@ export default class AnnouncementBubbleView extends React.PureComponent {
                 />
               }
               sentAtTimestamp={new Date()}
+              messageTruncated
             >
               This can go inside of other components, like the MessagingBubble or MessagingInput!
               The content expands and hides when the button is clicked. Links like
-              https://clever.com are clickable
+              https://clever.com are clickable. Bla bla bla bla bla bla bla bla bla bla bla bla bla
+              bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla
+              bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla
+              bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla
+              bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla
+              bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla
+              bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla
+              bla bla bla bla bla bla bla...
             </AnnouncementBubble>
           </ExampleCode>
           {this._renderConfig()}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.95.0",
+  "version": "2.96.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/AnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/AnnouncementBubble.tsx
@@ -35,7 +35,7 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
           senderIcon={props.senderIcon}
           senderName={props.senderName}
           sentAtTimestamp={props.sentAtTimestamp}
-          messageTruncated={props.messageTruncated}
+          isMessageTruncated={props.isMessageTruncated}
         >
           {props.children}
         </QuotedAnnouncementBubble>

--- a/src/AnnouncementBubble/AnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/AnnouncementBubble.tsx
@@ -35,6 +35,7 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
           senderIcon={props.senderIcon}
           senderName={props.senderName}
           sentAtTimestamp={props.sentAtTimestamp}
+          messageTruncated={props.messageTruncated}
         >
           {props.children}
         </QuotedAnnouncementBubble>

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -69,6 +69,15 @@
   text-overflow: ellipsis;
 }
 
+.QuotedAnnouncementBubble--messageTruncatedNotice {
+  .text--semi-bold();
+  .margin--bottom--xs();
+}
+
+.QuotedAnnouncementBubble--messageTruncatedNotice--icon {
+  margin-left: 0.3125rem;
+}
+
 .QuotedAnnouncementBubble--messageDetails--light,
 .QuotedAnnouncementBubble--messageDetails--white {
   color: @neutral_medium_gray;

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -20,7 +20,7 @@ export interface Props {
   children: React.ReactNode;
   className?: string;
   colorTheme: "white" | "light" | "dark";
-  messageTruncated: boolean;
+  messageTruncated?: boolean;
   senderIcon: React.ReactNode;
   senderName: string;
   sentAtTimestamp: Date;

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -20,7 +20,7 @@ export interface Props {
   children: React.ReactNode;
   className?: string;
   colorTheme: "white" | "light" | "dark";
-  messageTruncated?: boolean;
+  isMessageTruncated?: boolean;
   senderIcon: React.ReactNode;
   senderName: string;
   sentAtTimestamp: Date;
@@ -34,9 +34,9 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
   senderIcon,
   senderName,
   sentAtTimestamp,
-  messageTruncated,
+  isMessageTruncated,
 }: Props) => {
-  const [isExpanded, setisExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   const messageDetails = formMessageDetails(announcementGroupName, sentAtTimestamp);
 
@@ -97,7 +97,7 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
           {content}
         </Linkify>
       </div>
-      {messageTruncated && isExpanded && (
+      {isMessageTruncated && isExpanded && (
         <FlexBox className={cssClass("messageTruncatedNotice")} alignItems="center">
           Complete announcement not shown{" "}
           <Tooltip
@@ -116,7 +116,7 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
       )}
       <Button
         className={cssClass("button--outer")}
-        onClick={() => setisExpanded(!isExpanded)}
+        onClick={() => setIsExpanded(!isExpanded)}
         type="linkPlain"
       >
         <span

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -2,8 +2,9 @@ import * as React from "react";
 import { useState } from "react";
 import * as cx from "classnames";
 import Linkify from "react-linkify";
+import * as FontAwesome from "react-fontawesome";
 import * as _ from "lodash";
-import { FlexBox, Button } from "../";
+import { FlexBox, Button, Tooltip } from "../";
 import { formatDateForTimestamp } from "./NormalAnnouncementBubble";
 import { componentDecorator, matchDecorator } from "../MessagingBubble/linkifyUtils";
 
@@ -19,6 +20,7 @@ export interface Props {
   children: React.ReactNode;
   className?: string;
   colorTheme: "white" | "light" | "dark";
+  messageTruncated: boolean;
   senderIcon: React.ReactNode;
   senderName: string;
   sentAtTimestamp: Date;
@@ -32,6 +34,7 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
   senderIcon,
   senderName,
   sentAtTimestamp,
+  messageTruncated,
 }: Props) => {
   const [isExpanded, setisExpanded] = useState(false);
 
@@ -94,6 +97,20 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
           {content}
         </Linkify>
       </div>
+      {messageTruncated && isExpanded && (
+        <FlexBox className={cssClass("messageTruncatedNotice")} alignItems="center">
+          Complete announcement not shown{" "}
+          <Tooltip
+            content="This announcement exceeds the preview character limit. See original announcement for complete content."
+            placement={Tooltip.Placement.TOP}
+          >
+            <FontAwesome
+              name="question-circle"
+              className={cssClass("messageTruncatedNotice--icon")}
+            />
+          </Tooltip>
+        </FlexBox>
+      )}
       {isExpanded && (
         <span className={cssClass(`messageDetails--${colorTheme}`)}>{messageDetails}</span>
       )}


### PR DESCRIPTION
**Jira:**

https://clever.atlassian.net/browse/M5G-242

**Overview:**

Adding optional `messageTruncated` prop and copy to `<QuotedAnnouncementBubble />`

Notes:
* Added `messageTruncated` prop to AnnouncementBubble as well (because of discriminated union of props)
* Question Mark icon has tooltip with more info
* Copy only shows when "Show more" is clicked/text is expanded

**Screenshots/GIFs:**

![Screen Shot 2021-04-22 at 5 06 22 PM](https://user-images.githubusercontent.com/54862564/115799428-55322d00-a38d-11eb-99bd-696dbedc75eb.png)
![Screen Shot 2021-04-22 at 5 06 29 PM](https://user-images.githubusercontent.com/54862564/115799439-59f6e100-a38d-11eb-88c0-d57b5876499a.png)


**Testing:**

- ~~Unit tests~~
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Edge

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - New component or backward-compatible component feature change? Run `npm version minor`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
