### PR TITLE
disabled Select2 state

### DIFF
--- a/docs/components/Select2View.jsx
+++ b/docs/components/Select2View.jsx
@@ -107,6 +107,15 @@ export default class Select2View extends React.PureComponent {
             value={label}
           />
         </div>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            className={cssClass.CONFIG_TOGGLE}
+            checked={hideLabel}
+            onChange={(e) => this.setState({ hideLabel: e.target.checked })}
+          />{" "}
+          <span className={cssClass.CONFIG_LABEL_TEXT}>Hide Label</span>
+        </label>
         <div className={cssClass.CONFIG}>
           <span className={cssClass.CONFIG_LABEL_TEXT}>Controlled selected value:</span>
           <SegmentedControl
@@ -121,15 +130,6 @@ export default class Select2View extends React.PureComponent {
             onSelect={(v) => this.setState({ value: v })}
           />
         </div>
-        <label className={cssClass.CONFIG}>
-          <input
-            type="checkbox"
-            className={cssClass.CONFIG_TOGGLE}
-            checked={hideLabel}
-            onChange={(e) => this.setState({ hideLabel: e.target.checked })}
-          />{" "}
-          <span className={cssClass.CONFIG_LABEL_TEXT}>Hide Label</span>
-        </label>
         <label className={cssClass.CONFIG}>
           <input
             type="checkbox"

--- a/docs/components/Select2View.jsx
+++ b/docs/components/Select2View.jsx
@@ -28,7 +28,7 @@ export default class Select2View extends React.PureComponent {
     label: "Select an option",
     hideLabel: false,
     clearable: true,
-    required: true,
+    requirement: FormElementRequirement.REQUIRED,
     initialIsInError: false,
     value: null,
     size: FormElementSize.MEDIUM,
@@ -74,7 +74,7 @@ export default class Select2View extends React.PureComponent {
                 value: `option_${i + 1}_value`,
               }))}
               clearable={this.state.clearable}
