### PR TITLE
wrap the icon in a div to make fixedWidth work

### DIFF
--- a/src/AlertBox2/AlertBox2.tsx
+++ b/src/AlertBox2/AlertBox2.tsx
@@ -60,11 +60,13 @@ export const AlertBox2: React.FC<Props> = ({ children, className, type, buttons,
           !!buttons && cssClass.CONTENT_CONTAINER_WITH_BUTTONS,
         )}
       >
-        <FontAwesome
-          className={classnames(cssClass.ICON, `AlertBox2--icon--${type}`)}
-          fixedWidth
-          name={ICON_MAP[type]}
-        />
+        <div>
+          <FontAwesome
+            className={classnames(cssClass.ICON, `AlertBox2--icon--${type}`)}
+            fixedWidth
+            name={ICON_MAP[type]}
+          />
+        </div>
         <div className={cssClass.CONTENT}>{children}</div>
       </div>
       <div className="AlertBox2--buttons">


### PR DESCRIPTION
**Overview:**
I think this is because FontAwesome uses a `::before` psuedo-element to render the icon, so wrapping it in a div helps, but I'm not 100% sure

**Screenshots/GIFs:**
before:

https://user-images.githubusercontent.com/13126257/117246276-369e4e00-adf1-11eb-9b2c-c4f3843a9dec.mov

after:

https://user-images.githubusercontent.com/13126257/117246293-3b630200-adf1-11eb-8b76-de44bf389fac.mov

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
