### PR TITLE
M5G-365: attachment icon types

### DIFF
--- a/docs/components/MessagingInputView.jsx
+++ b/docs/components/MessagingInputView.jsx
@@ -55,7 +55,7 @@ export default class MessagingInputView extends React.PureComponent {
         key={"1"}
         title={"GoodMorning.mp3"}
         attachmentID={"abcd"}
-        icon={<FileAttachmentIcon fileType={"audio"} />}
+        icon={<FileAttachmentIcon fileType={"mp3"} />}
         onClickAttachment={(attachmentID) => {
           console.log("Downloaded attachment:", attachmentID);
         }}
@@ -70,6 +70,20 @@ export default class MessagingInputView extends React.PureComponent {
         title={"CoolAttachment.pdf"}
         attachmentID={"defg"}
         icon={<FileAttachmentIcon fileType={"pdf"} />}
+        onClickAttachment={(attachmentID) => {
+          console.log("Downloaded attachment:", attachmentID);
+        }}
+        onRemoveAttachment={(attachmentID) => {
+          console.log("Remove attachment:", attachmentID);
+        }}
+        isUpload
+        uploadComplete
+      />,
+      <MessagingAttachment
+        key={"3"}
+        title={"WeirdAttachment.abc"}
+        attachmentID={"hijk"}
+        icon={<FileAttachmentIcon fileType={"abc"} />}
         onClickAttachment={(attachmentID) => {
           console.log("Downloaded attachment:", attachmentID);
         }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.115.0",
+  "version": "2.116.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -70,6 +70,59 @@ function handleRemoveClick(e, onRemoveAttachment, attachmentID) {
 
 // /// Sub-components, exported icon components to be used by consumers /// //
 
+export type AttachmentFileType =
+  | "pdf"
+  | "doc"
+  | "docx"
+  | "xls"
+  | "xlsx"
+  | "csv"
+  | "ppt"
+  | "pptx"
+  | "jpg"
+  | "jpeg"
+  | "gif"
+  | "png"
+  | "svg"
+  | "mp4"
+  | "mov"
+  | "wmv"
+  | "mp3"
+  | "wav"
+  | "m4a"
+  | "flv"
+  | "txt"
+  | null;
+
+function fileTypeToIcon(fileType: string): AttachmentIconType {
+  const mapFileTypeToIcon = {
+    pdf: "pdf",
+    doc: "doc",
+    docx: "doc",
+    xls: "xls",
+    xlsx: "xls",
+    csv: "catchall",
+    ppt: "ppt",
+    pptx: "ppt",
+    jpg: "image",
+    jpeg: "image",
+    gif: "image",
+    png: "image",
+    svg: "image",
+    mp4: "audio",
+    mov: "video",
+    wmv: "video",
+    mp3: "audio",
+    wav: "audio",
+    m4a: "audio",
+    flv: "video",
+    txt: "doc",
+    null: "catchall",
+  };
+
+  return mapFileTypeToIcon[fileType] || "catchall";
+}
+
 const draftAudio = require("./icons/draft-attachment-audio.svg");
 const draftCatchall = require("./icons/draft-attachment-catchall.svg");
 const draftDoc = require("./icons/draft-attachment-doc.svg");
@@ -101,8 +154,18 @@ const fileIcons = {
   xls: { sent: sentXls, draft: draftXls },
 };
 
+export type AttachmentIconType =
+  | "audio"
+  | "catchall"
+  | "doc"
+  | "image"
+  | "pdf"
+  | "ppt"
+  | "video"
+  | "xls";
+
 type AttachmentIconProps = {
-  fileType: "audio" | "catchall" | "doc" | "image" | "pdf" | "ppt" | "video" | "xls";
+  fileType: string;
   isUpload?: boolean;
   uploadComplete?: boolean;
   errorMsg?: string;
@@ -110,11 +173,13 @@ type AttachmentIconProps = {
 
 // TODO: handle undefined. Note: Components uses jsx, LP uses tsx
 export function FileAttachmentIcon({
-  fileType = "catchall",
+  fileType,
   isUpload,
   uploadComplete,
   errorMsg,
 }: AttachmentIconProps) {
+  const cleanedFileType = fileTypeToIcon(fileType);
+
   if (!!errorMsg) {
     return (
       <FontAwesome name="exclamation-circle" className={cx(cssClass("ErrorCircle"), "fa-lg")} />
@@ -124,9 +189,9 @@ export function FileAttachmentIcon({
   }
   return (
     <img
-      src={isUpload ? fileIcons[fileType].draft : fileIcons[fileType].sent}
+      src={isUpload ? fileIcons[cleanedFileType].draft : fileIcons[cleanedFileType].sent}
       className={cssClass("AttachmentTypeIcon")}
-      alt={`MessagingAttachment ${fileType} icon`}
+      alt={`MessagingAttachment ${cleanedFileType} icon`}
     />
   );
 }


### PR DESCRIPTION
**Jira:**

https://clever.atlassian.net/browse/M5G-365

**Overview:**

Adding mapping from file extension to icon types for MessagingAttachment

**Screenshots/GIFs:**

![Screen Shot 2021-05-27 at 2 59 14 PM](https://user-images.githubusercontent.com/54862564/119902563-40046d00-befc-11eb-8c95-909d731a9164.png)


**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - backward-compatible component feature change? Run `npm version minor`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
