### PR TITLE
improve accessibility of select2 and multiselect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.111.0",
+  "version": "2.111.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MultiSelect/MultiSelect.less
+++ b/src/MultiSelect/MultiSelect.less
@@ -67,10 +67,13 @@
   box-sizing: border-box;
 }
 
-.MultiSelect--selectedItemContainer {
-  .flexbox();
+.MultiSelect--selectedItemWrapper {
   .margin--y--2xs();
   .margin--right--2xs();
+}
+
+.MultiSelect--selectedItemContainer {
+  .flexbox();
 }
 
 .MultiSelect--selectedItemButton {

--- a/src/MultiSelect/MultiSelect.tsx
+++ b/src/MultiSelect/MultiSelect.tsx
@@ -41,6 +41,7 @@ export const cssClass = {
   SELECT_CONTAINER: "MultiSelect--selectContainer",
   SELECT_CONTAINER_FOCUSED: "MultiSelect--selectContainer--focused",
   SELECTED_ITEMS_CONTAINER: "MultiSelect--selectedItemsContainer",
+  SELECTED_ITEM_WRAPPER: "MultiSelect--selectedItemWrapper",
   SELECTED_ITEM_CONTAINER: "MultiSelect--selectedItemContainer",
   SELECTED_ITEM_BUTTON: "MultiSelect--selectedItemButton",
   INPUT: "MultiSelect--input",
@@ -212,30 +213,33 @@ const MultiSelect: React.FC<Props> = ({
       >
         <div className={cssClass.SELECTED_ITEMS_CONTAINER}>
           {selectedItems.map((item, i) => (
-            <Label
+            // need this wrapper element to support downshift accessibility
+            <span
               key={`${item.value}${i}`}
-              className={cssClass.SELECTED_ITEM_CONTAINER}
+              className={cssClass.SELECTED_ITEM_WRAPPER}
               {...getSelectedItemProps({ selectedItem: item, index: i })}
             >
-              {item.customLabel || item.label}
-              <span
-                className={cssClass.SELECTED_ITEM_BUTTON}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onChange(
-                    [...selectedItems.slice(0, i), ...selectedItems.slice(i + 1)].map(
-                      (o) => o.value,
-                    ),
-                  );
-                  if (inputRef.current) {
-                    inputRef.current.select();
-                  }
-                }}
-              >
-                {/* https://www.compart.com/en/unicode/U+2715 */}
-                &#10005;
-              </span>
-            </Label>
+              <Label className={cssClass.SELECTED_ITEM_CONTAINER}>
+                {item.customLabel || item.label}
+                <span
+                  className={cssClass.SELECTED_ITEM_BUTTON}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onChange(
+                      [...selectedItems.slice(0, i), ...selectedItems.slice(i + 1)].map(
+                        (o) => o.value,
+                      ),
+                    );
+                    if (inputRef.current) {
+                      inputRef.current.select();
+                    }
+                  }}
+                >
+                  {/* https://www.compart.com/en/unicode/U+2715 */}
+                  &#10005;
+                </span>
+              </Label>
+            </span>
           ))}
           <input
             id={id}
@@ -245,7 +249,8 @@ const MultiSelect: React.FC<Props> = ({
             {...getInputProps(
               getDropdownProps({
                 ref: inputRef,
-                preventKeyAction: isOpen,
+                // prevents the user from navigating to the selected items when text is present
+                preventKeyAction: inputValue !== "",
                 onFocus: (e) => {
                   if (!isOpen) {
                     openMenu();

--- a/src/Select2/Select2.tsx
+++ b/src/Select2/Select2.tsx
@@ -97,6 +97,12 @@ const Select2: React.FC<Props> = ({
       const { changes, type } = actionAndChanges;
       switch (type) {
         case useCombobox.stateChangeTypes.InputKeyDownEscape:
+          return {
+            ...changes,
+            selectedItem: null,
+            inputValue: "",
+            isOpen: true,
+          };
         case useCombobox.stateChangeTypes.InputBlur: {
           // reset any text that has been entered
           return {


### PR DESCRIPTION
**Overview:**
Some accessibility improvements by taking more advantage of downshift:
* Select2 - escape key removes the selected item
* MultiSelect - arrow keys allow the user to select selected item and delete them using backspace

If you want to read how this library works, but it's here
https://github.com/downshift-js/downshift/tree/master/src/hooks/useCombobox
https://www.downshift-js.com/use-combobox
https://github.com/downshift-js/downshift/tree/master/src/hooks/useMultipleSelection
https://www.downshift-js.com/use-multiple-selection

**Screenshots/GIFs:**

https://user-images.githubusercontent.com/13126257/118219922-4dffbb80-b42f-11eb-840a-dfa086684ea6.mov

https://user-images.githubusercontent.com/13126257/118219975-6b348a00-b42f-11eb-9234-d6f242df3706.mov

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
