### PR TITLE
Stepper seekable states

### DIFF
--- a/docs/components/StepperView.jsx
+++ b/docs/components/StepperView.jsx
@@ -3,7 +3,7 @@ import React, { PureComponent } from "react";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import View from "./View";
 import PropDocumentation from "./PropDocumentation";
-import { Stepper, FlexBox, Grid, ItemAlign, TextInput, TextArea } from "src";
+import { Stepper, FlexBox, Grid, ItemAlign, TextInput, MultiSelect, TextArea } from "src";
 
 import "./StepperView.less";
 
@@ -28,7 +28,7 @@ export default class StepperView extends PureComponent {
     step1Description: "Step description",
     step1State: "INCOMPLETE",
     step1Optional: false,
-    seekable: true,
+    seekableStates: ["INCOMPLETE", "WARNING", "SUCCESS"],
     currentStepID: "step3",
   };
 
@@ -46,7 +46,6 @@ export default class StepperView extends PureComponent {
       step1State,
       step1Warning,
       step1Optional,
-      seekable,
       currentStepID,
     } = this.state;
     const steps = [
@@ -125,7 +124,8 @@ export default class StepperView extends PureComponent {
                   className="ExampleStepper"
                   currentStepID={currentStepID}
                   steps={steps}
-                  onStepClick={seekable ? (id) => this.jumpToStep(id) : null}
+                  seekableStates={this.state.seekableStates}
+                  onStepClick={(id) => this.jumpToStep(id)}
                 />
               </Col>
               <Col span={8}>
@@ -146,14 +146,13 @@ export default class StepperView extends PureComponent {
 
   _renderConfig() {
     const { Col } = Grid;
-    const { step1Title, step1Description } = this.state;
+    const { step1Title, step1Description, seekableStates } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
         <Col span={6}>
           <div className={cssClass.CONFIG}>
             <TextInput
-              className={cssClass.CONFIG_OPTIONS}
               onChange={(e) => this.setState({ step1Title: e.target.value })}
               label="Step 1 Title"
               name="StepperView--title"
@@ -163,13 +162,24 @@ export default class StepperView extends PureComponent {
           </div>
           <div className={cssClass.CONFIG}>
             <TextArea
-              className={cssClass.CONFIG_OPTIONS}
               onChange={(e) => this.setState({ step1Description: e.target.value })}
               label="Step 1 Description"
               name="StepperView--description"
               placeholder="Step 1 Description"
               value={step1Description}
               autoResize
+            />
+          </div>
+          <div className={cssClass.CONFIG}>
+            <MultiSelect
+              name="StepperView--seekableStatesSelect"
+              label="Seekable states"
+              options={[{ value: "INCOMPLETE" }, { value: "SUCCESS" }, { value: "WARNING" }]}
+              clearable
+              values={seekableStates}
+              onChange={(v) => {
+                this.setState({ seekableStates: v });
+              }}
             />
           </div>
         </Col>
@@ -179,19 +189,10 @@ export default class StepperView extends PureComponent {
   }
 
   _renderCheckboxes() {
-    const { seekable, step1State, step1Optional } = this.state;
+    const { step1State, step1Optional } = this.state;
 
     return (
       <div className={cssClass.CHECKBOX_GROUP}>
-        <label className={cssClass.CONFIG}>
-          <input
-            type="checkbox"
-            checked={seekable}
-            className={cssClass.CONFIG_TOGGLE}
-            onChange={(e) => this.setState({ seekable: e.target.checked })}
-          />{" "}
-          seekable
-        </label>
         <label className={cssClass.CONFIG}>
           <input
             type="checkbox"
@@ -256,6 +257,11 @@ export default class StepperView extends PureComponent {
               description: "The id of the current step",
               defaultValue: 0,
               optional: true,
+            },
+            {
+              name: "seekableStates",
+              type: 'Array<"INCOMPLETE" | "SUCCESS" | "WARNING">',
+              description: "States which are seekable",
             },
             {
               name: "onStepClick",

--- a/docs/components/StepperView.jsx
+++ b/docs/components/StepperView.jsx
@@ -149,7 +149,7 @@ export default class StepperView extends PureComponent {
     const { step1Title, step1Description, seekableStates } = this.state;
 
     return (
-      <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
+      <FlexBox className={cssClass.CONFIG_CONTAINER} wrap>
         <Col span={6}>
           <div className={cssClass.CONFIG}>
             <TextInput

--- a/docs/components/StepperView.less
+++ b/docs/components/StepperView.less
@@ -17,8 +17,6 @@
 }
 
 .StepperView--config {
-  .flexbox;
-  .items--center;
   .margin--bottom--m;
   .margin--right--m;
   .text--caps;
@@ -27,11 +25,7 @@
 
 label.StepperView--config {
   cursor: pointer;
-}
-
-.StepperView--configOptions {
-  .margin--left--2xs;
-  display: inline-block;
+  display: block;
 }
 
 .StepperView--configToggle {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.99.0",
+  "version": "2.100.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Stepper/Step.tsx
+++ b/src/Stepper/Step.tsx
@@ -7,7 +7,7 @@ import CheckMark from "./CheckMark";
 import { FlexBox } from "../flex";
 import Exclamation from "./Exclamation";
 
-type StepState = "INCOMPLETE" | "SUCCESS" | "WARNING";
+export type StepState = "INCOMPLETE" | "SUCCESS" | "WARNING";
 
 export interface Props {
   className?: string;

--- a/src/Stepper/Stepper.tsx
+++ b/src/Stepper/Stepper.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
-import * as PropTypes from "prop-types";
 
-import Step, { Props as StepProps } from "./Step";
+import Step, { Props as StepProps, StepState } from "./Step";
 
 import "./Stepper.less";
 
@@ -9,37 +8,17 @@ export interface Props {
   className?: string;
   steps: StepProps[];
   currentStepID: string;
+  seekableStates?: StepState[];
   onStepClick?: StepProps["onClick"];
 }
-
-const propTypes = {
-  className: PropTypes.string,
-  steps: PropTypes.arrayOf(
-    PropTypes.shape({
-      className: PropTypes.string,
-      title: PropTypes.string,
-      description: PropTypes.node,
-      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-      warning: PropTypes.string,
-      state: PropTypes.oneOf(["INCOMPLETE", "SUCCESS", "WARNING"]),
-      current: PropTypes.bool,
-      optional: PropTypes.bool,
-      onClick: PropTypes.func,
-    }),
-  ).isRequired,
-  currentStepID: PropTypes.string.isRequired,
-  onStepClick: PropTypes.func,
-};
 
 const cssClass = {
   STEPS_DISPLAY: "Stepper--stepsDisplay",
 };
 
 export default class Stepper extends React.PureComponent<Props> {
-  static propTypes = propTypes;
-
   render() {
-    const { currentStepID, steps, onStepClick, className } = this.props;
+    const { currentStepID, steps, seekableStates, onStepClick, className } = this.props;
     return (
       <ul className={cssClass.STEPS_DISPLAY}>
         {steps.map((step, idx) => (
@@ -54,7 +33,7 @@ export default class Stepper extends React.PureComponent<Props> {
               current={step.id === currentStepID}
               warning={step.warning}
               optional={step.optional}
-              onClick={onStepClick}
+              onClick={!seekableStates || seekableStates.includes(step.state) ? onStepClick : null}
             />
           </li>
         ))}


### PR DESCRIPTION
**Overview:**
Instead of making the entire stepper seekable via passing an optional function, make it so that we can set seekable states on the stepper itself

**Screenshots/GIFs:**

https://user-images.githubusercontent.com/13126257/115938731-6f810f00-a450-11eb-98e5-b5fd83f0411c.mov

**Testing:**

- [] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
