### PR TITLE
New day, new deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -16,7 +16,19 @@ then
   exit 1;
 fi
 
-npm install
+npmVersion=$(npm view npm version | awk -F. '{ print $1 }')
+if [[ npmVersion -gt 6 ]]
+then
+  echo -e "\n\033[0;32mRunning 'npm install' with --legacy-peer-deps\033[0m\n";
+  # When on npm 7, the default behavior is to try and install peer dependencies.
+  # This leads to installation conflicts, so fallback on old behavior.
+  # https://github.blog/2021-02-02-npm-7-is-now-generally-available/#peer-dependencies
+  # TODO: remove when we don't have conflicting peer dependencies.
+  npm install --legacy-peer-deps
+else
+  npm install
+fi
+
 ./node_modules/.bin/webpack
 
 git add docs/


### PR DESCRIPTION
**Jira:** N/A

**Overview:**
With npm 7, peer dependencies were changed to also be installed when installing
dependencies [1]. This breaks some functionality for incompatible peer
dependencies. By adding `--legacy-peer-deps`, we revert to how npm 4-6 dealt with
the issue.

[1] https://github.blog/2021-02-02-npm-7-is-now-generally-available/#peer-dependencies

**Screenshots/GIFs:**
N/A

**Testing:**
N/A