### PR TITLE
TextTruncate and ExpandableContainer bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.105.0",
+  "version": "2.106.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ExpandableContainer/ExpandableContainer.less
+++ b/src/ExpandableContainer/ExpandableContainer.less
@@ -3,12 +3,14 @@
 .ExpandableContainer--container {
   background-color: @neutral_white;
   color: @neutral_dark_gray;
+  width: 100%;
 }
 
 .ExpandableContainer--title {
   .padding--left--l();
   .padding--right--2xs();
   .padding--y--xs();
+  cursor: pointer;
 
   &:focus,
   &:hover {

--- a/src/ExpandableContainer/ExpandableContainer.less
+++ b/src/ExpandableContainer/ExpandableContainer.less
@@ -25,5 +25,4 @@
 .ExpandableContainer--content {
   .padding--left--l();
   .padding--right--2xs();
-  .padding--y--xs();
 }

--- a/src/TextTruncate/TextTruncate.tsx
+++ b/src/TextTruncate/TextTruncate.tsx
@@ -23,7 +23,7 @@ const propTypes = {
   text: PropTypes.string.isRequired,
   showMoreLabel: PropTypes.string,
   showLessLabel: PropTypes.string,
-  showTooltip: PropTypes.node,
+  showTooltip: PropTypes.bool,
   lines: PropTypes.number,
   maxCharsShown: PropTypes.number,
   useRichText: PropTypes.bool,


### PR DESCRIPTION
**Jira:**
n/a

**Overview:**
Noticed some bugs from my previous 2 dewey PRs regarding TextTruncate and ExpandableContainer.
- Fix TextTruncate showTooltip prop type 
- Change some styling for ExpandableContainer so that it takes up the entire width of the parent container and has a pointer cursor on the clickable title/header. Also removes vertical padding; leaves that styling to the consumer to handle.

**Screenshots/GIFs:**

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
