### PR TITLE
M5G-332: Check me out, I've got a checkbox!

### DIFF
--- a/docs/components/MessagingInputView.jsx
+++ b/docs/components/MessagingInputView.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-alert */
 import * as React from "react";
 
 import Example, { CodeSample, ExampleCode } from "./Example";
@@ -33,6 +34,8 @@ export default class MessagingInputView extends React.PureComponent {
     showReturnKeyInstructions: false,
     showUploadAttachmentButton: false,
     attachments: [],
+    checkboxValue: false,
+    showCheckbox: false,
   };
 
   render() {
@@ -44,6 +47,8 @@ export default class MessagingInputView extends React.PureComponent {
       showReturnKeyInstructions,
       showUploadAttachmentButton,
       attachments,
+      checkboxValue,
+      showCheckbox,
     } = this.state;
     const exampleReplyMessage = (
       <MessagingBubble className={cssClass.EXAMPLE_MESSAGE_REPLY} theme="otherMessage">
@@ -124,7 +129,6 @@ export default class MessagingInputView extends React.PureComponent {
               newlineOnEnter={newlineOnEnter}
               onChange={(newValue) => this.setState({ inputValue: newValue })}
               onSubmit={(message) => {
-                // eslint-disable-next-line no-alert
                 alert(message);
                 this.setState({ inputValue: "" });
               }}
@@ -138,6 +142,14 @@ export default class MessagingInputView extends React.PureComponent {
                 callbacks.success();
               }}
               attachments={attachments}
+              checkbox={
+                showCheckbox && {
+                  isChecked: checkboxValue,
+                  isVisible: true,
+                  label: "This is a checkbox!",
+                  onChange: (newValue) => this.setState({ checkboxValue: newValue }),
+                }
+              }
             />
           </ExampleCode>
           <label className={cssClass.CONFIG}>
@@ -196,8 +208,15 @@ export default class MessagingInputView extends React.PureComponent {
             />{" "}
             Show uploaded attachments
           </label>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={showCheckbox}
+              onChange={({ target }) => this.setState({ showCheckbox: target.checked })}
+            />{" "}
+            Show checkbox
+          </label>
         </Example>
-
         {this._renderProps()}
       </View>
     );
@@ -291,6 +310,13 @@ export default class MessagingInputView extends React.PureComponent {
             name: "attachments",
             type: "React.ReactNode[]",
             description: "Optional list of ReactNodes to render as uploaded attachments",
+            optional: true,
+          },
+          {
+            name: "checkbox",
+            type: "object",
+            description:
+              "Object type: { isChecked: boolean,\n isVisible: boolean,\n label: React.ReactNode,\n onChange: (value: boolean) => void }. An optional checkbox to display above the input with a customizable label.",
             optional: true,
           },
         ]}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.121.0",
+  "version": "2.122.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -65,16 +65,16 @@
   height: 1.25rem;
   border-radius: 50%;
   cursor: pointer;
