### PR TITLE
M5G-413 Attachments mobile refinements

### DIFF
--- a/docs/components/MessagingAttachmentView.jsx
+++ b/docs/components/MessagingAttachmentView.jsx
@@ -3,12 +3,13 @@ import * as React from "react";
 import Example, { CodeSample, ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import { MessagingAttachment, FlexBox } from "src";
+import { Label, MessagingAttachment, FlexBox } from "src";
 import { FileAttachmentIcon } from "src/MessagingAttachment/MessagingAttachment";
 
 import "./MessagingAttachmentView.less";
 
 const cssClass = {
+  BETA: "MessagingAttachmentView--beta",
   CONFIG_CONTAINER: "MessagingAttachmentView--configContainer",
   CONFIG_OPTIONS: "MessagingAttachmentView--configOptions",
   CONFIG: "MessagingAttachmentView--config",
@@ -31,6 +32,10 @@ export default class MessagingAttachmentView extends React.PureComponent {
         sourcePath="src/MessagingAttachment/MessagingAttachment.tsx"
       >
         <header className={cssClass.INTRO}>
+          <p className={cssClass.BETA}>
+            <Label color="new-feature">Beta</Label> MessagingAttachment is in Beta and breaking
+            changes may still be introduced.
+          </p>
           <p>
             MessagingAttachment component, to be used in AnnouncementBubble, MessagingBubble,
             MessagingInput, etc

--- a/docs/components/MessagingAttachmentView.less
+++ b/docs/components/MessagingAttachmentView.less
@@ -4,6 +4,10 @@
   .margin--bottom--xl;
 }
 
+.MessagingAttachmentView--beta {
+  .text--italic();
+}
+
 .MessagingAttachmentView--configContainer {
   .border--top--l(@neutral_silver);
   .margin--top--xl;

--- a/docs/components/SideBar/SideBar.jsx
+++ b/docs/components/SideBar/SideBar.jsx
@@ -109,7 +109,7 @@ export default class SideBar extends React.Component {
           {this._renderLink("/components/list", "List")}
           {this._renderLink("/components/logo", "Logo")}
           {this._renderLink("/components/menu", "Menu")}
-          {this._renderLink("/components/messaging-attachment", "MessagingAttachment")}
+          {this._renderLink("/components/messaging-attachment", "MessagingAttachment", { beta: true })}
           {this._renderLink("/components/messaging-avatar", "MessagingAvatar", { beta: true })}
           {this._renderLink("/components/messaging-bubble", "MessagingBubble", { beta: true })}
           {this._renderLink("/components/messaging-input", "MessagingInput", { beta: true })}

--- a/docs/components/SideBar/SideBar.jsx
+++ b/docs/components/SideBar/SideBar.jsx
@@ -109,7 +109,9 @@ export default class SideBar extends React.Component {
           {this._renderLink("/components/list", "List")}
           {this._renderLink("/components/logo", "Logo")}
           {this._renderLink("/components/menu", "Menu")}
-          {this._renderLink("/components/messaging-attachment", "MessagingAttachment", { beta: true })}
+          {this._renderLink("/components/messaging-attachment", "MessagingAttachment", {
+            beta: true,
+          })}
           {this._renderLink("/components/messaging-avatar", "MessagingAvatar", { beta: true })}
           {this._renderLink("/components/messaging-bubble", "MessagingBubble", { beta: true })}
           {this._renderLink("/components/messaging-input", "MessagingInput", { beta: true })}

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -204,11 +204,14 @@
     padding: @size_s @size_s @size_s @size_xs;
     width: auto;
   }
-  .MessagingBubble--Message .MessagingAttachment--Container {
-    // Full width for small screens
-    width: auto;
-  }
+ 
   .MessagingAttachment--Title {
     font-size: @type_small_medium; //14px
+  }
+  .MessagingBubble--Message--Container--Own .MessagingAttachment--Container {
+    margin-left: @size_5xl;
+  }
+  .MessagingBubble--Message--Container--Other .MessagingAttachment--Container {
+    margin-right: @size_5xl;
   }
 }

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -200,9 +200,15 @@
 
 // For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
-  .MessagingAttachment--Container,
+  .MessagingAttachment--Container {
+    padding: @size_s @size_s @size_s @size_xs;
+    width: auto;
+  }
   .MessagingBubble--Message .MessagingAttachment--Container {
     // Full width for small screens
     width: auto;
+  }
+  .MessagingAttachment--Title {
+    font-size: @type_small_medium; //14px
   }
 }

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -198,6 +198,10 @@
   }
 }
 
