### PR TITLE
Add ariaLabelledBy prop to RadioGroup

### DIFF
--- a/docs/components/RadioGroupView.jsx
+++ b/docs/components/RadioGroupView.jsx
@@ -30,13 +30,21 @@ export default class RadioGroupView extends React.PureComponent {
   state = {
     disableAll: false,
     selectedCity: null,
+    selectedEmoji: null,
     selectedFood: null,
     showError: false,
     requireSelection: false,
   };
 
   render() {
-    const { disableAll, requireSelection, selectedCity, selectedFood, showError } = this.state;
+    const {
+      disableAll,
+      requireSelection,
+      selectedCity,
+      selectedEmoji,
+      selectedFood,
+      showError,
+    } = this.state;
 
     return (
       <View
@@ -113,6 +121,23 @@ export default class RadioGroupView extends React.PureComponent {
               ]}
               selectedID={selectedFood}
             />
+
+            <h4 id="emoji-selector-label">Favourite Emoji: (label outside of RadioGroup)</h4>
+            <RadioGroup
+              ariaLabelledBy="emoji-selector-label"
+              onChange={(id) => this.setState({ selectedEmoji: id })}
+              options={[
+                { id: "bear", label: "🐻", disabled: disableAll },
+                { id: "sloth", label: "🦥", disabled: disableAll },
+                { id: "orangutan", label: "🦧", disabled: disableAll },
+                {
+                  id: "none",
+                  label: "None of the above",
+                  disabled: requireSelection || disableAll,
+                },
+              ]}
+              selectedID={selectedEmoji}
+            />
           </ExampleCode>
           {this._renderConfig()}
         </Example>
@@ -163,6 +188,13 @@ export default class RadioGroupView extends React.PureComponent {
       <PropDocumentation
         title="<RadioGroup /> Props"
         availableProps={[
+          {
+            name: "ariaLabelledBy",
+            type: "string",
+            description:
+              "Optional element ID to use as the aria-labelledby attribute. Use ONLY if the label prop is not used.",
+            optional: true,
+          },
           {
             name: "className",
             type: "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.111.1",
+  "version": "2.112.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -16,6 +16,7 @@ interface Option<IDType extends string = string, ValueType = any> {
 }
 
 export interface Props<OptionIDType extends string, OptionValueType> {
+  ariaLabelledBy?: string;
   className?: string;
   disabled?: boolean;
   error?: React.ReactNode;
@@ -46,8 +47,24 @@ export default class RadioGroup<
   _optionRefsByID = {};
 
   render() {
-    const { className, disabled, error, label, onChange, options, selectedID } = this.props;
+    const {
+      ariaLabelledBy,
+      className,
+      disabled,
+      error,
+      label,
+      onChange,
+      options,
+      selectedID,
+    } = this.props;
 
+    if (ariaLabelledBy && label) {
+      console.warn(
+        "You should not pass both `ariaLabelledBy` and `label` props. The `ariaLabelledBy` prop is ignored.",
+      );
+    }
+
+    const labelID = label || !ariaLabelledBy ? this._labelID : ariaLabelledBy;
     const focusableOptionID = this._getFocusableOptionID(options);
 
     return (
@@ -57,13 +74,15 @@ export default class RadioGroup<
         onChange={this._handleNavChange}
       >
         <div
-          aria-labelledby={this._labelID}
+          aria-labelledby={labelID}
           className={classnames(cssClass.CONTAINER, className)}
           role="radiogroup"
         >
-          <div className={cssClass.LABEL} id={this._labelID}>
-            {label}
-          </div>
+          {!ariaLabelledBy && (
+            <div className={cssClass.LABEL} id={labelID}>
+              {label}
+            </div>
+          )}
           {error && <FormError>{error}</FormError>}
           {_.map(options, (o) => (
             <Radio<OptionIDType, OptionValueType>


### PR DESCRIPTION
**Jira:**
n/a

**Overview:**
Sometimes a label is not needed, because the label exists elsewhere, like in our new language selector page of family-portal 
![image](https://user-images.githubusercontent.com/21094551/118662809-4be68580-b7be-11eb-9fed-78cb3f4bddf2.png)

This PR adds an `ariaLabelledBy` prop to RadioGroup that can be used instead. 

Also adds documentation:

**Screenshots/GIFs:**
![image](https://user-images.githubusercontent.com/21094551/118714797-cdefa200-b7f0-11eb-8029-4ce555311bb0.png)

![image](https://user-images.githubusercontent.com/21094551/118714763-c5976700-b7f0-11eb-875e-a9c7980c3119.png)

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
