### PR TITLE
Copy container button type

### DIFF
--- a/docs/components/CopyContainerView.jsx
+++ b/docs/components/CopyContainerView.jsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import { CopyContainer } from "src";
+import { CopyContainer, FlexBox, ItemAlign, SegmentedControl } from "src";
 
 import "./CopyContainerView.less";
 
@@ -19,8 +19,12 @@ const cssClass = {
 
 export default class CopyContainerView extends React.PureComponent {
   static cssClass = cssClass;
+  state = {
+    buttonType: "linkPlain",
+  };
 
   render() {
+    const { buttonType } = this.state;
     return (
       <View
         className={cssClass.CONTAINER}
@@ -61,6 +65,26 @@ export default class CopyContainerView extends React.PureComponent {
             </CopyContainer>
           </ExampleCode>
         </Example>
+        <Example title="With button type:">
+          <ExampleCode>
+            <CopyContainer className="my--custom--class" buttonType={buttonType}>
+              Click the button to copy me.
+            </CopyContainer>
+          </ExampleCode>
+          <FlexBox className={cssClass.CONFIG_CONTAINER} alignItems={ItemAlign.CENTER}>
+            <h4>Button type:</h4>
+            <SegmentedControl
+              className={cssClass.CONFIG_OPTIONS}
+              onSelect={(s) => this.setState({ buttonType: s })}
+              options={[
+                { content: "linkPlain [default]", value: "linkPlain" },
+                { content: "primary", value: "primary" },
+                { content: "secondary", value: "secondary" },
+              ]}
+              value={buttonType}
+            />
+          </FlexBox>
+        </Example>
 
         {this._renderProps()}
       </View>
@@ -99,6 +123,13 @@ export default class CopyContainerView extends React.PureComponent {
             name: "onCopyClick",
             type: "Function",
             description: "Callback when the copy button is clicked",
+            optional: true,
+          },
+          {
+            name: "buttonType",
+            type: "linkPlain | primary | secondary",
+            description: "Button type for the copy button",
+            defaultValue: "linkPlain",
             optional: true,
           },
         ]}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.97.0",
+  "version": "2.98.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/CopyContainer/CopyContainer.tsx
+++ b/src/CopyContainer/CopyContainer.tsx
@@ -14,6 +14,7 @@ export interface Props {
   copyText?: string;
   buttonLabel?: string;
   className?: string;
+  buttonType?: "linkPlain" | "primary" | "secondary";
   onCopyClick?: () => void;
 }
 
@@ -57,7 +58,7 @@ export default class CopyContainer extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { children, copyText, buttonLabel, className } = this.props;
+    const { children, copyText, buttonLabel, className, buttonType = "linkPlain" } = this.props;
     const { copied } = this.state;
 
     const copyLabel = !copied ? buttonLabel || "Copy" : "Copied!";
@@ -67,7 +68,7 @@ export default class CopyContainer extends React.PureComponent<Props, State> {
         {children}
         <FlexBox alignItems={ItemAlign.START} grow>
           <CopyToClipboard text={copyText || children || ""} onCopy={this._onCopy}>
-            <Button className={cssClass.BUTTON} type="linkPlain" value={copyLabel} />
+            <Button className={cssClass.BUTTON} type={buttonType} value={copyLabel} />
           </CopyToClipboard>
         </FlexBox>
       </FlexBox>


### PR DESCRIPTION
**Jira:**
NA

**Overview:**
This PR adds a new prop `buttonType` to `CopyContainer` to support different types of buttons

**Screenshots/GIFs:**
![image](https://user-images.githubusercontent.com/6362897/115929111-1313f480-a43c-11eb-8a4b-3aabd046d504.png)
![image](https://user-images.githubusercontent.com/6362897/115929115-14ddb800-a43c-11eb-86b4-5a92d407a2a9.png)
![image](https://user-images.githubusercontent.com/6362897/115929117-16a77b80-a43c-11eb-9332-b163f7c9404b.png)


**Testing:**

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
