### PR TITLE
M5G-462 Fixes MesssagingInput scroll styles mobile & desktop

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
-**Jira:**
+# Jira: [TKT-000](https://clever.atlassian.net/browse/TKT-000)
 
-**Overview:**
+# Overview:
 
-**Screenshots/GIFs:**
+# Screenshots/GIFs:
 
-**Testing:**
+# Testing:
 
 - [ ] Unit tests
 - Manual tests:
@@ -12,7 +12,7 @@
   - [ ] Safari
   - [ ] IE11
 
-**Roll Out:**
+# Roll Out:
 
 - Before merging:
   - [ ] Updated docs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.122.0",
+  "version": "2.123.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FileInput/FileInput.less
+++ b/src/FileInput/FileInput.less
@@ -29,6 +29,8 @@
 
 .FileInput--Icon {
   margin: auto;
+  position: absolute;
+  right: 0.5rem;
 }
 
 .FileInput--Text--selected {

--- a/src/FileInput/FileInput.less
+++ b/src/FileInput/FileInput.less
@@ -29,8 +29,6 @@
 
 .FileInput--Icon {
   margin: auto;
-  position: absolute;
-  right: 0.5rem;
 }
 
 .FileInput--Text--selected {

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -15,6 +15,8 @@
   }
 
   .FileInput--Icon {
+    position: absolute;
+    right: 0.5rem;
     margin: 0.25rem 0.5rem 0.25rem 0.75rem;
     .borderRadius--l();
 

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -110,8 +110,10 @@
   .border--m(@neutral_silver);
 
   .TextArea--input {
+    .margin--y--none();
+    .padding--y--xs();
+    padding-right: 2.6rem;
     color: @neutral_dark_gray;
-    .margin--y--xs();
     // Fits 3 rows of text. Overflow is scrollable.
     max-height: @size_5xl;
     .text--line-height-4();
@@ -231,7 +233,7 @@ button.MessagingInput--SendButton {
 
   button.MessagingInput--SendButton {
     position: absolute;
-    right: 0.375rem;
+    right: 0.75rem;
     bottom: 0.375rem;
     height: @size_xl;
     width: @size_xl;


### PR DESCRIPTION
# Jira ticket: [M5G-462](https://clever.atlassian.net/browse/M5G-462)

# Overview:

This PR corrects a handful of quirks in the message input styling:

1. on desktop, the scrollbar appeared between the text and the attachment icon
2. on both desktop and mobile, when scrolling, the text at the bottom and the top would be cut off before the edge of the input box
3. on mobile, the scroll bar would slightly overlap the send button and fall behind it.

Also, I found myself needing to edit the PR template in the same way each time I make a PR, so I updated the PR template.

# Screenshots/GIFs:
## Desktop before
![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/6520345/123499199-d99d6800-d5e9-11eb-9bad-7f28814350ac.gif)

### Desktop after
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/6520345/123499221-02256200-d5ea-11eb-9987-a3a9a5e02a5e.gif)


### Mobile before
![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/6520345/123499286-7fe96d80-d5ea-11eb-95ac-26a6b31728de.gif)

### Mobile after
![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/6520345/123499301-a60f0d80-d5ea-11eb-9b56-555cc311b4d2.gif)


**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
    - [x] OSX's "Show scroll bars" setting of "Automatically based on mouse or trackpad"
    - [x] OSX's "Show scroll bars" setting of "When scrolling"
    - [x]  OSX's "Show scroll bars" setting of "Always"
  - [x] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
  
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
