### PR TITLE
Lighter shade for hover state of expandable container header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.107.0",
+  "version": "2.107.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ExpandableContainer/ExpandableContainer.less
+++ b/src/ExpandableContainer/ExpandableContainer.less
@@ -14,7 +14,7 @@
 
   &:focus,
   &:hover {
-    background: @neutral_silver;
+    background: @neutral_off_white;
   }
 }
 


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/PRTL-380
**Overview:**
Lighter shade for hover state of expandable container header. This way, it matches the Messaging ThreadList. 

**Screenshots/GIFs:**

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
