### PR TITLE
M5G-366: render attachments in MessagingInput

### DIFF
--- a/docs/components/MessagingInputView.jsx
+++ b/docs/components/MessagingInputView.jsx
@@ -4,6 +4,10 @@ import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
 import { MessagingInput, Label, MessagingBubble } from "src";
+import {
+  MessagingAttachment,
+  FileAttachmentIcon,
+} from "src/MessagingAttachment/MessagingAttachment";
 
 import "./MessagingInputView.less";
 
@@ -28,6 +32,7 @@ export default class MessagingInputView extends React.PureComponent {
     newlineOnEnter: false,
     showReturnKeyInstructions: false,
     showUploadAttachmentButton: false,
+    attachments: [],
   };
 
   render() {
@@ -38,12 +43,43 @@ export default class MessagingInputView extends React.PureComponent {
       enableReplyTo,
       showReturnKeyInstructions,
       showUploadAttachmentButton,
+      attachments,
     } = this.state;
     const exampleReplyMessage = (
       <MessagingBubble className={cssClass.EXAMPLE_MESSAGE_REPLY} theme="otherMessage">
         This is an example message that you can try replying to.
       </MessagingBubble>
     );
+    const attachmentList = [
+      <MessagingAttachment
+        key={"1"}
+        title={"GoodMorning.mp3"}
+        attachmentID={"abcd"}
+        icon={<FileAttachmentIcon fileType={"audio"} />}
+        onClickAttachment={(attachmentID) => {
+          console.log("Downloaded attachment:", attachmentID);
+        }}
+        onRemoveAttachment={(attachmentID) => {
+          console.log("Removed attachment:", attachmentID);
+        }}
+        isUpload
+        uploadComplete
+      />,
+      <MessagingAttachment
+        key={"2"}
+        title={"CoolAttachment.pdf"}
+        attachmentID={"defg"}
+        icon={<FileAttachmentIcon fileType={"pdf"} />}
+        onClickAttachment={(attachmentID) => {
+          console.log("Downloaded attachment:", attachmentID);
+        }}
+        onRemoveAttachment={(attachmentID) => {
+          console.log("Remove attachment:", attachmentID);
+        }}
+        isUpload
+        uploadComplete
+      />,
+    ];
     return (
       <View
         className={cssClass.CONTAINER}
@@ -87,6 +123,7 @@ export default class MessagingInputView extends React.PureComponent {
                 console.log(file.name.toLowerCase());
                 callbacks.success();
               }}
+              attachments={attachments}
             />
           </ExampleCode>
           <label className={cssClass.CONFIG}>
@@ -132,6 +169,18 @@ export default class MessagingInputView extends React.PureComponent {
               }
             />{" "}
             Show upload attachment button
+          </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={attachments.length}
+              onChange={({ target }) =>
+                this.setState({
+                  attachments: target.checked && attachmentList,
+                })
+              }
+            />{" "}
+            Show uploaded attachments
           </label>
         </Example>
 
@@ -222,6 +271,12 @@ export default class MessagingInputView extends React.PureComponent {
             type: "(file, callbacks) => void",
             description:
               "Optional store function to be used with the FileInput for attachment uploads. This is only used if showUploadAttachmentButton == true, and should always be defined in that case.",
+            optional: true,
+          },
+          {
+            name: "attachments",
+            type: "React.ReactNode[]",
+            description: "Optional list of ReactNodes to render as uploaded attachments",
             optional: true,
           },
         ]}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.114.0",
+  "version": "2.115.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -154,6 +154,15 @@ button.MessagingInput--SendButton {
   .margin--left--m();
 }
 
+.MessagingInput--UploadedAttachments {
+  .padding--top--m();
+  .padding--bottom--xs();
+}
+
+.MessagingAttachment--ParentContainer {
+  .margin--right--m();
+}
+
 // For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
   .MessagingInput--TextField {

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -33,6 +33,7 @@ interface Props {
   showReturnKeyInstructions?: boolean;
   showUploadAttachmentButton?: boolean;
   store?: (file, callbacks) => void;
+  attachments?: React.ReactNode[];
 }
 
 export interface MessagingInputHandle {
@@ -60,6 +61,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
     showReturnKeyInstructions,
     showUploadAttachmentButton,
     store,
+    attachments,
   } = props;
   const textAreaRef = React.useRef<TextArea>(null);
 
@@ -135,6 +137,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
             showUploadAttachmentButton={showUploadAttachmentButton}
             storeUpload={store}
             fileUploadCustomIcon={<MessagingAttachmentIcon />}
+            uploads={attachments && formUploadedAttachments(attachments)}
           />
         </FlexBox>
         <Button
@@ -159,6 +162,10 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
     </FlexBox>
   );
 };
+
+function formUploadedAttachments(attachments: React.ReactNode[]) {
+  return <FlexBox className={cssClass("UploadedAttachments")}>{attachments}</FlexBox>;
+}
 
 function formReturnKeyInstructionsLabel(showReturnKeyInstructions: boolean, value: string) {
   // If showReturnKeyInstructions is not set, return undefined

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -38,6 +38,7 @@ export interface Props {
   showUploadAttachmentButton?: boolean;
   storeUpload?: (file, callbacks) => void;
   fileUploadCustomIcon?: JSX.Element;
+  uploads?: React.ReactNode;
 }
 
 interface State {
@@ -285,6 +286,7 @@ export class TextArea extends React.Component<Props, State> {
             />
           )}
         </FlexBox>
+        {this.props.uploads}
       </div>
     );
   }


### PR DESCRIPTION
**Jira:**

https://clever.atlassian.net/browse/M5G-366

**Overview:**

Rendering attachments in MessagingInput. Added a new prop `attachments?: React.ReactNode[]` to MessagingInput, which allows the consumer to pass in a list of MessagingAttachments. (Other components could also be passed in, if that is desired later.) 

This list is formatted inside a new FlexBox, which is passed into the TextArea inside MessagingInput under a new prop, `uploads?: React.ReactNode`. It is then rendered inside the textarea

**Screenshots/GIFs:**

![Screen Shot 2021-05-25 at 5 42 39 PM](https://user-images.githubusercontent.com/54862564/119586007-c8f69980-bd80-11eb-8f64-d47f1cc90755.png)


**Testing:**

- [ ] Unit tests
  -  I did not add unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Edge

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - backward-compatible component feature change? Run `npm version minor`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
