### PR TITLE
Select2 string values

### DIFF
--- a/docs/components/MultiSelectView.jsx
+++ b/docs/components/MultiSelectView.jsx
@@ -70,14 +70,14 @@ export default class MultiSelectView extends React.PureComponent {
               hideLabel={this.state.hideLabel}
               placeholder={this.state.placeholder}
               options={new Array(20).fill(0).map((_, i) => ({
-                value: `option_${i + 1}`,
-                content: (
+                label: `option ${i + 1}`,
+                customLabel: (
                   <FlexBox>
                     <FontAwesome style={{ marginRight: "8px" }} name="exclamation-triangle" />
                     <span>Option {i + 1}</span>
                   </FlexBox>
                 ),
-                searchKey: `option ${i + 1}`,
+                value: `option_${i + 1}_value`,
               }))}
               creatable={this.state.creatable}
               allowDuplicates={this.state.allowDuplicates}
@@ -126,17 +126,20 @@ export default class MultiSelectView extends React.PureComponent {
             name="TextInput2View--labelTextInput"
             label="Initial selected values"
             options={[
-              { value: "Option 1, Option 2" },
-              { value: "Option 2, Option 4" },
-              { value: "Option 4, Option 20" },
-              { value: "Option 1, Option 10, Option 11, Option 12" },
+              { label: "Option 1, Option 2", value: "option_1_value,option_2_value" },
+              { label: "Option 2, Option 4", value: "option_2_value,option_4_value" },
+              { label: "Option 4, Option 20", value: "option_4_value,option_20_value" },
+              {
+                label: "Option 1, Option 10, Option 11, Option 12",
+                value: "option_1_value,option_10_value,option_11_value,option_12_value",
+              },
             ]}
             clearable
             value={initialValuesSelect}
             onChange={(v) => {
               this.setState({
                 initialValuesSelect: v,
-                values: (v || "").split(", "),
+                values: (v || "").split(","),
               });
             }}
             size={FormElementSize.MEDIUM}

--- a/docs/components/MultiSelectView.jsx
+++ b/docs/components/MultiSelectView.jsx
@@ -234,11 +234,18 @@ export default class MultiSelectView extends React.PureComponent {
           },
           {
             name: "options",
-            type: (
-              <code>{"Array<{ value: string, content?: ReactNode, searchKey?: string }>"}</code>
+            type: <code>{"Array<{ value: string, label: string, customLabel?: ReactNode }>"}</code>,
+            description: (
+              <div>
+                List of options to be selected.
+                <ul>
+                  <li>'value' is the hidden string key</li>
+                  <li>if customLabel is not present, 'label' is used as the displayed content</li>
+                  <li>if customLabel is present, 'label' is used for searchability</li>
+                  <li>customLabel is an optional react node for custom rendering</li>
+                </ul>
+              </div>
             ),
-            description:
-              "List of options to be selected. 'value' is the string key and used for searchability by default, 'content' is an optional react node for custom rendering, 'searchKey' is an optional string to be used for searching",
             optional: true,
           },
           {
@@ -252,7 +259,8 @@ export default class MultiSelectView extends React.PureComponent {
             name: "values",
             type: "string[]",
             description:
-              "Set the selected values as a controlled component (also helpful for default states)",
+              "Set the selected values as a controlled component (also helpful for default states). These values must match one of the option's values",
+            optional: true,
           },
           {
             name: "onChange",

--- a/docs/components/Select2View.jsx
+++ b/docs/components/Select2View.jsx
@@ -64,14 +64,14 @@ export default class Select2View extends React.PureComponent {
               label={this.state.label}
               hideLabel={this.state.hideLabel}
               options={new Array(20).fill(0).map((_, i) => ({
-                value: `option_${i + 1}_value`,
-                content: (
+                label: `Option ${i + 1}`,
+                customLabel: (
                   <FlexBox>
                     <FontAwesome style={{ marginRight: "8px" }} name="exclamation-triangle" />
                     <span>Option {i + 1}</span>
                   </FlexBox>
                 ),
-                stringContent: `Option ${i + 1}`,
+                value: `option_${i + 1}_value`,
               }))}
               clearable={this.state.clearable}
               requirement={this.state.required ? "required" : ""}

--- a/docs/components/Select2View.jsx
+++ b/docs/components/Select2View.jsx
@@ -207,9 +207,22 @@ export default class Select2View extends React.PureComponent {
           },
           {
             name: "options",
-            type: <code>{"Array<{ value: string, content?: ReactNode }>"}</code>,
-            description:
-              "List of options to be selected. 'value' is the string key and used for searchability, 'content' is an optional react node for custom rendering",
+            type: <code>{"Array<{ value: string, label: string, customLabel?: ReactNode }>"}</code>,
+            description: (
+              <div>
+                List of options to be selected.
+                <ul>
+                  <li>'value' is the hidden string key</li>
+                  <li>
+                    'label' is used for what is displayed and used for searchability if customLabel
+                    is present
+                  </li>
+                  <li>customLabel is an optional react node for custom rendering</li>
+                </ul>
+                Note that for accessibility purposes, a selected item will be represented by its
+                'label' value in the input once it is selected
+              </div>
+            ),
             optional: true,
           },
           {
@@ -234,7 +247,7 @@ export default class Select2View extends React.PureComponent {
             name: "value",
             type: "string",
             description:
-              "Set the selected value as a controlled component (also helpful for default states)",
+              "Set the selected value as a controlled component (also helpful for default states). This must match one of the option's values. Set to null to unselect ",
           },
           {
             name: "onChange",

--- a/docs/components/Select2View.jsx
+++ b/docs/components/Select2View.jsx
@@ -64,13 +64,14 @@ export default class Select2View extends React.PureComponent {
               label={this.state.label}
               hideLabel={this.state.hideLabel}
               options={new Array(20).fill(0).map((_, i) => ({
-                value: `Option ${i + 1}`,
+                value: `option_${i + 1}_value`,
                 content: (
                   <FlexBox>
                     <FontAwesome style={{ marginRight: "8px" }} name="exclamation-triangle" />
                     <span>Option {i + 1}</span>
                   </FlexBox>
                 ),
+                stringContent: `Option ${i + 1}`,
               }))}
               clearable={this.state.clearable}
               requirement={this.state.required ? "required" : ""}
@@ -112,9 +113,9 @@ export default class Select2View extends React.PureComponent {
             className={cssClass.CONFIG_OPTIONS}
             options={[
               { content: "Empty", value: "" },
-              { content: "Option 1", value: "Option 1" },
-              { content: "Option 4", value: "Option 4" },
-              { content: "Option 20", value: "Option 20" },
+              { content: "Option 1", value: "option_1_value" },
+              { content: "Option 4", value: "option_4_value" },
+              { content: "Option 20", value: "option_20_value" },
             ]}
             value={value}
             onSelect={(v) => this.setState({ value: v })}

--- a/docs/components/StepperView.jsx
+++ b/docs/components/StepperView.jsx
@@ -182,10 +182,10 @@ export default class StepperView extends PureComponent {
               name="StepperView--seekableStatesSelect"
               label="Seekable states"
               options={[
-                { value: "NEXT" },
-                { value: "INCOMPLETE" },
-                { value: "SUCCESS" },
-                { value: "WARNING" },
+                { label: "NEXT", value: "NEXT" },
+                { label: "INCOMPLETE", value: "INCOMPLETE" },
+                { label: "SUCCESS", value: "SUCCESS" },
+                { label: "WARNING", value: "WARNING" },
               ]}
               clearable
               values={seekableStates}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.108.1",
+  "version": "2.109.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MultiSelect/MultiSelect.tsx
+++ b/src/MultiSelect/MultiSelect.tsx
@@ -80,7 +80,7 @@ export function getSelectableOptions(
   });
 
   const creatableOption = [];
-  if (creatable && !!inputValue && !hasExactMatch && selectableOptions.length === 0) {
+  if (creatable && !!inputValue && !hasExactMatch) {
     // add a dummy "add item X" placeholder
     // it will be special-case rendered and handled
     creatableOption.push({ value: ADD_NEW_ITEM_KEY });

--- a/src/MultiSelect/MultiSelect.tsx
+++ b/src/MultiSelect/MultiSelect.tsx
@@ -14,7 +14,7 @@ import "./MultiSelect.less";
 export const ADD_NEW_ITEM_KEY = "MultiSelect--addNewItem";
 
 // searchable text of this option is determined in the getSelectableOptions function
-type Option = { value: string; content?: React.ReactNode; searchKey?: string };
+type Option = { value: string; label: string; customLabel?: React.ReactNode };
 
 export interface Props {
   className?: string;
@@ -58,16 +58,13 @@ export function getSelectableOptions(
   selectedItems: Option[],
   inputValue: string,
   creatable: boolean,
-) {
+): Option[] {
   const selectedValues = new Set<string>(selectedItems.map((si) => si.value));
   const inputLowerCase = inputValue.toLocaleLowerCase();
 
   let hasExactMatch = false;
   const selectableOptions = options.filter((o) => {
-    const optionLowerCase = (typeof o.content === "string"
-      ? o.content
-      : o.searchKey || o.value
-    ).toLocaleLowerCase();
+    const optionLowerCase = o.label.toLocaleLowerCase();
     // small performance optimization to process exact match within the same iterator
     if (optionLowerCase === inputLowerCase) {
       hasExactMatch = true;
@@ -172,7 +169,7 @@ const MultiSelect: React.FC<Props> = ({
             setInputValue("");
             let newOption = selectedItem;
             if (selectedItem.value === ADD_NEW_ITEM_KEY) {
-              newOption = { value: inputValue };
+              newOption = { value: inputValue, label: inputValue };
               setOptions([...options, newOption]);
             }
             onChange([...selectedItems, newOption].map((o) => o.value));
@@ -220,7 +217,7 @@ const MultiSelect: React.FC<Props> = ({
               className={cssClass.SELECTED_ITEM_CONTAINER}
               {...getSelectedItemProps({ selectedItem: item, index: i })}
             >
-              {item.content || item.value}
+              {item.customLabel || item.label}
               <span
                 className={cssClass.SELECTED_ITEM_BUTTON}
                 onClick={(e) => {
@@ -281,7 +278,7 @@ const MultiSelect: React.FC<Props> = ({
                   key={`${o.value}${i}`}
                   {...getItemProps({ item: o, index: i })}
                 >
-                  {isAddNewItemOption ? `Add "${inputValue}"` : o.content || o.value}
+                  {isAddNewItemOption ? `Add "${inputValue}"` : o.customLabel || o.label}
                 </li>
               );
             })

--- a/src/MultiSelect/MultiSelect.tsx
+++ b/src/MultiSelect/MultiSelect.tsx
@@ -13,7 +13,7 @@ import "./MultiSelect.less";
 // export for testing
 export const ADD_NEW_ITEM_KEY = "MultiSelect--addNewItem";
 
-// value represents the searchable text of the option
+// searchable text of this option is determined in the getSelectableOptions function
 type Option = { value: string; content?: React.ReactNode; searchKey?: string };
 
 export interface Props {
@@ -64,7 +64,10 @@ export function getSelectableOptions(
 
   let hasExactMatch = false;
   const selectableOptions = options.filter((o) => {
-    const optionLowerCase = (o.searchKey || o.value).toLocaleLowerCase();
+    const optionLowerCase = (typeof o.content === "string"
+      ? o.content
+      : o.searchKey || o.value
+    ).toLocaleLowerCase();
     // small performance optimization to process exact match within the same iterator
     if (optionLowerCase === inputLowerCase) {
       hasExactMatch = true;

--- a/src/MultiSelect/MultiSelect.tsx
+++ b/src/MultiSelect/MultiSelect.tsx
@@ -55,11 +55,11 @@ export const cssClass = {
 // export for testing
 export function getSelectableOptions(
   options: Option[],
-  selectedItems: Option[],
+  selectedValues: string[],
   inputValue: string,
   creatable: boolean,
 ): Option[] {
-  const selectedValues = new Set<string>(selectedItems.map((si) => si.value));
+  const selectedValuesSet = new Set<string>(selectedValues);
   const inputLowerCase = inputValue.toLocaleLowerCase();
 
   let hasExactMatch = false;
@@ -71,7 +71,7 @@ export function getSelectableOptions(
     }
 
     return (
-      !selectedValues.has(o.value) &&
+      !selectedValuesSet.has(o.value) &&
       (inputValue === "" || optionLowerCase.includes(inputLowerCase))
     );
   });
@@ -117,7 +117,7 @@ const MultiSelect: React.FC<Props> = ({
 
   const selectableOptions = getSelectableOptions(
     options,
-    allowDuplicates ? [] : selectedItems,
+    allowDuplicates ? [] : values,
     inputValue,
     creatable,
   );

--- a/src/MultiSelect/MultiSelect_test.tsx
+++ b/src/MultiSelect/MultiSelect_test.tsx
@@ -10,7 +10,13 @@ describe("MultiSelect", () => {
 
   it("renders", () => {
     const myComponent = shallow(
-      <MultiSelect name="MultiSelect--name" label="testLabel" options={[{ value: "Option 1" }]} />,
+      <MultiSelect
+        name="MultiSelect--name"
+        label="testLabel"
+        options={[{ label: "Option 1", value: "Option 1" }]}
+        values={[]}
+        onChange={() => undefined}
+      />,
     );
 
     expect(myComponent.props().className).toMatch(cssClass.CONTAINER);
@@ -25,7 +31,9 @@ describe("MultiSelect", () => {
         className="my--custom--class"
         name="MultiSelect--name"
         label="testLabel"
-        options={[{ value: "Option 1" }]}
+        options={[{ label: "Option 1", value: "Option 1" }]}
+        values={[]}
+        onChange={() => undefined}
       />,
     );
 
@@ -49,10 +57,10 @@ describe("MultiSelect", () => {
     describe("not creatable", () => {
       it("returns original options when nothing is selected", () => {
         const options = [
-          { value: "testOption1" },
-          { value: "testOption2" },
-          { value: "testOption3" },
-          { value: "testOption4" },
+          { label: "Test Option 1", value: "testOption1" },
+          { label: "Test Option 2", value: "testOption2" },
+          { label: "Test Option 3", value: "testOption3" },
+          { label: "Test Option 4", value: "testOption4" },
         ];
         const results = getSelectableOptions(options, [], "", false);
         expect(results).toEqual(options);
@@ -60,45 +68,50 @@ describe("MultiSelect", () => {
 
       it("filters out selected options", () => {
         const options = [
-          { value: "testOption1" },
-          { value: "testOption2" },
-          { value: "testOption3" },
-          { value: "testOption4" },
+          { label: "Test Option 1", value: "testOption1" },
+          { label: "Test Option 2", value: "testOption2" },
+          { label: "Test Option 3", value: "testOption3" },
+          { label: "Test Option 4", value: "testOption4" },
         ];
-        const results = getSelectableOptions(options, options, "", false);
+        const results = getSelectableOptions(
+          options,
+          options.map((o) => o.value),
+          "",
+          false,
+        );
         expect(results).toEqual([]);
       });
 
       it("filters out options based on typed input", () => {
         const options = [
-          { value: "testOption1" },
-          { value: "testOption2" },
-          { value: "filtered1" },
-          { value: "filtered2" },
+          { label: "Test Option 1", value: "testOption1" },
+          { label: "Test Option 2", value: "testOption2" },
+          { label: "Filtered Option 1", value: "filtered1" },
+          { label: "Filtered Option 2", value: "filtered2" },
         ];
-        const results = getSelectableOptions(options, [], "option", false);
+        const results = getSelectableOptions(options, [], "test o", false);
         expect(results).toEqual(options.slice(0, 2));
       });
 
       it("filters out selected options and typed input", () => {
         const options = [
-          { value: "testOption1" },
-          { value: "testOption2" },
-          { value: "filtered1" },
-          { value: "filtered2" },
+          { label: "Test Option 1", value: "testOption1" },
+          { label: "Test Option 2", value: "testOption2" },
+          { label: "Filtered Option 1", value: "filtered1" },
+          { label: "Filtered Option 2", value: "filtered2" },
         ];
-        const results = getSelectableOptions(options, [{ value: "testOption2" }], "option", false);
-        expect(results).toEqual([{ value: "testOption1" }]);
+        const results = getSelectableOptions(options, ["testOption2"], "test o", false);
+        expect(results).toEqual([{ label: "Test Option 1", value: "testOption1" }]);
       });
     });
 
     describe("creatable", () => {
       it("adds ADD_ITEM option when something unique is typed", () => {
         const options = [
-          { value: "testOption1" },
-          { value: "testOption2" },
-          { value: "testOption3" },
-          { value: "testOption4" },
+          { label: "Test Option 1", value: "testOption1" },
+          { label: "Test Option 2", value: "testOption2" },
+          { label: "Test Option 3", value: "testOption3" },
+          { label: "Test Option 4", value: "testOption4" },
         ];
         const results = getSelectableOptions(options, [], "uniqueText", true);
         expect(results).toEqual([{ value: ADD_NEW_ITEM_KEY }]);
@@ -106,39 +119,39 @@ describe("MultiSelect", () => {
 
       it("does not add ADD_ITEM option when exact match is typed and item is selectable", () => {
         const options = [
-          { value: "testOption1" },
-          { value: "testOption2" },
-          { value: "testOption3" },
-          { value: "testOption4" },
+          { label: "Test Option 1", value: "testOption1" },
+          { label: "Test Option 2", value: "testOption2" },
+          { label: "Test Option 3", value: "testOption3" },
+          { label: "Test Option 4", value: "testOption4" },
         ];
-        const results = getSelectableOptions(options, [], "testOption1", true);
-        expect(results).toEqual([{ value: "testOption1" }]);
+        const results = getSelectableOptions(options, [], "Test Option 1", true);
+        expect(results).toEqual([{ label: "Test Option 1", value: "testOption1" }]);
       });
 
       it("does not add ADD_ITEM option when exact match is typed and item is already selected", () => {
         const options = [
-          { value: "testOption1" },
-          { value: "testOption2" },
-          { value: "testOption3" },
-          { value: "testOption4" },
+          { label: "Test Option 1", value: "testOption1" },
+          { label: "Test Option 2", value: "testOption2" },
+          { label: "Test Option 3", value: "testOption3" },
+          { label: "Test Option 4", value: "testOption4" },
         ];
-        const results = getSelectableOptions(
-          options,
-          [{ value: "testOption1" }],
-          "testOption1",
-          true,
-        );
+        const results = getSelectableOptions(options, ["testOption1"], "Test Option 1", true);
         expect(results).toEqual([]);
       });
 
       it("does not add ADD_ITEM option when all items filtered but no input value", () => {
         const options = [
-          { value: "testOption1" },
-          { value: "testOption2" },
-          { value: "testOption3" },
-          { value: "testOption4" },
+          { label: "Test Option 1", value: "testOption1" },
+          { label: "Test Option 2", value: "testOption2" },
+          { label: "Test Option 3", value: "testOption3" },
+          { label: "Test Option 4", value: "testOption4" },
         ];
-        const results = getSelectableOptions(options, options, "", true);
+        const results = getSelectableOptions(
+          options,
+          options.map((o) => o.value),
+          "",
+          true,
+        );
         expect(results).toEqual([]);
       });
     });

--- a/src/Select2/Select2.tsx
+++ b/src/Select2/Select2.tsx
@@ -9,8 +9,14 @@ import { Values } from "../utils/types";
 
 import "./Select2.less";
 
-// value represents the searchable text of the option
-type Option = { value: string; content?: React.ReactNode };
+// for accessibility purposes, downshift only allows us to render a string value in the <input> tag
+// so for custom rendered components we still need a string value
+// see https://www.downshift-js.com/use-combobox#materialui
+type Option = { value: string; content?: React.ReactNode; stringContent?: string };
+
+function itemToString(o: Option): string {
+  return typeof o.content === "string" ? o.content : o.stringContent || o.value;
+}
 
 export interface Props {
   className?: string;
@@ -89,7 +95,7 @@ const Select2: React.FC<Props> = ({
     selectedItem,
   } = useCombobox<Option>({
     items: selectableOptions,
-    itemToString: (o) => (o ? o.value : ""),
+    itemToString: (o) => (o ? itemToString(o) : ""),
     selectedItem: options.find((o) => o.value === value) || null,
     stateReducer: (state, actionAndChanges) => {
       const { changes, type } = actionAndChanges;
@@ -100,7 +106,7 @@ const Select2: React.FC<Props> = ({
           return {
             ...changes,
             selectedItem,
-            inputValue: selectedItem ? selectedItem.value : "",
+            inputValue: selectedItem ? itemToString(selectedItem) : "",
           };
         }
         default:
@@ -123,7 +129,9 @@ const Select2: React.FC<Props> = ({
     },
     onInputValueChange: ({ inputValue: v }) => {
       const inputLowerCase = v.toLowerCase();
-      setSelectableOptions(options.filter((o) => o.value.toLowerCase().includes(inputLowerCase)));
+      setSelectableOptions(
+        options.filter((o) => itemToString(o).toLowerCase().includes(inputLowerCase)),
+      );
     },
     onSelectedItemChange: (item) => {
       if (onChange) {
@@ -226,7 +234,7 @@ const Select2: React.FC<Props> = ({
                 key={`${o.value}${i}`}
                 {...getItemProps({ item: o, index: i })}
               >
-                {o.content || o.value}
+                {o.content || itemToString(o)}
               </li>
             ))
           ) : (

--- a/src/Select2/Select2.tsx
+++ b/src/Select2/Select2.tsx
@@ -12,11 +12,7 @@ import "./Select2.less";
 // for accessibility purposes, downshift only allows us to render a string value in the <input> tag
 // so for custom rendered components we still need a string value
 // see https://www.downshift-js.com/use-combobox#materialui
-type Option = { value: string; content?: React.ReactNode; stringContent?: string };
-
-function itemToString(o: Option): string {
-  return typeof o.content === "string" ? o.content : o.stringContent || o.value;
-}
+type Option = { value: string; label: string; customLabel?: React.ReactNode };
 
 export interface Props {
   className?: string;
@@ -95,7 +91,7 @@ const Select2: React.FC<Props> = ({
     selectedItem,
   } = useCombobox<Option>({
     items: selectableOptions,
-    itemToString: (o) => (o ? itemToString(o) : ""),
+    itemToString: (o) => (o ? o.label : ""),
     selectedItem: options.find((o) => o.value === value) || null,
     stateReducer: (state, actionAndChanges) => {
       const { changes, type } = actionAndChanges;
@@ -106,7 +102,7 @@ const Select2: React.FC<Props> = ({
           return {
             ...changes,
             selectedItem,
-            inputValue: selectedItem ? itemToString(selectedItem) : "",
+            inputValue: selectedItem ? selectedItem.label : "",
           };
         }
         default:
@@ -129,9 +125,7 @@ const Select2: React.FC<Props> = ({
     },
     onInputValueChange: ({ inputValue: v }) => {
       const inputLowerCase = v.toLowerCase();
-      setSelectableOptions(
-        options.filter((o) => itemToString(o).toLowerCase().includes(inputLowerCase)),
-      );
+      setSelectableOptions(options.filter((o) => o.label.toLowerCase().includes(inputLowerCase)));
     },
     onSelectedItemChange: (item) => {
       if (onChange) {
@@ -234,7 +228,7 @@ const Select2: React.FC<Props> = ({
                 key={`${o.value}${i}`}
                 {...getItemProps({ item: o, index: i })}
               >
-                {o.content || itemToString(o)}
+                {o.customLabel || o.label}
               </li>
             ))
           ) : (

--- a/src/Select2/Select2_test.tsx
+++ b/src/Select2/Select2_test.tsx
@@ -10,7 +10,13 @@ describe("Select2", () => {
 
   it("renders", () => {
     const myComponent = shallow(
-      <Select2 name="Select2--name" label="testLabel" options={[{ value: "Option 1" }]} />,
+      <Select2
+        name="Select2--name"
+        label="testLabel"
+        options={[{ label: "Option 1", value: "Option 1" }]}
+        value={null}
+        onChange={() => undefined}
+      />,
     );
 
     expect(myComponent.props().className).toMatch(cssClass.CONTAINER);
@@ -25,7 +31,9 @@ describe("Select2", () => {
         className="my--custom--class"
         name="Select2--name"
         label="testLabel"
-        options={[{ value: "Option 1" }]}
+        options={[{ label: "Option 1", value: "Option 1" }]}
+        value={null}
+        onChange={() => undefined}
       />,
     );
 


### PR DESCRIPTION
## Overview
I have 2 main points here. Would love your thoughts/comments:

### Point 1
* For Select2 and Multiselect, the base `option.value` may not always represent the display value, so we need a reactContent type of prop for display purposes in the options
* The `option.value` may not always represent the searchable value, and if the custom react rendered value doesn't match the value, then it may be confusing for the user (addressed here https://github.com/Clever/components/pull/634)
  * For example, we have `name.first` as the value, but we need `First name` with an icon as the display and the user needs to be able to search for `First name`, and `name.` should not show any results
* for accessibility purposes, downshift also requires only a string representation of the option value to be put into the `<input>` tag
* ~My current hacky implementation is to determine an option's string value based on an implicit order, but it's kind of janky~
  * EDIT: updated with new code

### Point 2 
Taking a step back and looking what the ideal state would be, I think that leads me back to the more common triple prop set:
* label, or stringValue (required)
* key, or value (required)
* customLabel (optional)

That would allow us to have a base string key and value, with an optional react rendered prop where it is clear that it is for display purposes only. If that sounds good I will take a stab at that type of implementation.

Open to other thoughts if you have any and also other naming options here.

### Bonus change
I made it so that the create option for multi-select shows even if there are other results. The use case I need this for is something like `sis_id` exists, and I want to add `id` to the options. I wouldn't be able to in the previous mode

## Screenshots/GIFs:
![image](https://user-images.githubusercontent.com/13126257/117240275-4c0d7b00-ade5-11eb-88a6-864789f0359b.png)
![image](https://user-images.githubusercontent.com/13126257/117240256-43b54000-ade5-11eb-8e1a-42d18af72a34.png)

![image](https://user-images.githubusercontent.com/13126257/117239759-3ba8d080-ade4-11eb-92c5-6b375366d580.png)

## Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
