### PR TITLE
M5G-297: MessagingInput FileUpload styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.113.0",
+  "version": "2.114.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Icon/Icon.tsx
+++ b/src/Icon/Icon.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as PropTypes from "prop-types";
 import * as classnames from "classnames";
 import * as _ from "lodash";
 
@@ -118,10 +117,4 @@ Icon.sizes = sizes;
 
 Icon.defaultProps = {
   size: "medium",
-};
-
-Icon.propTypes = {
-  name: PropTypes.oneOf(_.values(Icon.names)).isRequired,
-  size: PropTypes.oneOf(_.values(Icon.sizes)),
-  className: PropTypes.string,
 };

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -4,7 +4,7 @@
   position: relative;
 }
 
-.MessagingInput--Container.MessagingInput--ShowUploadAttachmentButton .FileInput {
+.MessagingInput--ShowUploadAttachmentButton .FileInput {
   height: @size_2xl;
   .padding--none();
   border: none;
@@ -164,6 +164,23 @@ button.MessagingInput--SendButton {
       // Padding to account for the inside-textarea Send button in mobile UI.
       //  Ensures that text is to the left of the Send button.
       padding-right: 2.5rem;
+    }
+  }
+
+  .MessagingInput--ShowUploadAttachmentButton {
+    .TextArea--input {
+      padding-right: 5.1875rem; // 83px
+    }
+
+    .FileInput {
+      position: absolute;
+      right: 2.25rem;
+      bottom: 0;
+
+      .FileInput--Icon {
+        .margin--left--xs();
+        margin-right: 0.3125rem; // 5px
+      }
     }
   }
 


### PR DESCRIPTION
**Jira:**

https://clever.atlassian.net/browse/M5G-297

**Overview:**

Simply moving some css from LP to Components, so it is available widely

* Also removed some unneeded PropTypes along the way

**Screenshots/GIFs:**

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Bumped version in `package.json`
    - backward-compatible component feature change? Run `npm version minor`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
