### PR TITLE
Stepper "NEXT" state

### DIFF
--- a/docs/components/StepperView.jsx
+++ b/docs/components/StepperView.jsx
@@ -28,7 +28,7 @@ export default class StepperView extends PureComponent {
     step1Description: "Step description",
     step1State: "INCOMPLETE",
     step1Optional: false,
-    seekableStates: ["INCOMPLETE", "WARNING", "SUCCESS"],
+    seekableStates: ["NEXT", "WARNING", "SUCCESS"],
     currentStepID: "step3",
   };
 
@@ -83,13 +83,20 @@ export default class StepperView extends PureComponent {
         label: "4",
       },
       {
+        title: "Next step",
+        description: "This is the next step that should be completed",
+        state: "NEXT",
+        id: "step5",
+        label: "5",
+      },
+      {
         title: "Complete remaining semester rollover actions",
         description:
           "Complete our checklist to ensure students and teachers have a smooth transition after the holiday season",
         optional: true,
         state: "INCOMPLETE",
-        id: "step5",
-        label: "5",
+        id: "step6",
+        label: "6",
       },
     ];
 
@@ -174,7 +181,12 @@ export default class StepperView extends PureComponent {
             <MultiSelect
               name="StepperView--seekableStatesSelect"
               label="Seekable states"
-              options={[{ value: "INCOMPLETE" }, { value: "SUCCESS" }, { value: "WARNING" }]}
+              options={[
+                { value: "NEXT" },
+                { value: "INCOMPLETE" },
+                { value: "SUCCESS" },
+                { value: "WARNING" },
+              ]}
               clearable
               values={seekableStates}
               onChange={(v) => {
@@ -221,6 +233,15 @@ export default class StepperView extends PureComponent {
             }
           />{" "}
           Step 1 - warning
+        </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            checked={step1State === "NEXT"}
+            className={cssClass.CONFIG_TOGGLE}
+            onChange={() => this.setState({ step1State: "NEXT", step1Warning: null })}
+          />{" "}
+          Step 1 - next
         </label>
         <label className={cssClass.CONFIG}>
           <input

--- a/docs/components/StepperView.jsx
+++ b/docs/components/StepperView.jsx
@@ -29,7 +29,7 @@ export default class StepperView extends PureComponent {
     step1State: "INCOMPLETE",
     step1Optional: false,
     seekableStates: ["NEXT", "WARNING", "SUCCESS"],
-    currentStepID: "step3",
+    currentStepID: "step2",
   };
 
   jumpToStep(id) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.106.0",
+  "version": "2.107.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Stepper/Step.less
+++ b/src/Stepper/Step.less
@@ -80,6 +80,20 @@ button.Step {
   }
 }
 
+.Step--next {
+  .Step--icon {
+    background-color: @neutral_white;
+    .border--s(@primary_blue);
+    color: @primary_blue;
+  }
+
+  .Step--title,
+  .Step--description,
+  .Step--message--optional {
+    color: @neutral_dark_gray;
+  }
+}
+
 .Step--current {
   .Step--icon {
     background-color: @primary_blue;
@@ -124,6 +138,13 @@ button.Step {
   }
 }
 
+.Step--next:focus {
+  .Step--icon {
+    .border--s(@primary_blue);
+    color: @primary_blue;
+  }
+}
+
 .Step--current.Step--warning {
   .Step--icon {
     background-color: @primary_blue;
@@ -148,6 +169,14 @@ button.Step {
   .Step--icon {
     background-color: @alert_red_shade_2;
     .border--s(@alert_red_shade_2);
+  }
+}
+
+.Step--seekable.Step--next:hover {
+  .Step--icon {
+    background-color: @neutral_white;
+    .border--s(@primary_blue_shade_2);
+    color: @primary_blue_shade_2;
   }
 }
 

--- a/src/Stepper/Step.tsx
+++ b/src/Stepper/Step.tsx
@@ -7,7 +7,7 @@ import CheckMark from "./CheckMark";
 import { FlexBox } from "../flex";
 import Exclamation from "./Exclamation";
 
-export type StepState = "INCOMPLETE" | "SUCCESS" | "WARNING";
+export type StepState = "INCOMPLETE" | "SUCCESS" | "WARNING" | "NEXT";
 
 export interface Props {
   className?: string;
@@ -29,7 +29,7 @@ const propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.node,
   warning: PropTypes.string,
-  state: PropTypes.oneOf<StepState>(["INCOMPLETE", "SUCCESS", "WARNING"]),
+  state: PropTypes.oneOf<StepState>(["INCOMPLETE", "SUCCESS", "WARNING", "NEXT"]),
   current: PropTypes.bool,
   optional: PropTypes.bool,
   onClick: PropTypes.func,
@@ -42,6 +42,7 @@ const cssClass = {
   ICON: "Step--icon",
   MESSAGE_OPTIONAL: "Step--message--optional",
   MESSAGE_WARNING: "Step--message--warning",
+  NEXT: "Step--next",
   SEEKABLE: "Step--seekable",
   SUCCESS: "Step--success",
   TITLE: "Step--title",
@@ -68,6 +69,7 @@ export default class Step extends React.PureComponent<Props> {
       SUCCESS: <CheckMark />,
       WARNING: <Exclamation />,
       INCOMPLETE: label,
+      NEXT: label,
     };
     if (current) {
       return label;
@@ -92,6 +94,7 @@ export default class Step extends React.PureComponent<Props> {
       state === "SUCCESS" && cssClass.SUCCESS,
       current && cssClass.CURRENT,
       state === "WARNING" && cssClass.WARNING,
+      state === "NEXT" && cssClass.NEXT,
       onClick && cssClass.SEEKABLE,
     );
 


### PR DESCRIPTION
**Overview:**
We wanted to support a state for the most recent unfinished step, in the case that the user is seeking back to a previous finished step (seekable states added here https://github.com/Clever/components/pull/641)

figma design:
https://www.figma.com/file/IBVNvo2dI221k4Dye4Hg0S/Dewey-2.0-WIP?node-id=19767%3A3373
figma states here:
![image](https://user-images.githubusercontent.com/13126257/117097825-9a594600-ad21-11eb-9ffd-8ad955b88db3.png)

**Screenshots/GIFs:**
default:
![image](https://user-images.githubusercontent.com/13126257/117097971-020f9100-ad22-11eb-8d44-72e249d7322d.png)

hover:
![image](https://user-images.githubusercontent.com/13126257/117097979-0c318f80-ad22-11eb-8c8b-ccd56921c752.png)

focus:
![image](https://user-images.githubusercontent.com/13126257/117097992-16ec2480-ad22-11eb-9566-6833ba62a924.png)

active:
![image](https://user-images.githubusercontent.com/13126257/117098014-24091380-ad22-11eb-8f33-91fdc818c2b3.png)

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari (safari doesn't have focus events for buttons https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#clicking_and_focus)
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add an entry in `ComponentsView.componentsToDisplay` using this template:
      ```
      {
        componentLink: "<COMPONENT LINK>",
        componentImg: "<COMPONENT LINK>.png",
        componentName: "<COMPONENT NAME>",
        componentImgAlt: "A <COMPONENT NAME> component",
      },
      ```
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
