### PR TITLE
AlertBox2 sub text

### DIFF
--- a/docs/components/AlertBox2View.jsx
+++ b/docs/components/AlertBox2View.jsx
@@ -12,6 +12,7 @@ import {
   ItemAlign,
   SegmentedControl,
   Label,
+  TextInput2,
 } from "src";
 
 import "./AlertBox2View.less";
@@ -34,6 +35,9 @@ export default class AlertBox2View extends React.PureComponent {
   state = {
     type: AlertBox2Type.CAUTION,
     isCloseable: false,
+    showButtons: false,
+    extraText:
+      "text inside child <p> tags will not be bolded. Check with your designer if you want to use this type of non-bolded text description. As a design convention at Clever, Alerts that are more than a single line are discouraged",
   };
 
   render() {
@@ -64,27 +68,32 @@ export default class AlertBox2View extends React.PureComponent {
             <AlertBox2
               className="my--custom--class"
               type={this.state.type}
+              buttons={
+                this.state.showButtons ? (
+                  <>
+                    <Button
+                      style={{ marginRight: "0.5rem" }}
+                      type="secondary"
+                      size="small"
+                      onClick={() => console.log("Clicked No!")}
+                    >
+                      No
+                    </Button>
+                    <Button type="primary" size="small" onClick={() => console.log("Clicked Yes!")}>
+                      Yes
+                    </Button>
+                  </>
+                ) : null
+              }
               isCloseable={this.state.isCloseable}
             >
-              <FlexBox justify={Justify.BETWEEN} alignItems={ItemAlign.CENTER}>
-                <p style={{ margin: "0" }}>
+              <div>
+                <div>
                   This is the box body. It can be any node.{" "}
                   <a href="/#/components/alert-box-2">look a link</a>!
-                </p>
-                <div>
-                  <Button
-                    style={{ marginRight: "0.5rem" }}
-                    type="secondary"
-                    size="small"
-                    onClick={() => console.log("Clicked No!")}
-                  >
-                    No
-                  </Button>
-                  <Button type="primary" size="small" onClick={() => console.log("Clicked Yes!")}>
-                    Yes
-                  </Button>
                 </div>
-              </FlexBox>
+                <p>{this.state.extraText}</p>
+              </div>
             </AlertBox2>
           </ExampleCode>
           {this._renderConfig()}
@@ -96,7 +105,7 @@ export default class AlertBox2View extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { type, isCloseable } = this.state;
+    const { type, isCloseable, showButtons, extraText } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -117,6 +126,24 @@ export default class AlertBox2View extends React.PureComponent {
           />{" "}
           <span className={cssClass.CONFIG_LABEL_TEXT}>isCloseable</span>
         </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            checked={showButtons}
+            className={cssClass.CONFIG_TOGGLE}
+            onChange={(e) => this.setState({ showButtons: e.target.checked })}
+          />{" "}
+          <span className={cssClass.CONFIG_LABEL_TEXT}>extra buttons</span>
+        </label>
+        <div className={cssClass.CONFIG}>
+          <TextInput2
+            className={cssClass.CONFIG_OPTIONS}
+            name="TextInput2View--labelTextInput"
+            label="Extra text"
+            onChange={(e) => this.setState({ extraText: e.target.value })}
+            value={extraText}
+          />
+        </div>
       </FlexBox>
     );
   }

--- a/docs/components/AlertBox2View.jsx
+++ b/docs/components/AlertBox2View.jsx
@@ -88,7 +88,7 @@ export default class AlertBox2View extends React.PureComponent {
               isCloseable={this.state.isCloseable}
             >
               <div>
-                <div>
+                <div style={{ marginBottom: "0.25rem" }}>
                   This is the box body. It can be any node.{" "}
                   <a href="/#/components/alert-box-2">look a link</a>!
                 </div>

--- a/docs/components/AlertBox2View.jsx
+++ b/docs/components/AlertBox2View.jsx
@@ -139,7 +139,7 @@ export default class AlertBox2View extends React.PureComponent {
           <TextInput2
             className={cssClass.CONFIG_OPTIONS}
             name="TextInput2View--labelTextInput"
-            label="Extra text"
+            label="Extra text (discouraged)"
             onChange={(e) => this.setState({ extraText: e.target.value })}
             value={extraText}
           />

--- a/docs/components/AlertBox2View.less
+++ b/docs/components/AlertBox2View.less
@@ -8,6 +8,11 @@
   .text--italic();
 }
 
+.my--custom--class p {
+  // override default styles for docs
+  max-width: 100%;
+}
+
 .AlertBox2View--configContainer {
   .border--top--l(@neutral_silver);
   .margin--top--xl;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.104.0",
+  "version": "2.105.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AlertBox2/AlertBox2.less
+++ b/src/AlertBox2/AlertBox2.less
@@ -55,7 +55,6 @@
 
   & p {
     .text--regular();
-    .margin--top--2xs();
   }
 }
 

--- a/src/AlertBox2/AlertBox2.less
+++ b/src/AlertBox2/AlertBox2.less
@@ -5,7 +5,6 @@
   .padding--m();
   .flexbox();
   .justify--between();
-  .items--center();
 
   &--critical {
     background-color: fade(@alert_red, 15%);
@@ -42,15 +41,27 @@
 
 .AlertBox2--contentContainer {
   .flexbox();
-  .items--center();
-  .flex--grow();
+  .items--baseline();
+}
+
+.AlertBox2--contentContainer--withButtons {
+  line-height: @size_xl;
 }
 
 .AlertBox2--content {
-  .flex--grow();
   .text--semi-bold();
   color: @neutral_dark_gray;
   .margin--left--m();
+
+  & p {
+    .text--regular();
+    .margin--top--2xs();
+  }
+}
+
+.AlertBox2--buttons {
+  .flexbox();
+  .items--baseline();
 }
 
 .AlertBox2--closeButton {
@@ -63,6 +74,7 @@
   opacity: 0.6;
   .text--medium();
   .margin--left--m();
+  .text--line-height-4();
 
   &:hover {
     opacity: 1;

--- a/src/AlertBox2/AlertBox2.tsx
+++ b/src/AlertBox2/AlertBox2.tsx
@@ -24,12 +24,16 @@ export interface Props {
   children: React.ReactNode;
   className?: string;
   type: AlertBox2Type;
+  // provide optional buttons separately because it affects the css spacing
+  buttons?: React.ReactNode;
   isCloseable?: boolean;
 }
 
 export const cssClass = {
   CONTAINER: "AlertBox2",
   CONTENT_CONTAINER: "AlertBox2--contentContainer",
+  CONTENT_CONTAINER_WITH_BUTTONS: "AlertBox2--contentContainer--withButtons",
+  ICON: "AlertBox2--icon",
   CONTENT: "AlertBox2--content",
   CLOSE_BUTTON: "AlertBox2--closeButton",
 };
@@ -37,7 +41,7 @@ export const cssClass = {
 /**
  * TODO: Add short description.
  */
-export const AlertBox2: React.FC<Props> = ({ children, className, type, isCloseable }) => {
+export const AlertBox2: React.FC<Props> = ({ children, className, type, buttons, isCloseable }) => {
   const [isClosed, setIsClosed] = useState(false);
 
   useEffect(() => {
@@ -50,12 +54,22 @@ export const AlertBox2: React.FC<Props> = ({ children, className, type, isClosea
 
   return (
     <div className={classnames(cssClass.CONTAINER, `AlertBox2--${type}`, className)}>
-      <div className={cssClass.CONTENT_CONTAINER}>
-        <FontAwesome fixedWidth name={ICON_MAP[type]} className={`AlertBox2--icon--${type}`} />
+      <div
+        className={classnames(
+          cssClass.CONTENT_CONTAINER,
+          !!buttons && cssClass.CONTENT_CONTAINER_WITH_BUTTONS,
+        )}
+      >
+        <FontAwesome
+          className={classnames(cssClass.ICON, `AlertBox2--icon--${type}`)}
+          fixedWidth
+          name={ICON_MAP[type]}
+        />
         <div className={cssClass.CONTENT}>{children}</div>
       </div>
-      {isCloseable && (
-        <div>
+      <div className="AlertBox2--buttons">
+        {buttons}
+        {isCloseable && (
           <button
             aria-label="Close"
             className={cssClass.CLOSE_BUTTON}
@@ -64,8 +78,8 @@ export const AlertBox2: React.FC<Props> = ({ children, className, type, isClosea
             {/* https://www.compart.com/en/unicode/U+2715 */}
             &#10005;
           </button>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
**Overview:**
https://clever.atlassian.net/wiki/spaces/DES/pages/1440153759/Banners+Component+Spec+formerly+Global+Alerts
https://www.figma.com/file/JliXKTlDzqAWO9oypH1Tuz/Dewey-design-workshop-templates?node-id=87%3A7833

According to the spec, we want to keep alerts as much as a single line bolded alert message as possible. However, talking to Georgia, she mentioned that for IDM we may need some extra non-bolded text since our product is so complicated.

So I added some support for non-bolded text as <p> tags in the children. The catch here is that adding any extra buttons to the content throws the spacing out of whack because the Dewey 1.0 buttons have a larger height than the line height of text. So I added buttons as an extra prop so we can adjust the layout if they are provided.

**Screenshots/GIFs:**

https://user-images.githubusercontent.com/13126257/116480285-e5f98480-a835-11eb-8ae5-fde98879b5af.mov

**Testing:**

- [] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
