### PR TITLE
Tabbable expandable container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.108.0",
+  "version": "2.108.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ExpandableContainer/ExpandableContainer.less
+++ b/src/ExpandableContainer/ExpandableContainer.less
@@ -6,7 +6,8 @@
   width: 100%;
 }
 
-.ExpandableContainer--title {
+button.ExpandableContainer--header {
+  color: @neutral_dark_gray;
   .padding--left--l();
   .padding--right--2xs();
   .padding--y--xs();
@@ -14,6 +15,7 @@
 
   &:focus,
   &:hover {
+    color: @neutral_dark_gray;
     background: @neutral_off_white;
   }
 }

--- a/src/ExpandableContainer/ExpandableContainer.less
+++ b/src/ExpandableContainer/ExpandableContainer.less
@@ -6,6 +6,15 @@
   width: 100%;
 }
 
+.ExpandableContainer--expandIcon {
+  .padding--xs();
+}
+
+.ExpandableContainer--content {
+  .padding--left--l();
+  .padding--right--2xs();
+}
+
 button.ExpandableContainer--header {
   color: @neutral_dark_gray;
   .padding--left--l();
@@ -18,13 +27,4 @@ button.ExpandableContainer--header {
     color: @neutral_dark_gray;
     background: @neutral_off_white;
   }
-}
-
-.ExpandableContainer--expandIcon {
-  .padding--xs();
-}
-
-.ExpandableContainer--content {
-  .padding--left--l();
-  .padding--right--2xs();
 }

--- a/src/ExpandableContainer/ExpandableContainer.tsx
+++ b/src/ExpandableContainer/ExpandableContainer.tsx
@@ -3,6 +3,7 @@ import * as FontAwesome from "react-fontawesome";
 import * as classnames from "classnames";
 import * as PropTypes from "prop-types";
 
+import { Button } from "../Button/Button";
 import FlexBox from "../flex/FlexBox";
 import FlexItem from "../flex/FlexItem";
 
@@ -18,7 +19,7 @@ export interface Props {
 
 const cssClass = {
   CONTAINER: "ExpandableContainer--container",
-  TITLE: "ExpandableContainer--title",
+  HEADER: "ExpandableContainer--header",
   CONTENT: "ExpandableContainer--content",
   EXPAND_ICON: "ExpandableContainer--expandIcon",
 };
@@ -32,14 +33,17 @@ export const ExpandableContainer: React.FC<Props> = ({
 }) => {
   return (
     <FlexBox column className={classnames(cssClass.CONTAINER, className)}>
-      <FlexBox alignItems="center" className={cssClass.TITLE} onClick={onClick}>
-        {title}
-        <FlexItem grow />
-        <FontAwesome
-          className={cssClass.EXPAND_ICON}
-          name={isExpanded ? "chevron-down" : "chevron-right"}
-        />
-      </FlexBox>
+      <Button className={cssClass.HEADER} type="linkPlain" onClick={onClick}>
+        <FlexBox tabIndex={-1} alignItems="center">
+          {title}
+          <FlexItem grow />
+          <FontAwesome
+            className={cssClass.EXPAND_ICON}
+            name={isExpanded ? "chevron-down" : "chevron-right"}
+          />
+        </FlexBox>
+      </Button>
+
       {isExpanded && <div className={cssClass.CONTENT}>{children}</div>}
     </FlexBox>
   );


### PR DESCRIPTION
**Jira:**
n/a

**Overview:**
Keyboard accessibility is important, this modifies the expandable container to be tabbable.

For anyone  curious [why I added tabIndex="-1" ](https://stackoverflow.com/questions/31402576/enable-focus-only-on-keyboard-use-or-tab-press), it allows the focus state (that we get for free with our Button component) to not apply to mouse clicks as it is a click on the inner element.

**Screenshots/GIFs:**
![Screen Recording 2021-05-12 at 11 28 24 PM](https://user-images.githubusercontent.com/21094551/118073747-74175400-b37a-11eb-9430-21b3a1fb2e8c.gif)


**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
