### PR TITLE
add searchKey for multi-select options

### DIFF
--- a/docs/components/MultiSelectView.jsx
+++ b/docs/components/MultiSelectView.jsx
@@ -240,7 +240,9 @@ export default class MultiSelectView extends React.PureComponent {
           },
           {
             name: "options",
-            type: <code>{"Array<{ value: string, content?: ReactNode, searchKey?: string }>"}</code>,
+            type: (
+              <code>{"Array<{ value: string, content?: ReactNode, searchKey?: string }>"}</code>
+            ),
             description:
               "List of options to be selected. 'value' is the string key and used for searchability by default, 'content' is an optional react node for custom rendering, 'searchKey' is an optional string to be used for searching",
             optional: true,

--- a/docs/components/MultiSelectView.jsx
+++ b/docs/components/MultiSelectView.jsx
@@ -69,15 +69,22 @@ export default class MultiSelectView extends React.PureComponent {
               label={this.state.label}
               hideLabel={this.state.hideLabel}
               placeholder={this.state.placeholder}
-              options={new Array(20).fill(0).map((_, i) => ({
-                value: `Option ${i + 1}`,
-                content: (
-                  <FlexBox>
-                    <FontAwesome style={{ marginRight: "8px" }} name="exclamation-triangle" />
-                    <span>Option {i + 1}</span>
-                  </FlexBox>
-                ),
-              }))}
+              options={new Array(20)
+                .fill(0)
+                .map((_, i) => ({
+                  value: `Option ${i + 1}`,
+                  content: (
+                    <FlexBox>
+                      <FontAwesome style={{ marginRight: "8px" }} name="exclamation-triangle" />
+                      <span>Option {i + 1}</span>
+                    </FlexBox>
+                  ),
+                }))
+                .concat({
+                  value: "sis_id",
+                  searchKey: "sis id",
+                  content: "SIS ID",
+                })}
               creatable={this.state.creatable}
               allowDuplicates={this.state.allowDuplicates}
               onChange={(v) => {
@@ -233,9 +240,9 @@ export default class MultiSelectView extends React.PureComponent {
           },
           {
             name: "options",
-            type: <code>{"Array<{ value: string, content?: ReactNode }>"}</code>,
+            type: <code>{"Array<{ value: string, content?: ReactNode, searchKey?: string }>"}</code>,
             description:
-              "List of options to be selected. 'value' is the string key and used for searchability, 'content' is an optional react node for custom rendering",
+              "List of options to be selected. 'value' is the string key and used for searchability by default, 'content' is an optional react node for custom rendering, 'searchKey' is an optional string to be used for searching",
             optional: true,
           },
           {

--- a/docs/components/MultiSelectView.jsx
+++ b/docs/components/MultiSelectView.jsx
@@ -69,22 +69,16 @@ export default class MultiSelectView extends React.PureComponent {
               label={this.state.label}
               hideLabel={this.state.hideLabel}
               placeholder={this.state.placeholder}
-              options={new Array(20)
-                .fill(0)
-                .map((_, i) => ({
-                  value: `Option ${i + 1}`,
-                  content: (
-                    <FlexBox>
-                      <FontAwesome style={{ marginRight: "8px" }} name="exclamation-triangle" />
-                      <span>Option {i + 1}</span>
-                    </FlexBox>
-                  ),
-                }))
-                .concat({
-                  value: "sis_id",
-                  searchKey: "sis id",
-                  content: "SIS ID",
-                })}
+              options={new Array(20).fill(0).map((_, i) => ({
+                value: `option_${i + 1}`,
+                content: (
+                  <FlexBox>
+                    <FontAwesome style={{ marginRight: "8px" }} name="exclamation-triangle" />
+                    <span>Option {i + 1}</span>
+                  </FlexBox>
+                ),
+                searchKey: `option ${i + 1}`,
+              }))}
               creatable={this.state.creatable}
               allowDuplicates={this.state.allowDuplicates}
               onChange={(v) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.96.0",
+  "version": "2.97.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MultiSelect/MultiSelect.tsx
+++ b/src/MultiSelect/MultiSelect.tsx
@@ -14,7 +14,7 @@ import "./MultiSelect.less";
 export const ADD_NEW_ITEM_KEY = "MultiSelect--addNewItem";
 
 // value represents the searchable text of the option
-type Option = { value: string; content?: React.ReactNode, searchKey?: string };
+type Option = { value: string; content?: React.ReactNode; searchKey?: string };
 
 export interface Props {
   className?: string;

--- a/src/MultiSelect/MultiSelect.tsx
+++ b/src/MultiSelect/MultiSelect.tsx
@@ -14,7 +14,7 @@ import "./MultiSelect.less";
 export const ADD_NEW_ITEM_KEY = "MultiSelect--addNewItem";
 
 // value represents the searchable text of the option
-type Option = { value: string; content?: React.ReactNode };
+type Option = { value: string; content?: React.ReactNode, searchKey?: string };
 
 export interface Props {
   className?: string;
@@ -64,7 +64,7 @@ export function getSelectableOptions(
 
   let hasExactMatch = false;
   const selectableOptions = options.filter((o) => {
-    const optionLowerCase = o.value.toLocaleLowerCase();
+    const optionLowerCase = (o.searchKey || o.value).toLocaleLowerCase();
     // small performance optimization to process exact match within the same iterator
     if (optionLowerCase === inputLowerCase) {
       hasExactMatch = true;


### PR DESCRIPTION
**Overview:**
Add optional `searchKey` for multi select options

The use case where we needed this was I have `value: "name.first"` which displays as `first name` and searching by `first name` doesn't show the result.

**Screenshots/GIFs:**
before:
![image](https://user-images.githubusercontent.com/13126257/115821987-a3a8f100-a3b8-11eb-849e-359202efd4b1.png)

after:
![image](https://user-images.githubusercontent.com/13126257/115822023-b1f70d00-a3b8-11eb-8283-6bf88815b27a.png)

**Testing:**

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
