### PR TITLE
Allow Menu.Item to be disabled

### DIFF
--- a/docs/components/MenuView.jsx
+++ b/docs/components/MenuView.jsx
@@ -205,9 +205,7 @@ export default class MenuView extends React.PureComponent {
               <Menu.Item href="https://google.com/search?q=four" target="_blank">
                 Plain Link Menu Item
               </Menu.Item>
-              <Menu.Item disabled>
-                Disabled Item
-              </Menu.Item>
+              <Menu.Item disabled>Disabled Item</Menu.Item>
             </Menu>
           </ExampleCode>
           {this._renderConfig()}

--- a/docs/components/MenuView.jsx
+++ b/docs/components/MenuView.jsx
@@ -205,6 +205,9 @@ export default class MenuView extends React.PureComponent {
               <Menu.Item href="https://google.com/search?q=four" target="_blank">
                 Plain Link Menu Item
               </Menu.Item>
+              <Menu.Item disabled>
+                Disabled Item
+              </Menu.Item>
             </Menu>
           </ExampleCode>
           {this._renderConfig()}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.96.0",
+  "version": "2.97.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.95.0",
+  "version": "2.96.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Menu/MenuItem.less
+++ b/src/Menu/MenuItem.less
@@ -33,6 +33,12 @@ button.Menu--MenuItem--default {
     box-shadow: inset @borderWidthL 0 @primary_blue_shade_1;
     color: @primary_blue_shade_2;
   }
+
+  &:disabled {
+    color: @neutral_dark_gray;
+    background: @neutral_silver;
+    border-color: @neutral_silver;
+  }
 }
 
 .Menu--MenuItem--default.Menu--MenuItem--selected {

--- a/src/Menu/MenuItem.tsx
+++ b/src/Menu/MenuItem.tsx
@@ -83,7 +83,7 @@ export default class MenuItem extends React.PureComponent<Props> {
     let MenuButton = component;
     if (!MenuButton) {
       // Render disabled href elements as buttons so that they can be disabled
-      MenuButton = href || !disabled ? "a" : "button" ;
+      MenuButton = href || !disabled ? "a" : "button";
     }
 
     // Safari fires focusout events on button mousedown events - it basically removes and returns

--- a/src/Menu/MenuItem.tsx
+++ b/src/Menu/MenuItem.tsx
@@ -76,12 +76,14 @@ export default class MenuItem extends React.PureComponent<Props> {
       onMouseEnter,
       selected,
       target,
+      disabled,
     } = this.props;
     const additionalProps = _.omit(this.props, Object.keys(propTypes));
 
     let MenuButton = component;
     if (!MenuButton) {
-      MenuButton = href ? "a" : "button";
+      // Render disabled href elements as buttons so that they can be disabled
+      MenuButton = href || !disabled ? "a" : "button" ;
     }
 
     // Safari fires focusout events on button mousedown events - it basically removes and returns
@@ -111,6 +113,7 @@ export default class MenuItem extends React.PureComponent<Props> {
         onClick={onClick}
         onMouseDown={onMouseDown}
         onMouseEnter={onMouseEnter}
+        disabled={disabled}
         role="menuitem"
         tabIndex={-1}
         target={target}


### PR DESCRIPTION
**Overview:**
Adding the disabled option for Menu.Item

**Screenshots/GIFs:**
![image](https://user-images.githubusercontent.com/6893359/115897221-0b8b2600-a411-11eb-9e33-7acbad829521.png)


**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
