### PR TITLE
handle empty attachments array for bubbles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.120.0",
+  "version": "2.121.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -59,7 +59,9 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
       <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
         <div className={cssClass("messageBody")}>{children}</div>
       </Linkify>
-      {attachments && <FlexBox className={cssClass("attachmentContainer")}>{attachments}</FlexBox>}
+      {attachments?.length > 0 && (
+        <FlexBox className={cssClass("attachmentContainer")}>{attachments}</FlexBox>
+      )}
       {replyButton}
     </FlexBox>
   );

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -135,7 +135,7 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
       )}
       {isExpanded && (
         <>
-          {attachments && (
+          {attachments?.length > 0 && (
             <FlexBox
               className={cx(
                 cssClass("attachmentContainer"),

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -22,6 +22,7 @@
   height: @ICON_REGULAR_SIZE;
   border: @size_4xs solid @neutral_silver;
   border-radius: @size_2xs;
+  box-sizing: content-box;
 }
 
 .MessagingBubble--Message .MessagingAttachment--Container {

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -82,7 +82,7 @@ export const MessagingBubble: React.FC<Props> = ({
           </Linkify>
         </div>
       </FlexBox>
-      {attachments && <FlexBox className={attachmentClassNames}>{attachments}</FlexBox>}
+      {attachments?.length > 0 && <FlexBox className={attachmentClassNames}>{attachments}</FlexBox>}
     </FlexBox>
   );
 };


### PR DESCRIPTION
**Overview:**
We were adding the attachments containers in AnnouncementBubble and MessagingBubble even when the attachments array was empty. This wasn't affecting the messaging bubble size since the container was of size 0 but the AnnouncementBubble attachment container had some margin on the top, which was creating some extra whitespace.


**Screenshots/GIFs:**
BEFORE
<img width="609" alt="Screen Shot 2021-06-22 at 3 05 54 PM" src="https://user-images.githubusercontent.com/29630673/123006044-f6c50300-d36b-11eb-845b-c308d3c438f5.png">

AFTER
<img width="687" alt="Screen Shot 2021-06-22 at 3 06 13 PM" src="https://user-images.githubusercontent.com/29630673/123006047-f7f63000-d36b-11eb-8990-bed578f46e68.png">

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
