### PR TITLE
M5G-294 attachments on AnnouncementBubble components

### DIFF
--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -130,6 +130,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
           <ExampleCode>
             <AnnouncementBubble
               theme={"quoted"}
+              attachments={attachmentsArray}
               colorTheme={colorTheme}
               announcementGroupName={"Math Rocks!"}
               senderName={"Ms. Stark"}

--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -115,7 +115,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
               senderIcon={
                 <MessagingAvatar
                   text={"Kristen Stark"}
-                  color={{ color: Colors.ACCENT_PINK }}
+                  color={{ color: Colors.PRIMARY_BLUE_TINT_2 }}
                 />
               }
               onReply={() => console.log("Reply!")}

--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -9,9 +9,12 @@ import {
   FlexBox,
   ItemAlign,
   Label,
+  MessagingAttachment,
   MessagingAvatar,
   SegmentedControl,
 } from "src";
+import { FileAttachmentIcon } from "src/MessagingAttachment/MessagingAttachment";
+
 import Colors from "src/utils/Colors";
 
 import "./AnnouncementBubbleView.less";
@@ -37,6 +40,26 @@ export default class AnnouncementBubbleView extends React.PureComponent {
 
   render() {
     const { colorTheme } = this.state;
+
+    const attachmentsArray = [
+      {
+        key: "1",
+        attachmentID: "1",
+        icon: <FileAttachmentIcon fileType={"audio"} />,
+        onClickAttachment: () => console.log("clicked!"),
+        title: "Morning message.m4a",
+        subtitle: "Click to download",
+      },
+    ].map((attachment) => (
+      <MessagingAttachment
+        key={attachment.key}
+        attachmentID={attachment.attachmentID}
+        icon={attachment.icon}
+        onClickAttachment={attachment.onClickAttachment}
+        title={attachment.title}
+        subtitle={attachment.subtitle}
+      />
+    ));
 
     return (
       <View
@@ -83,6 +106,23 @@ export default class AnnouncementBubbleView extends React.PureComponent {
               theme={"normal"}
             >
               Hello class! Links like https://clever.com are clickable
+            </AnnouncementBubble>
+
+            <AnnouncementBubble
+              className={cssClass.BUBBLE}
+              attachments={attachmentsArray}
+              senderName={"Ms. Stark"}
+              senderIcon={
+                <MessagingAvatar
+                  text={"Kristen Stark"}
+                  color={{ color: Colors.ACCENT_PINK }}
+                />
+              }
+              onReply={() => console.log("Reply!")}
+              sentAtTimestamp={new Date()}
+              theme={"normal"}
+            >
+              Announcements like this one can include attachments to open or download
             </AnnouncementBubble>
           </ExampleCode>
         </Example>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.119.0",
+  "version": "2.120.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/AnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/AnnouncementBubble.tsx
@@ -36,6 +36,7 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
         <QuotedAnnouncementBubble
           theme="quoted"
           announcementGroupName={props.announcementGroupName}
+          attachments={props.attachments}
           className={props.className}
           colorTheme={props.colorTheme}
           isMessageTruncated={props.isMessageTruncated}
@@ -56,6 +57,7 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
       return (
         <NormalAnnouncementBubble
           theme="normal"
+          attachments={props.attachments}
           className={props.className}
           onDelete={props.onDelete}
           onReply={props.onReply}

--- a/src/AnnouncementBubble/DeletedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/DeletedAnnouncementBubble.less
@@ -2,6 +2,7 @@
 
 .DeletedAnnouncementBubble--container {
   .border--m(@neutral_silver);
+  max-width: 33rem;
   border-radius: 0.3125rem; // 5px
   color: @neutral_medium_gray;
 }

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -43,6 +43,21 @@
   margin-left: auto;
 }
 
+.NormalAnnouncementBubble--attachmentContainer {
+  margin-top: 1rem;
+  width: 100%;
+}
+
+.NormalAnnouncementBubble--attachmentContainer > .MessagingAttachment--ParentContainer,
+.MessagingAttachment--ParentContainer > .MessagingAttachment--Container
+{
+  width: 100%;
+}
+
+.NormalAnnouncementBubble--attachmentContainer .MessagingAttachment--Container {
+  padding: 1rem;
+}
+
 button.NormalAnnouncementBubble--deleteMenuItem {
   box-shadow: inset @borderWidthL 0 @alert_red;
   color: @alert_red_shade_2;

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -1,14 +1,15 @@
 @import (reference) "../less/index";
 
 .NormalAnnouncementBubble--container {
+  max-width: 31rem; /* is 33 rem total width including 1 rem padding on either side */
   .boxShadow--medium();
-  border-radius: 1rem;
+  border-radius: 0.5rem;
   .padding--m();
   position: relative;
 }
 
 .NormalAnnouncementBubble--containerWithReply {
-  border-radius: 2rem;
+  border-radius: 1rem;
   .margin--bottom--m();
   .padding--bottom--xl();
 }
@@ -49,9 +50,9 @@
 }
 
 .NormalAnnouncementBubble--attachmentContainer > .MessagingAttachment--ParentContainer,
-.MessagingAttachment--ParentContainer > .MessagingAttachment--Container
-{
+.MessagingAttachment--ParentContainer > .MessagingAttachment--Container {
   width: 100%;
+  margin-right: 0;
 }
 
 .NormalAnnouncementBubble--attachmentContainer .MessagingAttachment--Container {
@@ -163,7 +164,6 @@ button.NormalAnnouncementBubble--replyButton {
   }
 
   .NormalAnnouncementBubble--containerWithReply {
-    border-radius: 2rem;
     .padding--bottom--xl();
   }
 

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -53,6 +53,7 @@
 .MessagingAttachment--ParentContainer > .MessagingAttachment--Container {
   width: 100%;
   margin-right: 0;
+  .text--truncate();
 }
 
 button.NormalAnnouncementBubble--deleteMenuItem {
@@ -156,6 +157,7 @@ button.NormalAnnouncementBubble--replyButton {
 
 @media only screen and (max-width: @breakpointM) {
   .NormalAnnouncementBubble--container {
+    width: 96%;
     .padding--s();
   }
 

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -55,10 +55,6 @@
   margin-right: 0;
 }
 
-.NormalAnnouncementBubble--attachmentContainer .MessagingAttachment--Container {
-  padding: 1rem;
-}
-
 button.NormalAnnouncementBubble--deleteMenuItem {
   box-shadow: inset @borderWidthL 0 @alert_red;
   color: @alert_red_shade_2;

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -13,7 +13,7 @@ function cssClass(element: string) {
 
 export interface Props {
   theme: "normal";
-  attachments?: React.ReactNode;
+  attachments?: React.ReactNode[];
   children: React.ReactNode;
   className?: string;
   onDelete?: () => void;

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -13,6 +13,7 @@ function cssClass(element: string) {
 
 export interface Props {
   theme: "normal";
+  attachments?: React.ReactNode;
   children: React.ReactNode;
   className?: string;
   onDelete?: () => void;
@@ -27,6 +28,7 @@ export interface Props {
 }
 
 export const NormalAnnouncementBubble: React.FC<Props> = ({
+  attachments,
   children,
   className,
   onDelete,
@@ -57,6 +59,7 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
       <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
         <div className={cssClass("messageBody")}>{children}</div>
       </Linkify>
+      {attachments && <FlexBox className={cssClass("attachmentContainer")}>{attachments}</FlexBox>}
       {replyButton}
     </FlexBox>
   );

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -165,5 +165,6 @@ button.QuotedAnnouncementBubble--button--outer {
     .MessagingAttachment--Container {
     width: 100%;
     margin-right: 0;
+    .text--truncate();
   }
 }

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -82,6 +82,12 @@
   .margin--bottom--xs();
 }
 
+.MessagingBubble--Message
+  .QuotedAnnouncementBubble--attachmentContainer
+  .MessagingAttachment--Container {
+  width: 14rem;
+}
+
 // the below styles disable the MessagingAttachment's normal hover styles
 // for all of our usecases.
 .QuotedAnnouncementBubble--attachmentContainer--dark .MessagingAttachment--Container:hover {
@@ -148,5 +154,14 @@ button.QuotedAnnouncementBubble--button--outer {
 @media only screen and (max-width: @breakpointM) {
   .QuotedAnnouncementBubble--messageBody {
     .margin--y--xs();
+  }
+
+  .QuotedAnnouncementBubble--attachmentContainer,
+  .QuotedAnnouncementBubble--attachmentContainer > .MessagingAttachment--ParentContainer,
+  .MessagingBubble--Message
+    .QuotedAnnouncementBubble--attachmentContainer
+    .MessagingAttachment--Container {
+    width: 100%;
+    margin-right: 0;
   }
 }

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -86,6 +86,7 @@
   .QuotedAnnouncementBubble--attachmentContainer
   .MessagingAttachment--Container {
   width: 14rem;
+  .text--truncate();
 }
 
 // the below styles disable the MessagingAttachment's normal hover styles

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -87,7 +87,12 @@
   .QuotedAnnouncementBubble--attachmentContainer
   .MessagingAttachment--Container {
   width: 14rem;
+  padding: @size_s;
   .text--truncate();
+}
+
+.QuotedAnnouncementBubble--attachmentContainer .MessagingAttachment--Title {
+  .text--smallMedium();
 }
 
 // the below styles disable the MessagingAttachment's normal hover styles

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -79,6 +79,7 @@
 }
 
 .QuotedAnnouncementBubble--attachmentContainer {
+  max-width: 100%;
   .margin--bottom--xs();
 }
 

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -13,7 +13,7 @@
 }
 
 .QuotedAnnouncementBubble--container--white {
-  background-color: #ffffff; /* stylelint-disable-line */
+  background-color: @neutral_white;
   color: @neutral_dark_gray;
 }
 
@@ -76,6 +76,28 @@
 
 .QuotedAnnouncementBubble--messageTruncatedNotice--icon {
   margin-left: 0.3125rem;
+}
+
+.QuotedAnnouncementBubble--attachmentContainer {
+  .margin--bottom--xs();
+}
+
+// the below styles disable the MessagingAttachment's normal hover styles
+// for all of our usecases.
+.QuotedAnnouncementBubble--attachmentContainer--dark .MessagingAttachment--Container:hover {
+  background-color: #626776; /* stylelint-disable-line */
+  border-color: @neutral_silver;
+}
+
+.QuotedAnnouncementBubble--attachmentContainer--dark
+  .MessagingAttachment--Container:hover
+  .MessagingAttachment--Title,
+.QuotedAnnouncementBubble--attachmentContainer--dark .MessagingAttachment--TextContainer {
+  color: @neutral_white;
+}
+
+.QuotedAnnouncementBubble--attachmentContainer--dark img {
+  filter: brightness(0) invert(1); /* makes the file icon white without needing a different <img> src attr */
 }
 
 .QuotedAnnouncementBubble--messageDetails--light,

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -17,6 +17,7 @@ function cssClass(element: string) {
 export interface Props {
   theme: "quoted";
   announcementGroupName: string;
+  attachments?: React.ReactNode;
   children: React.ReactNode;
   className?: string;
   colorTheme: "white" | "light" | "dark";
@@ -35,6 +36,7 @@ export interface Props {
 
 export const QuotedAnnouncementBubble: React.FC<Props> = ({
   announcementGroupName,
+  attachments,
   children,
   className,
   colorTheme,
@@ -132,7 +134,12 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
         </FlexBox>
       )}
       {isExpanded && (
-        <span className={cssClass(`messageDetails--${colorTheme}`)}>{messageDetails}</span>
+        <>
+          {attachments && (
+            <FlexBox className={cssClass("attachmentContainer")}>{attachments}</FlexBox>
+          )}
+          <span className={cssClass(`messageDetails--${colorTheme}`)}>{messageDetails}</span>
+        </>
       )}
       <Button
         className={cssClass("button--outer")}

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -17,7 +17,7 @@ function cssClass(element: string) {
 export interface Props {
   theme: "quoted";
   announcementGroupName: string;
-  attachments?: React.ReactNode;
+  attachments?: React.ReactNode[];
   children: React.ReactNode;
   className?: string;
   colorTheme: "white" | "light" | "dark";

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -136,7 +136,14 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
       {isExpanded && (
         <>
           {attachments && (
-            <FlexBox className={cssClass("attachmentContainer")}>{attachments}</FlexBox>
+            <FlexBox
+              className={cx(
+                cssClass("attachmentContainer"),
+                cssClass(`attachmentContainer--${colorTheme}`),
+              )}
+            >
+              {attachments}
+            </FlexBox>
           )}
           <span className={cssClass(`messageDetails--${colorTheme}`)}>{messageDetails}</span>
         </>

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -29,6 +29,7 @@
 }
 
 .MessagingBubble--Message .MessagingAttachment--ParentContainer {
+  max-width: 100%;
   margin-right: 0;
 }
 
@@ -53,6 +54,7 @@
   justify-content: center;
   color: @neutral_dark_gray;
   max-width: 18.625rem; // 298px
+  .text--truncate();
 }
 
 // TODO: remove if unused

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -8,6 +8,7 @@
 
 .MessagingAttachment--ParentContainer {
   position: relative;
+  .text--truncate();
 }
 
 .MessagingAttachment--Container {

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -118,9 +118,11 @@
 
   .MessagingBubble--Message--Attachment--Own {
     width: auto;
+    .text--truncate();
   }
 
   .MessagingBubble--Message--Attachment--Other {
     width: auto;
+    .text--truncate();
   }
 }

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -13,10 +13,12 @@
 }
 
 .MessagingBubble--Message--Container--Own {
+  max-width: 100%;
   .items--end();
 }
 
 .MessagingBubble--Message--Container--Other {
+  max-width: 100%;
   .items--start();
 }
 
@@ -64,11 +66,13 @@
 .MessagingBubble--Message--TimestampBubbleContainer--Own {
   flex-direction: row;
   align-items: center;
+  max-width: 100%;
 }
 
 .MessagingBubble--Message--TimestampBubbleContainer--Other {
   flex-direction: row-reverse;
   align-items: center;
+  max-width: 100%;
 }
 
 .MessagingBubble--Message--Timestamp--Own {
@@ -78,6 +82,7 @@
   .text--line-height-1();
   white-space: nowrap;
   flex-shrink: 0;
+  min-width: 3.5rem;
 }
 
 .MessagingBubble--Message--Timestamp--Other {
@@ -87,6 +92,7 @@
   .text--line-height-1();
   white-space: nowrap;
   flex-shrink: 0;
+  min-width: 3.5rem;
 }
 
 // For mobile/tablet

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -34,6 +34,7 @@
   width: 100%;
   flex-direction: row;
   align-items: center;
+  justify-content: center;
 }
 
 .MessageMetadata--ReadReceipt {

--- a/src/MessagingThreadHistory/MessagingThreadHistory.less
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.less
@@ -23,6 +23,7 @@
     margin-top: 0.75rem;
     margin-bottom: 0.75rem;
   }
+
   .ThreadHistory--Container {
     padding-right: 0;
   }

--- a/src/MessagingThreadHistory/MessagingThreadHistory.less
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.less
@@ -23,4 +23,7 @@
     margin-top: 0.75rem;
     margin-bottom: 0.75rem;
   }
+  .ThreadHistory--Container {
+    padding-right: 0;
+  }
 }


### PR DESCRIPTION
# Jira: [M5G-294](https://clever.atlassian.net/browse/M5G-294)

## Overview

This PR adds the optional `attachments` prop to the `NormalAttachmentBubble` and `QuotedAttachmentBubble` components, which is passed into them via the `AttachmentBubble` component. This prop accepts an array of react components to display within the announcement. This will allow us to display attachments in all announcement contexts.

The PR also adds a handful of styling changes as dictated by [these figma docs](https://www.figma.com/file/HE5OffYDhp2nElIFahzYlt/Clever-Messages-v2-(Attachments)?node-id=430%3A22449). These changes focus around refinements to the `NormalAnnouncementBubble` which is now narrower in all desktop screens and has less rounded corners.

## Screenshots/GIFs

### Updated Dewey docs:
**NormalAnnouncementBubble**
![image](https://user-images.githubusercontent.com/6520345/122479069-5c397e00-cf7f-11eb-9848-494fe9192569.png)

**QuotedAnnouncementBubble**
![image](https://user-images.githubusercontent.com/6520345/122479274-a3277380-cf7f-11eb-8b15-44e65f1ecadb.png)


### Student mobile
**Receiving announcement with attachment**
![image](https://user-images.githubusercontent.com/6520345/122270496-3d5dbd80-ce93-11eb-9341-af33b2d81a8b.png)

**With deleted announcement**
![image](https://user-images.githubusercontent.com/6520345/122270747-7e55d200-ce93-11eb-9a2d-5b1ecc13f72b.png)

**Drafting a response**
![image](https://user-images.githubusercontent.com/6520345/122274565-86b00c00-ce97-11eb-8028-4ab7a533cc2e.png)

**After responding in DM**
Note (a `width` styling in launchpad needs to be removed in student messaging, see below for improvement)
![image](https://user-images.githubusercontent.com/6520345/122474131-a3bc0c00-cf77-11eb-90fb-797f196a7bca.png)
After above `width` styling in launchpad is removed
![image](https://user-images.githubusercontent.com/6520345/122474249-d36b1400-cf77-11eb-90ec-f7a1a606eaf1.png)



### Teacher announcements, mobile
![image](https://user-images.githubusercontent.com/6520345/122270603-56ff0500-ce93-11eb-85ea-6dd443d1d1a4.png)

**With deleted message**
![image](https://user-images.githubusercontent.com/6520345/122270661-67af7b00-ce93-11eb-9060-f9d5ab1ac0d4.png)

**Seeing quoted announcement in message from student**
![image](https://user-images.githubusercontent.com/6520345/122476487-25f9ff80-cf7b-11eb-836a-8b774c5235dc.png)


## Testing

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [x] Posted in #eng if I made a breaking change to a beta component
