### PR TITLE
M5G-278: word-break: normal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.103.0",
+  "version": "2.104.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -73,7 +73,6 @@ button.NormalAnnouncementBubble--menuIconContainer {
   .margin--top--m();
   .text--line-height-4();
   white-space: pre-wrap;
-  // TODO: Remove? Does Dewey work on IE?
   word-wrap: break-word; // IE version
   word-break: normal;
   overflow-wrap: anywhere;

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -73,8 +73,9 @@ button.NormalAnnouncementBubble--menuIconContainer {
   .margin--top--m();
   .text--line-height-4();
   white-space: pre-wrap;
+  // TODO: Remove? Does Dewey work on IE?
   word-wrap: break-word; // IE version
-  word-break: break-all; // Safari version
+  word-break: normal;
   overflow-wrap: anywhere;
 
   .LinkifyUtils--Link,

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -54,8 +54,10 @@
   .margin--y--xs();
   // Handle whitespace characters
   white-space: pre-wrap;
+  // TODO: Remove? Does Dewey work on IE?
+  // TODO: Remove?
   word-wrap: break-word; // IE version
-  word-break: break-all; // Safari version
+  word-break: normal;
   overflow-wrap: anywhere;
 }
 

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -54,8 +54,6 @@
   .margin--y--xs();
   // Handle whitespace characters
   white-space: pre-wrap;
-  // TODO: Remove? Does Dewey work on IE?
-  // TODO: Remove?
   word-wrap: break-word; // IE version
   word-break: normal;
   overflow-wrap: anywhere;


### PR DESCRIPTION
**Jira:** https://clever.atlassian.net/browse/M5G-278

**Overview:** Do not break words in AnnouncementBubbles unless necessary (i.e. if a word is longer than the line).

**Screenshots/GIFs:**

NormalAnnouncementBubble before
![Screen Shot 2021-04-27 at 4 21 31 PM](https://user-images.githubusercontent.com/54862564/116324535-2e04a280-a775-11eb-802a-9a63bc25adc2.png)

NormalAnnouncementBubble after
![Screen Shot 2021-04-27 at 4 22 20 PM](https://user-images.githubusercontent.com/54862564/116324541-32c95680-a775-11eb-9bcd-0551614026de.png)

QuotedAnnouncementBubble before
![Screen Shot 2021-04-27 at 4 22 13 PM](https://user-images.githubusercontent.com/54862564/116324576-3eb51880-a775-11eb-92a5-f6a2218493e2.png)

QuotedAnnouncementBubble after
![Screen Shot 2021-04-27 at 4 22 31 PM](https://user-images.githubusercontent.com/54862564/116324584-41b00900-a775-11eb-9f74-f1c9edb19a55.png)

Mobile before
![Screen Shot 2021-04-27 at 4 24 30 PM](https://user-images.githubusercontent.com/54862564/116324632-5096bb80-a775-11eb-85ff-4eadf119c900.png)

Mobile after
![Screen Shot 2021-04-27 at 4 24 38 PM](https://user-images.githubusercontent.com/54862564/116324635-52607f00-a775-11eb-859f-0d55f67b1dd0.png)

**Testing:**

- [ ] ~~Unit tests~~
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Edge
  - [ ] IE11

**Roll Out:**

100%

- Before merging:
  - [ ] ~~Updated docs~~
  - [x] Bumped version in `package.json`
    - New component or backward-compatible component feature change? Run `npm version minor`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