-  background-color: @neutral_silver;
-  color: @neutral_dark_gray;
-  border: none;
+  background-color: @neutral_medium_gray;
+  border: @size_3xs solid white;
+  color: @neutral_white;
   padding: 0;
 
   &:hover,
   &:focus,
   &:active {
-    background-color: @neutral_gray;
-    color: @neutral_off_white;
+    background-color: @neutral_black;
+    color: @neutral_white;
   }
 }
 

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -27,6 +27,7 @@
 .MessagingInput--Checkbox {
   margin-left: auto;
   animation: fadein 0.25s;
+  .text--truncate();
 }
 
 .MessagingInput--InnerContainer {
@@ -85,6 +86,7 @@
 .MessagingInput--TextFieldLabel {
   color: @neutral_medium_gray;
   .margin--bottom--2xs();
+  .margin--right--m();
 }
 
 .MessagingInput--TextFieldLabelHidden {

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -26,10 +26,7 @@
 
 .MessagingInput--Checkbox {
   margin-left: auto;
-
-  .Checkbox--label {
-    .margin--left--s();
-  }
+  animation: fadein 0.25s;
 }
 
 .MessagingInput--InnerContainer {
@@ -144,6 +141,7 @@ button.MessagingInput--SendButton {
 
 .MessagingInput--InstructionsLabel {
   color: @neutral_medium_gray;
+  animation: fadein 0.25s;
   font-size: 0.75rem; // 12px
   line-height: 1rem;
   .margin--y--2xs();
@@ -169,6 +167,16 @@ button.MessagingInput--SendButton {
 
 .MessagingAttachment--ParentContainer {
   .margin--right--m();
+}
+
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 // For mobile/tablet

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -24,6 +24,14 @@
   }
 }
 
+.MessagingInput--Checkbox {
+  margin-left: auto;
+
+  .Checkbox--label {
+    .margin--left--s();
+  }
+}
+
 .MessagingInput--InnerContainer {
   align-items: flex-end;
   width: 100%;

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as cx from "classnames";
 
-import { TextArea, Button, FlexBox, ItemAlign } from "../index";
+import { TextArea, Button, FlexBox, ItemAlign, Checkbox } from "../index";
 import KeyCode from "../utils/KeyCode";
 import * as FontAwesome from "react-fontawesome";
 
@@ -34,6 +34,12 @@ interface Props {
   showUploadAttachmentButton?: boolean;
   store?: (file, callbacks) => void;
   attachments?: React.ReactNode[];
+  checkbox?: {
+    isChecked: boolean;
+    isVisible: boolean;
+    label: React.ReactNode;
+    onChange: (value: boolean) => void;
+  };
 }
 
 export interface MessagingInputHandle {
@@ -62,6 +68,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
     showUploadAttachmentButton,
     store,
     attachments,
+    checkbox,
   } = props;
   const textAreaRef = React.useRef<TextArea>(null);
 
@@ -83,14 +90,25 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
       column
       alignItems={ItemAlign.START}
     >
-      <label
-        htmlFor={TEXT_FIELD_NAME}
-        className={cssClass(replyTo ? "TextFieldLabelHidden" : "TextFieldLabel")}
-      >
-        {labelText}
-      </label>
       <FlexBox className={cssClass("InnerContainer")}>
         <FlexBox column className={cx(cssClass("InnerContainer--Content"))}>
+          <FlexBox grow alignItems="center">
+            <label
+              htmlFor={TEXT_FIELD_NAME}
+              className={cssClass(replyTo ? "TextFieldLabelHidden" : "TextFieldLabel")}
+            >
+              {labelText}
+            </label>
+            {checkbox?.isVisible && (
+              <Checkbox
+                className={cssClass("Checkbox")}
+                checked={checkbox.isChecked}
+                onChange={({ checked }) => checkbox.onChange(checked)}
+              >
+                {checkbox.label}
+              </Checkbox>
+            )}
+          </FlexBox>
           {replyTo && (
             <div className={cssClass("Reply--Container")}>
               <div className={cssClass("Reply--Content")}>

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -119,6 +119,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
                     role="button"
                     className={cssClass("Reply--CloseButton")}
                     onClick={onReplyCancel}
+                    aria-label="Cancel reply"
                   >
                     <FontAwesome name="times" className={cssClass("Reply--CloseIcon")} />
                   </button>


### PR DESCRIPTION
**Jira:**

https://clever.atlassian.net/browse/M5G-332

**Overview:**

For milestone 1c of Announcements, we want to give teacher's the ability to send an announcement to both guardians and students at the same time by checking a box. This PR adds the checkbox! It also adds a transition to both the return key instructions and the checkbox when appearing, according to Nick's designs.

Intended Figma design: 
![Screen Shot 2021-06-23 at 10 46 03 AM](https://user-images.githubusercontent.com/26425483/123144139-36ddc180-d410-11eb-863f-4bd3aa9f2916.png)

New input after this PR: 

https://user-images.githubusercontent.com/26425483/123154301-84136080-d41b-11eb-82da-204fc0807d96.mov





**Screenshots/GIFs:**

**Testing:**

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
