### PR TITLE
M5G-293 attachments prop messaging bubble

### DIFF
--- a/docs/components/MessagingBubbleView.jsx
+++ b/docs/components/MessagingBubbleView.jsx
@@ -3,7 +3,15 @@ import * as React from "react";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import { MessagingBubble, FlexBox, ItemAlign, SegmentedControl, Label } from "src";
+import {
+  MessagingAttachment,
+  MessagingBubble,
+  FlexBox,
+  ItemAlign,
+  SegmentedControl,
+  Label,
+} from "src";
+import { FileAttachmentIcon } from "src/MessagingAttachment/MessagingAttachment";
 
 import "./MessagingBubbleView.less";
 
@@ -28,6 +36,42 @@ export default class MessagingBubbleView extends React.PureComponent {
 
   render() {
     const { theme } = this.state;
+
+    const attachmentsArray = [
+      {
+        key: "1",
+        attachmentID: "1",
+        icon: <FileAttachmentIcon fileType={"doc"} />,
+        onClickAttachment: () => console.log("clicked!"),
+        title: "MyCoolDoclajsdjasldjaslkdjasldkjasldjaslkdjasldjasldjalskjdalskjdaslkjasljd.doc",
+        subtitle: "Click to download",
+      },
+      {
+        key: "2",
+        attachmentID: "2",
+        icon: <FileAttachmentIcon fileType={"image"} />,
+        onClickAttachment: () => console.log("clicked!"),
+        title: "Flyer.png",
+        subtitle: "Click to view",
+      },
+      {
+        key: "3",
+        attachmentID: "3",
+        icon: <FileAttachmentIcon fileType={"audio"} />,
+        onClickAttachment: () => console.log("clicked!"),
+        title: "Morning message.m4a",
+        subtitle: "Click to download",
+      },
+    ].map((attachment) => (
+      <MessagingAttachment
+        key={attachment.key}
+        attachmentID={attachment.attachmentID}
+        icon={attachment.icon}
+        onClickAttachment={attachment.onClickAttachment}
+        title={attachment.title}
+        subtitle={attachment.subtitle}
+      />
+    ));
 
     return (
       <View
@@ -62,8 +106,11 @@ export default class MessagingBubbleView extends React.PureComponent {
             <MessagingBubble className={cssClass.BUBBLE} theme={theme}>
               Links like https://clever.com are clickable
             </MessagingBubble>
-            <MessagingBubble theme={theme} replyTo={"This is a message!"}>
+            <MessagingBubble className={cssClass.BUBBLE} theme={theme} replyTo={"This is a message!"}>
               This is a reply to that message!
+            </MessagingBubble>
+            <MessagingBubble className={cssClass.BUBBLE} theme={theme} attachments={attachmentsArray}>
+              Check out these attachments!
             </MessagingBubble>
           </ExampleCode>
           {this._renderConfig()}

--- a/docs/components/MessagingBubbleView.jsx
+++ b/docs/components/MessagingBubbleView.jsx
@@ -106,10 +106,18 @@ export default class MessagingBubbleView extends React.PureComponent {
             <MessagingBubble className={cssClass.BUBBLE} theme={theme}>
               Links like https://clever.com are clickable
             </MessagingBubble>
-            <MessagingBubble className={cssClass.BUBBLE} theme={theme} replyTo={"This is a message!"}>
+            <MessagingBubble
+              className={cssClass.BUBBLE}
+              theme={theme}
+              replyTo={"This is a message!"}
+            >
               This is a reply to that message!
             </MessagingBubble>
-            <MessagingBubble className={cssClass.BUBBLE} theme={theme} attachments={attachmentsArray}>
+            <MessagingBubble
+              className={cssClass.BUBBLE}
+              theme={theme}
+              attachments={attachmentsArray}
+            >
               Check out these attachments!
             </MessagingBubble>
           </ExampleCode>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.117.0",
+  "version": "2.118.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -23,6 +23,11 @@
   border-radius: @size_2xs;
 }
 
+.MessagingBubble--Message .MessagingAttachment--Container {
+  .margin--top--3xs();
+  width: 22.5rem;
+}
+
 .MessagingAttachment--IconContainer {
   height: @ICON_REGULAR_SIZE;
   .margin--right--s();

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -28,6 +28,10 @@
   width: 22.5rem;
 }
 
+.MessagingBubble--Message .MessagingAttachment--ParentContainer {
+  margin-right: 0;
+}
+
 .MessagingAttachment--IconContainer {
   height: @ICON_REGULAR_SIZE;
   .margin--right--s();
@@ -192,7 +196,8 @@
 
 // For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
-  .MessagingAttachment--Container {
+  .MessagingAttachment--Container,
+  .MessagingBubble--Message .MessagingAttachment--Container {
     // Full width for small screens
     width: auto;
   }

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -12,6 +12,14 @@
   word-wrap: break-word; // IE name for overflow-wrap
 }
 
+.MessagingBubble--Message--Container--Own {
+  .items--end();
+}
+
+.MessagingBubble--Message--Container--Other {
+  .items--start();
+}
+
 .MessagingBubble--Message--Own {
   background-color: @neutral_dark_gray;
   color: @neutral_white;
@@ -51,6 +59,32 @@
 .MessagingBubble--Message--Attachment--Other {
   .flex--direction--column();
   .items--start();
+}
+
+.MessagingBubble--Message--TimestampBubbleContainer--Own {
+  flex-direction: row;
+  align-items: center;
+}
+
+.MessagingBubble--Message--TimestampBubbleContainer--Other {
+  flex-direction: row-reverse;
+  align-items: center;
+}
+
+.MessagingBubble--Message--Timestamp--Own {
+  color: @neutral_gray;
+  font-size: 0.875rem;
+  .margin--right--xs();
+  .text--line-height-1();
+  white-space: nowrap;
+}
+
+.MessagingBubble--Message--Timestamp--Other {
+  color: @neutral_gray;
+  font-size: 0.875rem;
+  .margin--left--xs();
+  .text--line-height-1();
+  white-space: nowrap;
 }
 
 // For mobile/tablet

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -10,6 +10,10 @@
   overflow-wrap: break-word;
   white-space: pre-wrap;
   word-wrap: break-word; // IE name for overflow-wrap
+  .MessagingAttachment--Container {
+    .margin--top--3xs();
+    width: 22.5rem;
+  }
 }
 
 .MessagingBubble--Message--Own {
@@ -41,6 +45,16 @@
   border-radius: 0.3125rem;
   color: @neutral_black;
   .margin--bottom--s();
+}
+
+.MessagingBubble--Message--Attachment--Own {
+  .flex--direction--column();
+  .items--end();
+}
+
+.MessagingBubble--Message--Attachment--Other {
+  .flex--direction--column();
+  .items--start();
 }
 
 // For mobile/tablet

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -10,10 +10,6 @@
   overflow-wrap: break-word;
   white-space: pre-wrap;
   word-wrap: break-word; // IE name for overflow-wrap
-  .MessagingAttachment--Container {
-    .margin--top--3xs();
-    width: 22.5rem;
-  }
 }
 
 .MessagingBubble--Message--Own {
@@ -76,5 +72,12 @@
 
   .MessagingBubble--Message--Reply--Other {
     .margin--bottom--xs();
+  }
+
+  .MessagingBubble--Message--Attachment--Own {
+    width: auto;
+  }
+  .MessagingBubble--Message--Attachment--Other {
+    width: auto;
   }
 }

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -113,6 +113,7 @@
   .MessagingBubble--Message--Attachment--Own {
     width: auto;
   }
+
   .MessagingBubble--Message--Attachment--Other {
     width: auto;
   }

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -77,6 +77,7 @@
   .margin--right--xs();
   .text--line-height-1();
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .MessagingBubble--Message--Timestamp--Other {
@@ -85,6 +86,7 @@
   .margin--left--xs();
   .text--line-height-1();
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 // For mobile/tablet

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -9,19 +9,14 @@ import "./MessagingBubble.less";
 
 const cssClasses = {
   MESSAGE_BASE: "MessagingBubble--Message",
-  MESSAGE_OWN: "MessagingBubble--Message--Own",
-  MESSAGE_OTHER: "MessagingBubble--Message--Other",
-  MESSAGE_CONTAINER_OWN: "MessagingBubble--Message--Container--Own",
-  MESSAGE_CONTAINER_OTHER: "MessagingBubble--Message--Container--Other",
-  MESSAGE_REPLY_OWN: "MessagingBubble--Message--Reply--Own",
-  MESSAGE_REPLY_OTHER: "MessagingBubble--Message--Reply--Other",
+  MESSAGE_CONTAINER_BASE: "MessagingBubble--Message--Container",
+  MESSAGE_REPLY_BASE: "MessagingBubble--Message--Reply",
   MESSAGE_REPLY_PARENT: "MessagingBubble--Message--Reply--Parent",
-  MESSAGE_TIME_BUBBLE_CONTAINER_OWN: "MessagingBubble--Message--TimestampBubbleContainer--Own",
-  MESSAGE_TIME_BUBBLE_CONTAINER_OTHER: "MessagingBubble--Message--TimestampBubbleContainer--Other",
-  MESSAGE_TIMESTAMP_OWN: "MessagingBubble--Message--Timestamp--Own",
-  MESSAGE_TIMESTAMP_OTHER: "MessagingBubble--Message--Timestamp--Other",
-  MESSAGE_ATTACHMENT_OWN: "MessagingBubble--Message--Attachment--Own",
-  MESSAGE_ATTACHMENT_OTHER: "MessagingBubble--Message--Attachment--Other",
+  MESSAGE_TIME_BUBBLE_CONTAINER_BASE: "MessagingBubble--Message--TimestampBubbleContainer",
+  MESSAGE_TIMESTAMP_BASE: "MessagingBubble--Message--Timestamp",
+  MESSAGE_ATTACHMENT_BASE: "MessagingBubble--Message--Attachment",
+  OWN_SUFFIX: "--Own",
+  OTHER_SUFFIX: "--Other",
 };
 
 interface Props {
@@ -48,37 +43,32 @@ export const MessagingBubble: React.FC<Props> = ({
   attachments,
 }: Props) => {
   const isOwnMessage = theme === "ownMessage";
-
-  const containerClassNames = cx(
-    className,
-    isOwnMessage ? cssClasses.MESSAGE_CONTAINER_OWN : cssClasses.MESSAGE_CONTAINER_OTHER,
-  );
+  const classSuffix = isOwnMessage ? cssClasses.OWN_SUFFIX : cssClasses.OTHER_SUFFIX;
+  const containerClassNames = cx(className, `${cssClasses.MESSAGE_CONTAINER_BASE}${classSuffix}`);
 
   const bubbleClassNames = cx(
     cssClasses.MESSAGE_BASE,
-    isOwnMessage ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
+    `${cssClasses.MESSAGE_BASE}${classSuffix}`,
     replyTo && cssClasses.MESSAGE_REPLY_PARENT,
   );
 
   const replyClassNames = cx(
     cssClasses.MESSAGE_BASE,
-    isOwnMessage ? cssClasses.MESSAGE_REPLY_OWN : cssClasses.MESSAGE_REPLY_OTHER,
+    `${cssClasses.MESSAGE_REPLY_BASE}${classSuffix}`,
   );
 
   const timeAndBubbleContainerClasses = cx(
-    isOwnMessage
-      ? cssClasses.MESSAGE_TIME_BUBBLE_CONTAINER_OWN
-      : cssClasses.MESSAGE_TIME_BUBBLE_CONTAINER_OTHER,
+    `${cssClasses.MESSAGE_TIME_BUBBLE_CONTAINER_BASE}${classSuffix}`,
   );
 
   const timestampClassNames = cx(
     cssClasses.MESSAGE_BASE,
-    isOwnMessage ? cssClasses.MESSAGE_TIMESTAMP_OWN : cssClasses.MESSAGE_TIMESTAMP_OTHER,
+    `${cssClasses.MESSAGE_TIMESTAMP_BASE}${classSuffix}`,
   );
 
   const attachmentClassNames = cx(
     cssClasses.MESSAGE_BASE,
-    isOwnMessage ? cssClasses.MESSAGE_ATTACHMENT_OWN : cssClasses.MESSAGE_ATTACHMENT_OTHER,
+    `${cssClasses.MESSAGE_ATTACHMENT_BASE}${classSuffix}`,
   );
 
   return (

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -53,7 +53,7 @@ export const MessagingBubble: React.FC<Props> = ({
     className,
     isOwnMessage ? cssClasses.MESSAGE_CONTAINER_OWN : cssClasses.MESSAGE_CONTAINER_OTHER,
   );
-  
+
   const bubbleClassNames = cx(
     cssClasses.MESSAGE_BASE,
     isOwnMessage ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
@@ -66,7 +66,9 @@ export const MessagingBubble: React.FC<Props> = ({
   );
 
   const timeAndBubbleContainerClasses = cx(
-    isOwnMessage ? cssClasses.MESSAGE_TIME_BUBBLE_CONTAINER_OWN : cssClasses.MESSAGE_TIME_BUBBLE_CONTAINER_OTHER,
+    isOwnMessage
+      ? cssClasses.MESSAGE_TIME_BUBBLE_CONTAINER_OWN
+      : cssClasses.MESSAGE_TIME_BUBBLE_CONTAINER_OTHER,
   );
 
   const timestampClassNames = cx(
@@ -82,9 +84,7 @@ export const MessagingBubble: React.FC<Props> = ({
   return (
     <FlexBox column className={containerClassNames}>
       <FlexBox className={timeAndBubbleContainerClasses}>
-        <span className={timestampClassNames}>
-          {_formatDateForTimestamp(timestamp)}
-        </span>
+        <span className={timestampClassNames}>{_formatDateForTimestamp(timestamp)}</span>
         <div className={bubbleClassNames}>
           {replyTo && <div className={replyClassNames}>{replyTo}</div>}
           <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -18,6 +18,7 @@ interface Props {
   className?: string;
   children: React.ReactNode;
   replyTo?: React.ReactNode;
+  attachments?: React.ReactNode[];
   theme: "ownMessage" | "otherMessage";
 }
 
@@ -26,29 +27,33 @@ export const MessagingBubble: React.FC<Props> = ({
   children,
   theme,
   replyTo,
+  attachments,
 }: Props) => {
   return (
-    <div
-      className={cx(
-        cssClasses.MESSAGE_BASE,
-        theme === "ownMessage" ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
-        className,
-        replyTo && cssClasses.MESSAGE_REPLY_PARENT,
-      )}
-    >
-      {replyTo && (
-        <div
-          className={cx(
-            cssClasses.MESSAGE_BASE,
-            theme === "ownMessage" ? cssClasses.MESSAGE_REPLY_OWN : cssClasses.MESSAGE_REPLY_OTHER,
-          )}
-        >
-          {replyTo}
-        </div>
-      )}
-      <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
-        {children}
-      </Linkify>
-    </div>
+    <>
+      <div
+        className={cx(
+          cssClasses.MESSAGE_BASE,
+          theme === "ownMessage" ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
+          className,
+          replyTo && cssClasses.MESSAGE_REPLY_PARENT,
+        )}
+      >
+        {replyTo && (
+          <div
+            className={cx(
+              cssClasses.MESSAGE_BASE,
+              theme === "ownMessage" ? cssClasses.MESSAGE_REPLY_OWN : cssClasses.MESSAGE_REPLY_OTHER,
+            )}
+          >
+            {replyTo}
+          </div>
+        )}
+        <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
+          {children}
+        </Linkify>
+      </div>
+      {attachments && attachments}
+    </>
   );
 };

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -32,44 +32,34 @@ export const MessagingBubble: React.FC<Props> = ({
   replyTo,
   attachments,
 }: Props) => {
+  const bubbleClassNames = cx(
+    cssClasses.MESSAGE_BASE,
+    theme === "ownMessage" ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
+    replyTo && cssClasses.MESSAGE_REPLY_PARENT,
+  );
+
+  const replyClassNames = cx(
+    cssClasses.MESSAGE_BASE,
+    theme === "ownMessage" ? cssClasses.MESSAGE_REPLY_OWN : cssClasses.MESSAGE_REPLY_OTHER,
+  );
+
+  const attachmentClassNames = cx(
+    cssClasses.MESSAGE_BASE,
+    cssClasses.FLEXBOX,
+    theme === "ownMessage"
+      ? cssClasses.MESSAGE_ATTACHMENT_OWN
+      : cssClasses.MESSAGE_ATTACHMENT_OTHER,
+  );
+
   return (
     <div className={className}>
-      <div
-        className={cx(
-          cssClasses.MESSAGE_BASE,
-          theme === "ownMessage" ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
-          replyTo && cssClasses.MESSAGE_REPLY_PARENT,
-        )}
-      >
-        {replyTo && (
-          <div
-            className={cx(
-              cssClasses.MESSAGE_BASE,
-              theme === "ownMessage"
-                ? cssClasses.MESSAGE_REPLY_OWN
-                : cssClasses.MESSAGE_REPLY_OTHER,
-            )}
-          >
-            {replyTo}
-          </div>
-        )}
+      <div className={bubbleClassNames}>
+        {replyTo && <div className={replyClassNames}>{replyTo}</div>}
         <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
           {children}
         </Linkify>
       </div>
-      {attachments && (
-        <div
-          className={cx(
-            cssClasses.MESSAGE_BASE,
-            cssClasses.FLEXBOX,
-            theme === "ownMessage"
-              ? cssClasses.MESSAGE_ATTACHMENT_OWN
-              : cssClasses.MESSAGE_ATTACHMENT_OTHER,
-          )}
-        >
-          {attachments}
-        </div>
-      )}
+      {attachments && <div className={attachmentClassNames}>{attachments}</div>}
     </div>
   );
 };

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -32,22 +32,21 @@ export const MessagingBubble: React.FC<Props> = ({
   replyTo,
   attachments,
 }: Props) => {
+  const isOwnMessage = theme === "ownMessage";
   const bubbleClassNames = cx(
     cssClasses.MESSAGE_BASE,
-    theme === "ownMessage" ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
+    isOwnMessage ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
     replyTo && cssClasses.MESSAGE_REPLY_PARENT,
   );
 
   const replyClassNames = cx(
     cssClasses.MESSAGE_BASE,
-    theme === "ownMessage" ? cssClasses.MESSAGE_REPLY_OWN : cssClasses.MESSAGE_REPLY_OTHER,
+    isOwnMessage ? cssClasses.MESSAGE_REPLY_OWN : cssClasses.MESSAGE_REPLY_OTHER,
   );
 
   const attachmentClassNames = cx(
     cssClasses.MESSAGE_BASE,
-    theme === "ownMessage"
-      ? cssClasses.MESSAGE_ATTACHMENT_OWN
-      : cssClasses.MESSAGE_ATTACHMENT_OTHER,
+    isOwnMessage ? cssClasses.MESSAGE_ATTACHMENT_OWN : cssClasses.MESSAGE_ATTACHMENT_OTHER,
   );
 
   return (

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as moment from "moment";
 import Linkify from "react-linkify";
 import * as cx from "classnames";
 import FlexBox from "../flex/FlexBox";
@@ -10,9 +11,15 @@ const cssClasses = {
   MESSAGE_BASE: "MessagingBubble--Message",
   MESSAGE_OWN: "MessagingBubble--Message--Own",
   MESSAGE_OTHER: "MessagingBubble--Message--Other",
+  MESSAGE_CONTAINER_OWN: "MessagingBubble--Message--Container--Own",
+  MESSAGE_CONTAINER_OTHER: "MessagingBubble--Message--Container--Other",
   MESSAGE_REPLY_OWN: "MessagingBubble--Message--Reply--Own",
   MESSAGE_REPLY_OTHER: "MessagingBubble--Message--Reply--Other",
   MESSAGE_REPLY_PARENT: "MessagingBubble--Message--Reply--Parent",
+  MESSAGE_TIME_BUBBLE_CONTAINER_OWN: "MessagingBubble--Message--TimestampBubbleContainer--Own",
+  MESSAGE_TIME_BUBBLE_CONTAINER_OTHER: "MessagingBubble--Message--TimestampBubbleContainer--Other",
+  MESSAGE_TIMESTAMP_OWN: "MessagingBubble--Message--Timestamp--Own",
+  MESSAGE_TIMESTAMP_OTHER: "MessagingBubble--Message--Timestamp--Other",
   MESSAGE_ATTACHMENT_OWN: "MessagingBubble--Message--Attachment--Own",
   MESSAGE_ATTACHMENT_OTHER: "MessagingBubble--Message--Attachment--Other",
 };
@@ -20,19 +27,33 @@ const cssClasses = {
 interface Props {
   className?: string;
   children: React.ReactNode;
+  timestamp: Date;
   replyTo?: React.ReactNode;
   attachments?: React.ReactNode[];
   theme: "ownMessage" | "otherMessage";
 }
 
+// Helper function: Format a Date for our pretty timestamps.
+//  Always returns "xx:xx <AM/PM>" format.
+function _formatDateForTimestamp(date: Date): string {
+  return moment(date).format("h:mm A");
+}
+
 export const MessagingBubble: React.FC<Props> = ({
   className,
   children,
+  timestamp,
   theme,
   replyTo,
   attachments,
 }: Props) => {
   const isOwnMessage = theme === "ownMessage";
+
+  const containerClassNames = cx(
+    className,
+    isOwnMessage ? cssClasses.MESSAGE_CONTAINER_OWN : cssClasses.MESSAGE_CONTAINER_OTHER,
+  );
+  
   const bubbleClassNames = cx(
     cssClasses.MESSAGE_BASE,
     isOwnMessage ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
@@ -44,20 +65,34 @@ export const MessagingBubble: React.FC<Props> = ({
     isOwnMessage ? cssClasses.MESSAGE_REPLY_OWN : cssClasses.MESSAGE_REPLY_OTHER,
   );
 
+  const timeAndBubbleContainerClasses = cx(
+    isOwnMessage ? cssClasses.MESSAGE_TIME_BUBBLE_CONTAINER_OWN : cssClasses.MESSAGE_TIME_BUBBLE_CONTAINER_OTHER,
+  );
+
+  const timestampClassNames = cx(
+    cssClasses.MESSAGE_BASE,
+    isOwnMessage ? cssClasses.MESSAGE_TIMESTAMP_OWN : cssClasses.MESSAGE_TIMESTAMP_OTHER,
+  );
+
   const attachmentClassNames = cx(
     cssClasses.MESSAGE_BASE,
     isOwnMessage ? cssClasses.MESSAGE_ATTACHMENT_OWN : cssClasses.MESSAGE_ATTACHMENT_OTHER,
   );
 
   return (
-    <div className={className}>
-      <div className={bubbleClassNames}>
-        {replyTo && <div className={replyClassNames}>{replyTo}</div>}
-        <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
-          {children}
-        </Linkify>
-      </div>
+    <FlexBox column className={containerClassNames}>
+      <FlexBox className={timeAndBubbleContainerClasses}>
+        <span className={timestampClassNames}>
+          {_formatDateForTimestamp(timestamp)}
+        </span>
+        <div className={bubbleClassNames}>
+          {replyTo && <div className={replyClassNames}>{replyTo}</div>}
+          <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
+            {children}
+          </Linkify>
+        </div>
+      </FlexBox>
       {attachments && <FlexBox className={attachmentClassNames}>{attachments}</FlexBox>}
-    </div>
+    </FlexBox>
   );
 };

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import Linkify from "react-linkify";
 import * as cx from "classnames";
+import FlexBox from "../flex/FlexBox";
 import { matchDecorator, componentDecorator } from "./linkifyUtils";
 
 import "./MessagingBubble.less";
 
 const cssClasses = {
-  FLEXBOX: "flexbox",
   MESSAGE_BASE: "MessagingBubble--Message",
   MESSAGE_OWN: "MessagingBubble--Message--Own",
   MESSAGE_OTHER: "MessagingBubble--Message--Other",
@@ -45,7 +45,6 @@ export const MessagingBubble: React.FC<Props> = ({
 
   const attachmentClassNames = cx(
     cssClasses.MESSAGE_BASE,
-    cssClasses.FLEXBOX,
     theme === "ownMessage"
       ? cssClasses.MESSAGE_ATTACHMENT_OWN
       : cssClasses.MESSAGE_ATTACHMENT_OTHER,
@@ -59,7 +58,7 @@ export const MessagingBubble: React.FC<Props> = ({
           {children}
         </Linkify>
       </div>
-      {attachments && <div className={attachmentClassNames}>{attachments}</div>}
+      {attachments && <FlexBox className={attachmentClassNames}>{attachments}</FlexBox>}
     </div>
   );
 };

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -6,12 +6,15 @@ import { matchDecorator, componentDecorator } from "./linkifyUtils";
 import "./MessagingBubble.less";
 
 const cssClasses = {
+  FLEXBOX: "flexbox",
   MESSAGE_BASE: "MessagingBubble--Message",
   MESSAGE_OWN: "MessagingBubble--Message--Own",
   MESSAGE_OTHER: "MessagingBubble--Message--Other",
   MESSAGE_REPLY_OWN: "MessagingBubble--Message--Reply--Own",
   MESSAGE_REPLY_OTHER: "MessagingBubble--Message--Reply--Other",
   MESSAGE_REPLY_PARENT: "MessagingBubble--Message--Reply--Parent",
+  MESSAGE_ATTACHMENT_OWN: "MessagingBubble--Message--Attachment--Own",
+  MESSAGE_ATTACHMENT_OTHER: "MessagingBubble--Message--Attachment--Other",
 };
 
 interface Props {
@@ -30,12 +33,11 @@ export const MessagingBubble: React.FC<Props> = ({
   attachments,
 }: Props) => {
   return (
-    <>
+    <div className={className}>
       <div
         className={cx(
           cssClasses.MESSAGE_BASE,
           theme === "ownMessage" ? cssClasses.MESSAGE_OWN : cssClasses.MESSAGE_OTHER,
-          className,
           replyTo && cssClasses.MESSAGE_REPLY_PARENT,
         )}
       >
@@ -43,7 +45,9 @@ export const MessagingBubble: React.FC<Props> = ({
           <div
             className={cx(
               cssClasses.MESSAGE_BASE,
-              theme === "ownMessage" ? cssClasses.MESSAGE_REPLY_OWN : cssClasses.MESSAGE_REPLY_OTHER,
+              theme === "ownMessage"
+                ? cssClasses.MESSAGE_REPLY_OWN
+                : cssClasses.MESSAGE_REPLY_OTHER,
             )}
           >
             {replyTo}
@@ -53,7 +57,19 @@ export const MessagingBubble: React.FC<Props> = ({
           {children}
         </Linkify>
       </div>
-      {attachments && attachments}
-    </>
+      {attachments && (
+        <div
+          className={cx(
+            cssClasses.MESSAGE_BASE,
+            cssClasses.FLEXBOX,
+            theme === "ownMessage"
+              ? cssClasses.MESSAGE_ATTACHMENT_OWN
+              : cssClasses.MESSAGE_ATTACHMENT_OTHER,
+          )}
+        >
+          {attachments}
+        </div>
+      )}
+    </div>
   );
 };

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -36,22 +36,6 @@
   align-items: center;
 }
 
-.MessageMetadata--Timestamp--right {
-  color: @neutral_medium_gray;
-  font-size: 0.875rem;
-  .margin--right--xs();
-  .text--line-height-1();
-  white-space: nowrap;
-}
-
-.MessageMetadata--Timestamp--left {
-  color: @neutral_medium_gray;
-  font-size: 0.875rem;
-  .margin--left--xs();
-  .text--line-height-1();
-  white-space: nowrap;
-}
-
 .MessageMetadata--ReadReceipt {
   .padding--top--2xs();
   text-align: right;

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -24,16 +24,12 @@ export const MessageMetadata: React.FC<
   const { className, placement, readStatusText, children, errorMsg } = props;
   return (
     <div ref={ref} className={classNames(cssClass("Message--container"), className)}>
-      <div className={cssClass(`Message--${placement}`)}>
-        {children}
-      </div>
+      <div className={cssClass(`Message--${placement}`)}>{children}</div>
       {readStatusText && <div className={cssClass("ReadReceipt")}>{readStatusText}</div>}
       {errorMsg && formErrorContainer(errorMsg)}
     </div>
   );
 });
-
-
 
 function formErrorContainer(errorMsg: React.ReactNode): JSX.Element {
   return (

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as classNames from "classnames";
-import * as moment from "moment";
 import * as FontAwesome from "react-fontawesome";
 import { FlexBox } from "../";
 
@@ -22,17 +21,11 @@ interface Props {
 export const MessageMetadata: React.FC<
   Props & { ref?: React.Ref<HTMLDivElement> }
 > = React.forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) => {
-  const { className, placement, timestamp, readStatusText, children, errorMsg } = props;
-  const showTimestamp = timestamp && placement !== "fullWidth";
+  const { className, placement, readStatusText, children, errorMsg } = props;
   return (
     <div ref={ref} className={classNames(cssClass("Message--container"), className)}>
       <div className={cssClass(`Message--${placement}`)}>
         {children}
-        {showTimestamp && (
-          <span className={cssClass(`Timestamp--${placement}`)}>
-            {_formatDateForTimestamp(timestamp)}
-          </span>
-        )}
       </div>
       {readStatusText && <div className={cssClass("ReadReceipt")}>{readStatusText}</div>}
       {errorMsg && formErrorContainer(errorMsg)}
@@ -40,11 +33,7 @@ export const MessageMetadata: React.FC<
   );
 });
 
-// Helper function: Format a Date for our pretty timestamps.
-//  Always returns "xx:xx <AM/PM>" format.
-function _formatDateForTimestamp(date: Date): string {
-  return moment(date).format("h:mm A");
-}
+
 
 function formErrorContainer(errorMsg: React.ReactNode): JSX.Element {
   return (


### PR DESCRIPTION
# Jira: [M5G-293](https://clever.atlassian.net/browse/M5G-293)

[Figma designs for Clever Messages attachments](https://www.figma.com/file/HE5OffYDhp2nElIFahzYlt/Clever-Messages-v2-(Attachments))

## Overview:
In order for attachments to appear appropriately on messages, the `MessagingBubble` component needs to support displaying attachments. This PR adds an `attachments` prop to the `MessagingBubble` component, which expects an array of React components. It also renders these attachments as part of the `MessagingBubble` component.

In order to ensure that the timestamps maintain the proper layout relative to the actual message, this PR required a breaking change to the `MessagingMetadata` component and the data required to be passed into the `messages` prop of `MessagingThreadHistory`.

## Screenshots/GIFs:
### In Launchpad
**Desktop**
![image](https://user-images.githubusercontent.com/6520345/121232599-9fd90d00-c846-11eb-8872-02550f722362.png)

**Mobile**
![image](https://user-images.githubusercontent.com/6520345/121232661-ad8e9280-c846-11eb-9322-ed53525e3a14.png)


### In this repo's docs
**Own messages (sent)**
![image](https://user-images.githubusercontent.com/6520345/121232073-0dd10480-c846-11eb-84fe-445660d15b07.png)

**"Other" Messages (recieved)**
![image](https://user-images.githubusercontent.com/6520345/121232353-5be60800-c846-11eb-8065-9ca6a2db621d.png)


**Testing:**
**THIS PR IS NOT COVERED BY AUTOMATED TESTS**
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [x] Posted in #eng if I made a breaking change to a beta component
