### PR TITLE
Add optional tooltip for truncated text component

### DIFF
--- a/docs/components/TextTruncateView.jsx
+++ b/docs/components/TextTruncateView.jsx
@@ -29,6 +29,7 @@ export default class TextTruncateView extends React.PureComponent {
     showMoreLabel: "Show more",
     showLessLabel: "Show less",
     showLongText: true,
+    showTooltip: false,
     useRichText: false,
   };
 
@@ -40,7 +41,14 @@ export default class TextTruncateView extends React.PureComponent {
   }
 
   render() {
-    const { maxCharsShown, showMoreLabel, showLessLabel, showLongText, useRichText } = this.state;
+    const {
+      maxCharsShown,
+      showMoreLabel,
+      showLessLabel,
+      showLongText,
+      showTooltip,
+      useRichText,
+    } = this.state;
 
     return (
       <View
@@ -66,6 +74,7 @@ export default class TextTruncateView extends React.PureComponent {
               maxCharsShown={maxCharsShown}
               showMoreLabel={showMoreLabel}
               showLessLabel={showLessLabel}
+              showTooltip={showTooltip}
               useRichText={useRichText}
               text={showLongText ? this.longText : this.shortText}
             />
@@ -79,7 +88,14 @@ export default class TextTruncateView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { showLongText, maxCharsShown, showMoreLabel, showLessLabel, useRichText } = this.state;
+    const {
+      showLongText,
+      maxCharsShown,
+      showMoreLabel,
+      showLessLabel,
+      showTooltip,
+      useRichText,
+    } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -118,6 +134,18 @@ export default class TextTruncateView extends React.PureComponent {
               { content: "1000", value: "1000" },
             ]}
             value={`${maxCharsShown}`}
+          />
+        </div>
+        <div className={cssClass.CONFIG}>
+          Tooltip:
+          <SegmentedControl
+            className={cssClass.CONFIG_OPTIONS}
+            onSelect={(value) => this.setState({ showTooltip: value === "show" })}
+            options={[
+              { content: "None", value: "none" },
+              { content: "Show", value: "show" },
+            ]}
+            value={showTooltip ? "show" : "none"}
           />
         </div>
         <div className={cssClass.CONFIG}>
@@ -172,6 +200,13 @@ export default class TextTruncateView extends React.PureComponent {
             type: "string",
             description: "Text for 'show less' clickable toggle",
             defaultValue: "Show less",
+            optional: true,
+          },
+          {
+            name: "showTooltip",
+            type: "boolean",
+            description: "Whether to show a tooltip of the entire text when the text is truncated",
+            defaultValue: "false",
             optional: true,
           },
           {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.101.0",
+  "version": "2.102.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextTruncate/TextTruncate.tsx
+++ b/src/TextTruncate/TextTruncate.tsx
@@ -107,7 +107,11 @@ export default class TextTruncate extends React.PureComponent<Props> {
     );
 
     if (showTooltip) {
-      return <Tooltip content={text}>{truncatedText}</Tooltip>;
+      return (
+        <Tooltip content={text} placement={Tooltip.Placement.BOTTOM}>
+          {truncatedText}
+        </Tooltip>
+      );
     }
     return truncatedText;
   }

--- a/src/TextTruncate/TextTruncate.tsx
+++ b/src/TextTruncate/TextTruncate.tsx
@@ -4,12 +4,14 @@ import * as React from "react";
 
 import { Button } from "../Button/Button";
 import RichText from "../RichText/RichText";
+import Tooltip from "../Tooltip";
 
 export interface Props {
   className?: string;
   text: string;
   showMoreLabel?: string;
   showLessLabel?: string;
+  showTooltip?: boolean;
   lines?: number;
   maxCharsShown?: number;
   useRichText?: boolean;
@@ -21,6 +23,7 @@ const propTypes = {
   text: PropTypes.string.isRequired,
   showMoreLabel: PropTypes.string,
   showLessLabel: PropTypes.string,
+  showTooltip: PropTypes.node,
   lines: PropTypes.number,
   maxCharsShown: PropTypes.number,
   useRichText: PropTypes.bool,
@@ -31,6 +34,7 @@ const defaultProps = {
   maxCharsShown: 300,
   showMoreLabel: "Show more",
   showLessLabel: "Show less",
+  showTooltip: false,
   useRichText: false,
 };
 
@@ -66,6 +70,7 @@ export default class TextTruncate extends React.PureComponent<Props> {
       text,
       showMoreLabel,
       showLessLabel,
+      showTooltip,
       maxCharsShown,
       useRichText,
       name,
@@ -77,7 +82,9 @@ export default class TextTruncate extends React.PureComponent<Props> {
       return null;
     }
 
-    if (text.length < maxCharsShown) {
+    const isTextTruncated = text.length > maxCharsShown;
+
+    if (!isTextTruncated) {
       return (
         <div className={classnames(cssClass.CONTAINER, className)}>
           {useRichText ? <RichText text={text} /> : text}
@@ -87,7 +94,7 @@ export default class TextTruncate extends React.PureComponent<Props> {
 
     const displayText = truncated ? `${this.truncate(text)}…` : text;
     const toggleText = truncated ? showMoreLabel : showLessLabel;
-    return (
+    const truncatedText = (
       <div className={classnames(cssClass.CONTAINER, className)}>
         {useRichText ? <RichText text={displayText} /> : displayText}{" "}
         <Button
@@ -98,5 +105,10 @@ export default class TextTruncate extends React.PureComponent<Props> {
         />
       </div>
     );
+
+    if (showTooltip) {
+      return <Tooltip content={text}>{truncatedText}</Tooltip>;
+    }
+    return truncatedText;
   }
 }


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/PRTL-380

**Overview:**
Optionally add a tooltip for TextTruncate component (only when the text is truncated).

This change was prompted from messaging chat sidebar work for displaying contact info but not wanting it to take up any more than one line in case the text was too long.
![image](https://user-images.githubusercontent.com/21094551/116273704-9d639d80-a747-11eb-92ea-c2ee2a89bc5a.png)


**Screenshots/GIFs:**
![image](https://user-images.githubusercontent.com/21094551/116192420-724f5e80-a6f3-11eb-86a1-9d2a3f132cbb.png)


**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