-              requirement={this.state.required ? "required" : ""}
+              requirement={this.state.requirement}
               initialIsInError={this.state.initialIsInError}
               onChange={(v) => {
                 console.log(`selected: ${v}`);
@@ -93,7 +93,7 @@ export default class Select2View extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { label, value, hideLabel, clearable, required, initialIsInError, size } = this.state;
+    const { label, value, hideLabel, clearable, requirement, initialIsInError, size } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -139,15 +139,20 @@ export default class Select2View extends React.PureComponent {
           />{" "}
           <span className={cssClass.CONFIG_LABEL_TEXT}>Clearable</span>
         </label>
-        <label className={cssClass.CONFIG}>
-          <input
-            type="checkbox"
-            checked={required}
-            className={cssClass.CONFIG_TOGGLE}
-            onChange={(e) => this.setState({ required: e.target.checked })}
-          />{" "}
-          <span className={cssClass.CONFIG_LABEL_TEXT}>Required</span>
-        </label>
+        <div className={cssClass.CONFIG}>
+          <span className={cssClass.CONFIG_TEXT}>Requirement:</span>
+          <SegmentedControl
+            className={cssClass.CONFIG_OPTIONS}
+            options={[
+              { content: "none", value: "" },
+              { content: "optional", value: FormElementRequirement.OPTIONAL },
+              { content: "required", value: FormElementRequirement.REQUIRED },
+              { content: "disabled", value: FormElementRequirement.DISABLED },
+            ]}
+            value={requirement}
+            onSelect={(v) => this.setState({ requirement: v })}
+          />
+        </div>
         <label className={cssClass.CONFIG}>
           <input
             type="checkbox"
@@ -233,7 +238,7 @@ export default class Select2View extends React.PureComponent {
           },
           {
             name: "requirement",
-            type: '"required"',
+            type: '"required", "optional", or "disabled"',
             description: "Indicator to note if the input is required",
             optional: true,
           },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.109.0",
+  "version": "2.110.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select2/Select2.less
+++ b/src/Select2/Select2.less
@@ -74,6 +74,14 @@
   &--error:hover {
     .border--m(@alert_red);
   }
+
+  &--disabled {
+    .border--m(@neutral_silver);
+  }
+
+  &--disabled:hover {
+    .border--m(@neutral_silver);
+  }
 }
 
 .Select2--selectContainer--focused.Select2--selectContainer--error {
@@ -103,6 +111,10 @@
 
   &:-ms-input-placeholder {
     color: @neutral_gray;
+  }
+
+  &:disabled {
+    background-color: @neutral_white;
   }
 }
 

--- a/src/Select2/Select2.tsx
+++ b/src/Select2/Select2.tsx
@@ -22,8 +22,7 @@ export interface Props {
   hideLabel?: boolean;
   options: Option[];
   clearable?: boolean;
-  // TODO: support all requirement types
-  requirement?: typeof FormElementRequirement.REQUIRED;
+  requirement?: Values<typeof FormElementRequirement>;
   initialIsInError?: boolean;
   value: string;
   onChange: (value: string) => void;
@@ -40,6 +39,7 @@ export const cssClass = {
   SELECT_CONTAINER: "Select2--selectContainer",
   SELECT_CONTAINER_FOCUSED: "Select2--selectContainer--focused",
   SELECT_CONTAINER_ERROR: "Select2--selectContainer--error",
+  SELECT_CONTAINER_DISABLED: "Select2--selectContainer--disabled",
   INPUT: "Select2--input",
   TRAILING_ELEMENT: "Select2--trailingElement",
   ERROR_ICON: "Select2--errorIcon",
@@ -159,9 +159,14 @@ const Select2: React.FC<Props> = ({
           cssClass.SELECT_CONTAINER,
           isOpen && cssClass.SELECT_CONTAINER_FOCUSED,
           isInError && cssClass.SELECT_CONTAINER_ERROR,
+          requirement === FormElementRequirement.DISABLED && cssClass.SELECT_CONTAINER_DISABLED,
         )}
         {...getComboboxProps({
           onClick: (e) => {
+            if (requirement === FormElementRequirement.DISABLED) {
+              e.stopPropagation();
+              return;
+            }
             if (!isOpen) {
               openMenu();
               if (inputRef.current) {
@@ -175,7 +180,11 @@ const Select2: React.FC<Props> = ({
           id={id}
           name={id}
           className={cssClass.INPUT}
-          {...getInputProps({ ref: inputRef, onFocus: () => setHasBeenFocused(true) })}
+          {...getInputProps({
+            ref: inputRef,
+            onFocus: () => setHasBeenFocused(true),
+            disabled: requirement === FormElementRequirement.DISABLED,
+          })}
         />
         {isInError && (
           <div className={classNames(cssClass.TRAILING_ELEMENT, cssClass.ERROR_ICON)}>
@@ -191,6 +200,10 @@ const Select2: React.FC<Props> = ({
             )}
             onClick={(e) => {
               e.stopPropagation();
+              if (requirement === FormElementRequirement.DISABLED) {
+                return;
+              }
+
               onChange(null);
               openMenu();
               if (inputRef.current) {
@@ -208,7 +221,7 @@ const Select2: React.FC<Props> = ({
             cssClass.TRAILING_ELEMENT,
             cssClass.CARET_BUTTON,
           )}
-          {...getToggleButtonProps()}
+          {...getToggleButtonProps({ disabled: requirement === FormElementRequirement.DISABLED })}
         >
           <FontAwesome name={isOpen ? "caret-up" : "caret-down"} />
         </button>


### PR DESCRIPTION
**Overview:**
Support optional and disabled requirements for Select2

**Screenshots/GIFs:**

https://user-images.githubusercontent.com/13126257/118107230-5a363b00-b393-11eb-986a-1aaca0866511.mov

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
