### PR TITLE
M5G-242: fix tooltip placement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.97.0",
+  "version": "2.98.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -99,16 +99,18 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
       </div>
       {isMessageTruncated && isExpanded && (
         <FlexBox className={cssClass("messageTruncatedNotice")} alignItems="center">
-          Complete announcement not shown{" "}
-          <Tooltip
-            content="This announcement exceeds the preview character limit. See original announcement for complete content."
-            placement={Tooltip.Placement.TOP}
-          >
-            <FontAwesome
-              name="question-circle"
-              className={cssClass("messageTruncatedNotice--icon")}
-            />
-          </Tooltip>
+          <span>
+            Complete announcement not shown{" "}
+            <Tooltip
+              content="This announcement exceeds the preview character limit. See original announcement for complete content."
+              placement={Tooltip.Placement.TOP}
+            >
+              <FontAwesome
+                name="question-circle"
+                className={cssClass("messageTruncatedNotice--icon")}
+              />
+            </Tooltip>
+          </span>
         </FlexBox>
       )}
       {isExpanded && (

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -100,7 +100,7 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
       {isMessageTruncated && isExpanded && (
         <FlexBox className={cssClass("messageTruncatedNotice")} alignItems="center">
           <span>
-            Complete announcement not shown{" "}
+            Complete announcement not shown
             <Tooltip
               content="This announcement exceeds the preview character limit. See original announcement for complete content."
               placement={Tooltip.Placement.TOP}


### PR DESCRIPTION
**Jira:**

M5G-242

**Overview:**

* Put truncated notice and tooltip/fontawesome in a span, so they would stay together on narrow screens

**Screenshots/GIFs:**

![Screen Shot 2021-04-23 at 3 26 06 PM](https://user-images.githubusercontent.com/54862564/115935594-62f8b880-a448-11eb-8e77-f1706b1cc287.png)
^Note: It looks like the icon is not vertically centered with the text, but I believe that's because of the lowercase text. It should be vertically centered with capital letters

**Testing:**

- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] ~~Updated docs~~
  - [x] Bumped version in `package.json`
    - New component or backward-compatible component feature change? Run `npm version minor`
- After merging:
  - [ ] ~~Deployed updated docs (`make deploy-docs`)~~
  - [ ] ~~Posted in #eng if I made a breaking change to a beta component~~
