### PR TITLE
don't use async in View files

### DIFF
--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -612,13 +612,14 @@ export default class Table2BetaView extends React.PureComponent {
               this._lazyTable = t;
             }}
             lazy
-            getData={async ({ startingAfter, pageSize }) => {
+            getData={({ startingAfter, pageSize }) => {
               let start = 0;
               if (startingAfter != null) {
                 start = _.findIndex(tableData, (r) => r.id === startingAfter) + 1;
               }
-              await new Promise((resolve) => setTimeout(resolve, 1000));
-              return tableData.slice(start, start + pageSize);
+              return new Promise((resolve) => setTimeout(resolve, 1000)).then(() =>
+                tableData.slice(start, start + pageSize),
+              );
             }}
             firstSortDirection={Table2Beta.sortDirection.DESCENDING}
             numRows={tableData.length}

--- a/docs/components/TableView.jsx
+++ b/docs/components/TableView.jsx
@@ -449,13 +449,14 @@ export default class TableView extends PureComponent {
               this._lazyTable = t;
             }}
             lazy
-            getData={async ({ startingAfter, pageSize }) => {
+            getData={({ startingAfter, pageSize }) => {
               let start = 0;
               if (startingAfter != null) {
                 start = _.findIndex(tableData, (r) => r.id === startingAfter) + 1;
               }
-              await new Promise((resolve) => setTimeout(resolve, 1000));
-              return tableData.slice(start, start + pageSize);
+              return new Promise((resolve) => setTimeout(resolve, 1000)).then(() =>
+                tableData.slice(start, start + pageSize),
+              );
             }}
             firstSortDirection={Table.sortDirection.DESCENDING}
             numRows={tableData.length}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.100.0",
+  "version": "2.101.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Overview:**
In moving to reduce build times, it looks like we removed this babel plugin that supported async/await (https://github.com/Clever/components/pull/599/files#diff-379120de71991cfea15f15a1225d1ba83a7a50e55a356c831f5f5e0be305ce0bL16). This is causing an error with async/await calls in the TableView.jsx and Table2BetaView.jsx

It looks like we're using typescript to compile/build the main components so this would only affect View components, so as a workaround right now, I've just convert the async/await calls to return a Promise. The reason why we haven't been able convert the View files to typescript/tsx is because we rely on some special babel transform to render our `<Example>` components (https://github.com/Clever/components/blob/d94a59a973bab8c717eebe9c0ef6461e2f366be7/transform-code-string.js). In theory we should be able to have ts-loader load this custom babel transform, and then move completely to typescript, but for now I've just remove the async/await code in the View.

In the long term, I would want to take a look at ts-loader using the babel plugin, which would also give us all the niceties of type safety and stuff in the View files.

**Screenshots/GIFs:**
![image](https://user-images.githubusercontent.com/13126257/116172050-dc99dc00-a6be-11eb-919e-42417dd6de0f.png)
![image](https://user-images.githubusercontent.com/13126257/116172072-e8859e00-a6be-11eb-90bc-a5459f742362.png)

Verified that lazy loading Tables work:
![image](https://user-images.githubusercontent.com/13126257/116173101-cee55600-a6c0-11eb-8fbc-24ece8d5082f.png)


**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
