### PR TITLE
only form attachments for non-empty list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.116.0",
+  "version": "2.117.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -137,7 +137,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
             showUploadAttachmentButton={showUploadAttachmentButton}
             storeUpload={store}
             fileUploadCustomIcon={<MessagingAttachmentIcon />}
-            uploads={attachments.length > 0 && formUploadedAttachments(attachments)}
+            uploads={attachments?.length > 0 && formUploadedAttachments(attachments)}
           />
         </FlexBox>
         <Button

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -137,7 +137,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
             showUploadAttachmentButton={showUploadAttachmentButton}
             storeUpload={store}
             fileUploadCustomIcon={<MessagingAttachmentIcon />}
-            uploads={attachments && formUploadedAttachments(attachments)}
+            uploads={attachments.length > 0 && formUploadedAttachments(attachments)}
           />
         </FlexBox>
         <Button


### PR DESCRIPTION
**Jira:**

**Overview:**

Quick fix to only form attachments if the list of attachments is non-empty

**Screenshots/GIFs:**

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - backward-compatible component feature change? Run `npm version minor`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