+.MessagingAttachment--ParentContainer.MessagingAttachment--ParentContainer--IsUpload {
+  overflow: visible; // ensures you can see the x icon in top right corner
+}
+
 // For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
   .MessagingAttachment--Container {

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -208,9 +208,11 @@
   .MessagingAttachment--Title {
     font-size: @type_small_medium; //14px
   }
+
   .MessagingBubble--Message--Container--Own .MessagingAttachment--Container {
     margin-left: @size_5xl;
   }
+
   .MessagingBubble--Message--Container--Other .MessagingAttachment--Container {
     margin-right: @size_5xl;
   }

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -204,7 +204,7 @@
     padding: @size_s @size_s @size_s @size_xs;
     width: auto;
   }
- 
+
   .MessagingAttachment--Title {
     font-size: @type_small_medium; //14px
   }

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -34,7 +34,9 @@ export const MessagingAttachment: React.FC<Props> = ({
   uploadComplete,
 }: Props) => {
   return (
-    <FlexBox className={cssClass("ParentContainer")}>
+    <FlexBox
+      className={cx(cssClass("ParentContainer"), isUpload && cssClass("ParentContainer--IsUpload"))}
+    >
       {onRemoveAttachment && (
         <button
           className={cssClass("CloseButton")}

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -171,10 +171,6 @@ button.MessagingInput--SendButton {
   .margin--right--m();
 }
 
-.MessagingInput--UploadedAttachments .MessagingAttachment--ParentContainer {
-  overflow: visible; // ensures you can see the x icon in top right corner
-}
-
 @keyframes fadein {
   from {
     opacity: 0;

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -167,6 +167,10 @@ button.MessagingInput--SendButton {
   .padding--bottom--xs();
 }
 
+.MessagingInput--UploadedAttachments .MessagingAttachment--ParentContainer {
+  overflow: visible; // ensures you can see the x icon in top right corner
+}
+
 .MessagingAttachment--ParentContainer {
   .margin--right--m();
 }

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -167,12 +167,12 @@ button.MessagingInput--SendButton {
   .padding--bottom--xs();
 }
 
-.MessagingInput--UploadedAttachments .MessagingAttachment--ParentContainer {
-  overflow: visible; // ensures you can see the x icon in top right corner
-}
-
 .MessagingAttachment--ParentContainer {
   .margin--right--m();
+}
+
+.MessagingInput--UploadedAttachments .MessagingAttachment--ParentContainer {
+  overflow: visible; // ensures you can see the x icon in top right corner
 }
 
 @keyframes fadein {


### PR DESCRIPTION
## Jira: [M5G-413](https://clever.atlassian.net/browse/M5G-413)

## Overview:
 This PR updates the messaging attachment component to properly respond to the mobile setting. Here are the details as documented in [the figma](https://www.figma.com/file/HE5OffYDhp2nElIFahzYlt/Clever-Messages-v2-(Attachments)?node-id=430%3A22449): 

1. Ensure that attachments on mobile are a shorter height of 56px
2. Font on mobile attachments is adjusted to 14px
3. Adjust the padding within the attachment to match the (12px instead of 16px)
4. Ensure that the attachment width is responsive according to the sequence of mocks here. That is, the attachment and the message bubble should maintain the same width once the message bubble is small enough (because of the narrow screen size). **Note the gifs below aim to demonstrate this change, primarily**

While working on this PR, I also found an issue with the x icon on the uploaded attachment, which is fixed here.

The PR also updates the MessagingAttachment component documentation to properly label it as a **Beta** componenet.



## Screenshots/GIFs: 
#### Before:
![image](https://user-images.githubusercontent.com/6520345/123344071-ef3a6100-d507-11eb-91fc-b9c568eecc15.png)

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/6520345/123344221-43dddc00-d508-11eb-93ea-d43f3d180d48.gif)

![image](https://user-images.githubusercontent.com/6520345/123349094-4a6f5200-d50e-11eb-87c6-09c3aa5feb22.png)

![image](https://user-images.githubusercontent.com/6520345/123355399-755fa300-d51a-11eb-8219-e7939da62ae3.png)


#### After
![image](https://user-images.githubusercontent.com/6520345/123341165-5bb26180-d502-11eb-8395-7ff6a29e380b.png)

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/6520345/123341627-21958f80-d503-11eb-9b7d-d6ca91252a9a.gif)

![image](https://user-images.githubusercontent.com/6520345/123355181-fbc7b500-d519-11eb-80ed-266593c1f8bd.png)

![image](https://user-images.githubusercontent.com/6520345/123355358-60830f80-d51a-11eb-8490-b32c695c3706.png)




## Testing:
Styling changes only, no unit tests.
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

## Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
