### PR TITLE
fix ordering of insertion of autogenerated code

### DIFF
--- a/bin/addRoute.ts
+++ b/bin/addRoute.ts
@@ -34,7 +34,9 @@ const addRoute: Transform = (file, api, options) => {
 
   // insert in an alphabetically ordered position
   let insertIndex = -1;
-  return j(file.source)
+
+  const root = j(file.source);
+  const nodeToInsertAt = root
     .findJSXElements("Route")
     .filter(j.filters.JSXElement.hasAttributes({ path: "components" }))
     .childElements()
@@ -69,10 +71,17 @@ const addRoute: Transform = (file, api, options) => {
         insertIndex = i;
       }
     })
-    .at(insertIndex)
-    .insertAfter(routeCode)
-    .insertAfter(newlineAST)
-    .toSource();
+    .at(insertIndex);
+
+  if (insertIndex === -1) {
+    nodeToInsertAt.insertAfter(routeCode);
+    nodeToInsertAt.insertAfter(newlineAST);
+  } else {
+    nodeToInsertAt.insertBefore(routeCode);
+    nodeToInsertAt.insertBefore(newlineAST);
+  }
+
+  return root.toSource({ wrapColumn: 100 });
 };
 
 // https://github.com/facebook/jscodeshift/issues/148#issuecomment-341366999

--- a/bin/addScreenshot.ts
+++ b/bin/addScreenshot.ts
@@ -1,7 +1,7 @@
 import * as _ from "lodash";
 import { Transform } from "jscodeshift";
 
-// https://astexplorer.net/#/gist/bc75762e3cd5e7f5286dc8949aff1f7e/3ded78255024c9aca20f95d3e8418cabfe904e7a
+// https://astexplorer.net/#/gist/851a55838151c274b233e5318d23bd68/0aa8af858342710749b755ae9512de491f24e02c
 const transform: Transform = (file, api, options) => {
   const j = api.jscodeshift;
 
@@ -33,7 +33,7 @@ const transform: Transform = (file, api, options) => {
   ]);
   // insert in an alphabetically ordered position
   let insertIndex = -1;
-  componentsToDisplay
+  const nodeToInsertAt = componentsToDisplay
     .find(j.ObjectExpression)
     .forEach((path, i) => {
       if (insertIndex !== -1) {
@@ -62,8 +62,13 @@ const transform: Transform = (file, api, options) => {
         insertIndex = i;
       }
     })
-    .at(insertIndex)
-    .insertAfter(objectCode);
+    .at(insertIndex);
+
+  if (insertIndex === -1) {
+    nodeToInsertAt.insertAfter(objectCode);
+  } else {
+    nodeToInsertAt.insertBefore(objectCode);
+  }
 
   return root.toSource({ wrapColumn: 100 });
 };

--- a/bin/addToSidebar.ts
+++ b/bin/addToSidebar.ts
@@ -22,7 +22,7 @@ const transform: Transform = (file, api, options) => {
 
   // insert in an alphabetically ordered position
   let insertIndex = -1;
-  navGroups
+  const nodeToInsertAt = navGroups
     // if we use .find() directly, we will also select the icon prop that uses a JSXExpressionContainer
     // as well as potentially other nested elements
     .childNodes()
@@ -52,9 +52,15 @@ const transform: Transform = (file, api, options) => {
         insertIndex = i;
       }
     })
-    .at(insertIndex)
-    .insertAfter(newLinkCode)
-    .insertAfter(newlineAST);
+    .at(insertIndex);
+
+  if (insertIndex === -1) {
+    nodeToInsertAt.insertAfter(newLinkCode);
+    nodeToInsertAt.insertAfter(newlineAST);
+  } else {
+    nodeToInsertAt.insertBefore(newLinkCode);
+    nodeToInsertAt.insertBefore(newlineAST);
+  }
 
   return root.toSource({ wrapColumn: 100 });
 };


### PR DESCRIPTION
Follow up to https://github.com/Clever/components/pull/595

There's a bug with the component ordering, since there are `N` existing entries in a list with `N+1` places to insert them.

Your comment here was very wise (https://github.com/Clever/components/pull/595#discussion_r602608162) and I once again don't have time to write them but I'm very interested in doing so later I promise 🙏 