### PR TITLE
Vc/fix menuitem default type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.107.1",
+  "version": "2.108.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Menu/MenuItem.tsx
+++ b/src/Menu/MenuItem.tsx
@@ -83,7 +83,7 @@ export default class MenuItem extends React.PureComponent<Props> {
     let MenuButton = component;
     if (!MenuButton) {
       // Render disabled href elements as buttons so that they can be disabled
-      MenuButton = href || !disabled ? "a" : "button";
+      MenuButton = href && !disabled ? "a" : "button";
     }
 
     // Safari fires focusout events on button mousedown events - it basically removes and returns


### PR DESCRIPTION
MenuItem was defaulting `anchor` if the item was not disabled, but we want it to default to `button`.