### PR TITLE
Add temporary props to allow overriding text with translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.118.0",
+  "version": "2.119.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/AnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/AnnouncementBubble.tsx
@@ -23,7 +23,13 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
 ) => {
   switch (props.theme) {
     case "deleted": {
-      return <DeletedAnnouncementBubble theme="deleted" className={props.className} />;
+      return (
+        <DeletedAnnouncementBubble
+          theme="deleted"
+          className={props.className}
+          deletionNoticeText={props.deletionNoticeText}
+        />
+      );
     }
     case "quoted": {
       return (
@@ -32,10 +38,15 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
           announcementGroupName={props.announcementGroupName}
           className={props.className}
           colorTheme={props.colorTheme}
+          isMessageTruncated={props.isMessageTruncated}
+          postedInText={props.postedInText}
           senderIcon={props.senderIcon}
           senderName={props.senderName}
           sentAtTimestamp={props.sentAtTimestamp}
-          isMessageTruncated={props.isMessageTruncated}
+          showLessButtonText={props.showLessButtonText}
+          showMoreButtonText={props.showMoreButtonText}
+          truncationNoticeText={props.truncationNoticeText}
+          truncationTooltipText={props.truncationTooltipText}
         >
           {props.children}
         </QuotedAnnouncementBubble>
@@ -49,6 +60,7 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
           onDelete={props.onDelete}
           onReply={props.onReply}
           repliesDisabledMsg={props.repliesDisabledMsg}
+          replyButtonText={props.replyButtonText}
           senderIcon={props.senderIcon}
           senderName={props.senderName}
           sentAtTimestamp={props.sentAtTimestamp}

--- a/src/AnnouncementBubble/DeletedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/DeletedAnnouncementBubble.tsx
@@ -12,9 +12,15 @@ function cssClass(element: string) {
 export interface Props {
   theme: "deleted";
   className?: string;
+
+  // Temporary props to allow overriding text with translations
+  deletionNoticeText?: string;
 }
 
-export const DeletedAnnouncementBubble: React.FC<Props> = ({ className }: Props) => {
+export const DeletedAnnouncementBubble: React.FC<Props> = ({
+  className,
+  deletionNoticeText,
+}: Props) => {
   return (
     <FlexBox
       grow
@@ -23,7 +29,9 @@ export const DeletedAnnouncementBubble: React.FC<Props> = ({ className }: Props)
       className={cx(cssClass("container"), className)}
     >
       <FontAwesome name="trash-o" className={cssClass("icon")} aria-hidden="true" />
-      <div className={cssClass("text")}>This announcement was deleted.</div>
+      <div className={cssClass("text")}>
+        {deletionNoticeText || "This announcement was deleted."}
+      </div>
     </FlexBox>
   );
 };

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -21,6 +21,9 @@ export interface Props {
   senderIcon: React.ReactNode;
   senderName: string;
   sentAtTimestamp: Date;
+
+  // Temporary props to allow overriding text with translations
+  replyButtonText?: string;
 }
 
 export const NormalAnnouncementBubble: React.FC<Props> = ({
@@ -29,12 +32,13 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
   onDelete,
   onReply,
   repliesDisabledMsg,
+  replyButtonText,
   senderIcon,
   senderName,
   sentAtTimestamp,
 }: Props) => {
   const deleteMenu = formDeleteMenu(onDelete);
-  const replyButton = formReplyButton(onReply, repliesDisabledMsg);
+  const replyButton = formReplyButton(onReply, repliesDisabledMsg, replyButtonText);
 
   return (
     <FlexBox
@@ -83,22 +87,34 @@ function formDeleteMenu(onDelete: () => void): JSX.Element {
   );
 }
 
-function formReplyButton(onReply: () => void, repliesDisabledMsg: string): JSX.Element {
+function formReplyButton(
+  onReply: () => void,
+  repliesDisabledMsg: string,
+  replyButtonText?: string,
+): JSX.Element {
   // If a repliesDisabledMsg prop is provided, show the disabled reply button
   if (repliesDisabledMsg) {
-    return <DisabledReplyButton disabledMsg={repliesDisabledMsg} />;
+    return (
+      <DisabledReplyButton disabledMsg={repliesDisabledMsg} replyButtonText={replyButtonText} />
+    );
   }
 
   // If an onReply callback prop is provided, show the reply button
   if (onReply) {
-    return <ReplyButton onReply={onReply} />;
+    return <ReplyButton onReply={onReply} replyButtonText={replyButtonText} />;
   }
 
   // Default case is to show no reply button
   return undefined;
 }
 
-function ReplyButton({ onReply }: { onReply: () => void }): JSX.Element {
+function ReplyButton({
+  onReply,
+  replyButtonText,
+}: {
+  onReply: () => void;
+  replyButtonText?: string;
+}): JSX.Element {
   return (
     <Button className={cssClass("replyButton")} onClick={onReply} type={"secondary"}>
       <FlexBox alignItems="center" justify="center">
@@ -107,13 +123,19 @@ function ReplyButton({ onReply }: { onReply: () => void }): JSX.Element {
           className={cssClass("replyButton--icon")}
           src={require("./messages-black-icon.svg")}
         />
-        <span className={cssClass("replyButton--text")}>Reply</span>
+        <span className={cssClass("replyButton--text")}>{replyButtonText || "Reply"}</span>
       </FlexBox>
     </Button>
   );
 }
 
-function DisabledReplyButton({ disabledMsg }: { disabledMsg: string }): JSX.Element {
+function DisabledReplyButton({
+  disabledMsg,
+  replyButtonText,
+}: {
+  disabledMsg: string;
+  replyButtonText?: string;
+}): JSX.Element {
   return (
     <Button
       ariaLabel={disabledMsg}
@@ -136,7 +158,7 @@ function DisabledReplyButton({ disabledMsg }: { disabledMsg: string }): JSX.Elem
           <span
             className={cx(cssClass("replyButton--text"), cssClass("replyButton--text--disabled"))}
           >
-            Reply
+            {replyButtonText || "Reply"}
           </span>
         </FlexBox>
       </Tooltip>

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -24,6 +24,13 @@ export interface Props {
   senderIcon: React.ReactNode;
   senderName: string;
   sentAtTimestamp: Date;
+
+  // Temporary props to allow overriding text with translations
+  postedInText?: string;
+  showLessButtonText?: string;
+  showMoreButtonText?: string;
+  truncationNoticeText?: string;
+  truncationTooltipText?: string;
 }
 
 export const QuotedAnnouncementBubble: React.FC<Props> = ({
@@ -31,14 +38,20 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
   children,
   className,
   colorTheme,
+  isMessageTruncated,
+  postedInText,
   senderIcon,
   senderName,
   sentAtTimestamp,
-  isMessageTruncated,
+  showLessButtonText,
+  showMoreButtonText,
+  truncationNoticeText,
+  truncationTooltipText,
 }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const messageDetails = formMessageDetails(announcementGroupName, sentAtTimestamp);
+  let messageDetails = postedInText || `Posted in ${announcementGroupName}`;
+  messageDetails += ` | ${formatDateForTimestamp(sentAtTimestamp)}`;
 
   /* If the content is not expanded, limit the message length so that screen readers
     don't attempt to read the entire hidden message. This only works for plain-string children */
@@ -73,7 +86,9 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
     }
   }
 
-  const buttonText = isExpanded ? "Show less" : "Show more";
+  const buttonText = isExpanded
+    ? showLessButtonText || "Show less"
+    : showMoreButtonText || "Show more";
 
   return (
     <FlexBox
@@ -100,9 +115,12 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
       {isMessageTruncated && isExpanded && (
         <FlexBox className={cssClass("messageTruncatedNotice")} alignItems="center">
           <span>
-            Complete announcement not shown
+            {truncationNoticeText || "Complete announcement not shown"}
             <Tooltip
-              content="This announcement exceeds the preview character limit. See original announcement for complete content."
+              content={
+                truncationTooltipText ||
+                "This announcement exceeds the preview character limit. See original announcement for complete content."
+              }
               placement={Tooltip.Placement.TOP}
             >
               <FontAwesome
@@ -131,7 +149,3 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
     </FlexBox>
   );
 };
-
-function formMessageDetails(announcementGroupName: string, timestamp: Date) {
-  return `Posted in ${announcementGroupName} | ${formatDateForTimestamp(timestamp)}`;
-}


### PR DESCRIPTION
# Jira

[M5G-396](https://clever.atlassian.net/browse/M5G-396)

# Overview

To translate copy within Dewey components, we're temporarily allowing consumers to override text with translations. Eventually, we want Dewey to house its own translations, but we're not quite there yet.

<img width="590" alt="normal" src="https://user-images.githubusercontent.com/12616928/121380490-c2782e00-c8f9-11eb-98c1-7d22d2975762.png">

^ New props: `replyButtonText`

<img width="590" alt="quoted" src="https://user-images.githubusercontent.com/12616928/121380491-c2782e00-c8f9-11eb-9b50-722abaeb9719.png">

^ New props: `postedInText`, `showLessButtonText`, `showMoreButtonText`, `truncationNoticeText`, `truncationTooltipText`

<img width="580" alt="deleted" src="https://user-images.githubusercontent.com/12616928/121380487-c1470100-c8f9-11eb-834e-e95af32a7323.png">

^ New props: `deletionNoticeText`

# Testing

- [ ] Unit tests

_Manual tests_

Tested each of the new props. Also verified that the component still works when none of the new props are specified.

- [x] Chrome <-- This isn't a UI element change, just a logic change, so manual testing in other browsers isn't critical
- [ ] Safari 
- [ ] IE11

# Rollout

_Before merging_

- [ ] Updated docs <-- The props table for `AnnouncementBubble` is still listed as a TODO. Opened a ticket to track! [M5G-414](https://clever.atlassian.net/browse/M5G-414)
- [x] Bumped version in `package.json`

_After merging_

- [ ] Deployed updated docs (`make deploy-docs`) <-- N/A
- [ ] Posted in #eng if I made a breaking change to a beta component <-- N/A