### PR TITLE
M5G-332: Add onFocus prop to MessagingInput and clean up 

### DIFF
--- a/docs/components/MessagingInputView.jsx
+++ b/docs/components/MessagingInputView.jsx
@@ -240,7 +240,8 @@ export default class MessagingInputView extends React.PureComponent {
           {
             name: "onSubmit",
             type: "(message: string) => void",
-            description: "Function that's called when the text is submitted.",
+            description:
+              "Function that's called when the text is submitted. onSubmit accepts a value rather than submitting the current message value so that we may trim it before the send happens. Otherwise, the consumer would have to handle the trim themselves.",
           },
           {
             name: "onFocus",

--- a/docs/components/MessagingInputView.jsx
+++ b/docs/components/MessagingInputView.jsx
@@ -243,6 +243,12 @@ export default class MessagingInputView extends React.PureComponent {
             description: "Function that's called when the text is submitted.",
           },
           {
+            name: "onFocus",
+            type: "() => void",
+            description: "Function that's called when the input is focused.",
+            optional: true,
+          },
+          {
             name: "onBlur",
             type: "() => void",
             description: "Function that's called when the input is unfocused.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.123.0",
+  "version": "2.124.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -4,34 +4,6 @@
   position: relative;
 }
 
-.MessagingInput--ShowUploadAttachmentButton .FileInput {
-  height: @size_2xl;
-  .padding--none();
-  border: none;
-
-  // Hide FileInput after file has been selected and uploading has begun
-  &.FileInput--AttachmentIsUploading {
-    display: none;
-  }
-
-  .FileInput--Icon {
-    position: absolute;
-    right: 0.5rem;
-    margin: 0.25rem 0.5rem 0.25rem 0.75rem;
-    .borderRadius--l();
-
-    &:hover {
-      fill: #f5f8fd;
-    }
-  }
-}
-
-.MessagingInput--Checkbox {
-  margin-left: auto;
-  animation: fadein 0.25s;
-  .text--truncate();
-}
-
 .MessagingInput--InnerContainer {
   align-items: flex-end;
   width: 100%;
@@ -42,6 +14,39 @@
   .margin--right--xs();
   overflow-y: auto;
 }
+
+// ----- Info that shows above reply/text area
+
+.MessagingInput--TopInfo--Container {
+  .margin--bottom--2xs();
+}
+
+.MessagingInput--TopInfo--Checkbox {
+  margin-left: auto;
+  animation: fadein 0.25s;
+  .text--truncate();
+}
+
+.MessagingInput--TopInfo--Label {
+  color: @neutral_medium_gray;
+  .margin--right--m();
+}
+
+.MessagingInput--TopInfo--Label--hidden {
+  /* stylelint-disable */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap; /* added line */
+  border: 0;
+  /* stylelint-enable */
+}
+
+// ----- Reply
 
 .MessagingInput--Reply--Container {
   justify-content: center;
@@ -85,25 +90,7 @@
   margin-left: 0.0625rem; // 1 px because the FA icon is slightly off center
 }
 
-.MessagingInput--TextFieldLabel {
-  color: @neutral_medium_gray;
-  .margin--bottom--2xs();
-  .margin--right--m();
-}
-
-.MessagingInput--TextFieldLabelHidden {
-  /* stylelint-disable */
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap; /* added line */
-  border: 0;
-  /* stylelint-enable */
-}
+// ----- Text input and send button
 
 .MessagingInput--TextField {
   .padding--y--none();
@@ -145,6 +132,8 @@ button.MessagingInput--SendButton {
   line-height: normal;
 }
 
+// ----- Return key instructions underneath MessagingInput
+
 .MessagingInput--InstructionsLabel {
   color: @neutral_medium_gray;
   animation: fadein 0.25s;
@@ -166,6 +155,8 @@ button.MessagingInput--SendButton {
   .margin--left--m();
 }
 
+// ----- Attachments
+
 .MessagingInput--UploadedAttachments {
   .padding--top--m();
   .padding--bottom--xs();
@@ -173,6 +164,28 @@ button.MessagingInput--SendButton {
 
 .MessagingAttachment--ParentContainer {
   .margin--right--m();
+}
+
+.MessagingInput--ShowUploadAttachmentButton .FileInput {
+  height: @size_2xl;
+  .padding--none();
+  border: none;
+
+  // Hide FileInput after file has been selected and uploading has begun
+  &.FileInput--AttachmentIsUploading {
+    display: none;
+  }
+
+  .FileInput--Icon {
+    position: absolute;
+    right: 0.5rem;
+    margin: 0.25rem 0.5rem 0.25rem 0.75rem;
+    .borderRadius--l();
+
+    &:hover {
+      fill: #f5f8fd;
+    }
+  }
 }
 
 @keyframes fadein {

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -15,24 +15,24 @@
   overflow-y: auto;
 }
 
-// ----- Info that shows above reply/text area
+// ----- Label and checkbox that show above reply/text area
 
-.MessagingInput--TopInfo--Container {
+.MessagingInput--LabelAndCheckbox--Container {
   .margin--bottom--2xs();
 }
 
-.MessagingInput--TopInfo--Checkbox {
+.MessagingInput--LabelAndCheckbox--Checkbox {
   margin-left: auto;
   animation: fadein 0.25s;
   .text--truncate();
 }
 
-.MessagingInput--TopInfo--Label {
+.MessagingInput--LabelAndCheckbox--Label {
   color: @neutral_medium_gray;
   .margin--right--m();
 }
 
-.MessagingInput--TopInfo--Label--hidden {
+.MessagingInput--LabelAndCheckbox--Label--hidden {
   /* stylelint-disable */
   position: absolute;
   width: 1px;

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
+import { useRef, useImperativeHandle } from "react";
+import * as FontAwesome from "react-fontawesome";
 import * as cx from "classnames";
 
 import { TextArea, Button, FlexBox, ItemAlign, Checkbox } from "../index";
 import KeyCode from "../utils/KeyCode";
-import * as FontAwesome from "react-fontawesome";
 
 import "./MessagingInput.less";
-import { useRef, useImperativeHandle } from "react";
 
 function cssClass(element: string) {
   return `MessagingInput--${element}`;

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -6,6 +6,7 @@ import KeyCode from "../utils/KeyCode";
 import * as FontAwesome from "react-fontawesome";
 
 import "./MessagingInput.less";
+import { useRef, useImperativeHandle } from "react";
 
 function cssClass(element: string) {
   return `MessagingInput--${element}`;
@@ -70,9 +71,9 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
     attachments,
     checkbox,
   } = props;
-  const textAreaRef = React.useRef<TextArea>(null);
+  const textAreaRef = useRef<TextArea>(null);
 
-  React.useImperativeHandle(ref, () => ({
+  useImperativeHandle(ref, () => ({
     focus: () => {
       if (textAreaRef.current) {
         textAreaRef.current.focus();
@@ -91,17 +92,17 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
       alignItems={ItemAlign.START}
     >
       <FlexBox className={cssClass("InnerContainer")}>
-        <FlexBox column className={cx(cssClass("InnerContainer--Content"))}>
-          <FlexBox grow alignItems="center">
+        <FlexBox column className={cssClass("InnerContainer--Content")}>
+          <FlexBox alignItems="center" className={cssClass("TopInfo--Container")} grow>
             <label
               htmlFor={TEXT_FIELD_NAME}
-              className={cssClass(replyTo ? "TextFieldLabelHidden" : "TextFieldLabel")}
+              className={cssClass(replyTo ? "TopInfo--Label--hidden" : "TopInfo--Label")}
             >
               {labelText}
             </label>
             {checkbox?.isVisible && (
               <Checkbox
-                className={cssClass("Checkbox")}
+                className={cssClass("TopInfo--Checkbox")}
                 checked={checkbox.isChecked}
                 onChange={({ checked }) => checkbox.onChange(checked)}
               >

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -13,34 +13,35 @@ function cssClass(element: string) {
 }
 
 interface Props {
-  className?: string;
-  newlineOnEnter?: boolean;
-  value: string;
-  onChange: (newValue: string) => void;
-  // onSubmit accepts a value rather than submitting the current message value
-  //  so that we may trim it precisely before the send happens. Otherwise,
-  //  the consumer would have to handle the trim themselves.
-  onSubmit: (message: string) => void;
-  onBlur?: () => void;
-  // optional content to display when replying to a message
-  replyTo?: React.ReactNode;
-  // optional callback for cancelling reply
-  onReplyCancel?: () => void;
-  /** Temporarily added to allow overriding the text with a translation. */
-  sendButtonText?: string;
-  /** Temporarily added to allow overriding the text with a translation. */
-  labelText?: string;
-  disableSendButton?: boolean;
-  showReturnKeyInstructions?: boolean;
-  showUploadAttachmentButton?: boolean;
-  store?: (file, callbacks) => void;
   attachments?: React.ReactNode[];
+  className?: string;
   checkbox?: {
     isChecked: boolean;
     isVisible: boolean;
     label: React.ReactNode;
     onChange: (value: boolean) => void;
   };
+  disableSendButton?: boolean;
+  /** Temporarily added to allow overriding the text with a translation. */
+  labelText?: string;
+  onBlur?: () => void;
+  onChange: (newValue: string) => void;
+  onFocus?: () => void;
+  // optional callback for cancelling reply
+  onReplyCancel?: () => void;
+  // onSubmit accepts a value rather than submitting the current message value
+  //  so that we may trim it precisely before the send happens. Otherwise,
+  //  the consumer would have to handle the trim themselves.
+  onSubmit: (message: string) => void;
+  newlineOnEnter?: boolean;
+  /** Temporarily added to allow overriding the text with a translation. */
+  // optional content to display when replying to a message
+  replyTo?: React.ReactNode;
+  sendButtonText?: string;
+  showReturnKeyInstructions?: boolean;
+  showUploadAttachmentButton?: boolean;
+  store?: (file, callbacks) => void;
+  value: string;
 }
 
 export interface MessagingInputHandle {
@@ -54,22 +55,23 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
   ref,
 ) => {
   const {
+    attachments,
+    checkbox,
     className,
-    newlineOnEnter,
-    value,
-    onChange,
-    onSubmit,
-    onBlur,
-    replyTo,
-    onReplyCancel,
-    sendButtonText = "Send",
-    labelText = "Send a message",
     disableSendButton,
+    labelText = "Send a message",
+    newlineOnEnter,
+    onBlur,
+    onChange,
+    onFocus,
+    onReplyCancel,
+    onSubmit,
+    replyTo,
+    sendButtonText = "Send",
     showReturnKeyInstructions,
     showUploadAttachmentButton,
     store,
-    attachments,
-    checkbox,
+    value,
   } = props;
   const textAreaRef = useRef<TextArea>(null);
 
@@ -150,6 +152,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
             }}
             placeholder={replyTo ? labelText : ""}
             onBlur={onBlur}
+            onFocus={onFocus}
             autoResize
             // The field starts with `rows + 1` rows, so
             //  passing in 0 gets us the desired starting height.

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -22,26 +22,21 @@ interface Props {
     onChange: (value: boolean) => void;
   };
   disableSendButton?: boolean;
-  /** Temporarily added to allow overriding the text with a translation. */
-  labelText?: string;
+  newlineOnEnter?: boolean;
   onBlur?: () => void;
   onChange: (newValue: string) => void;
   onFocus?: () => void;
-  // optional callback for cancelling reply
   onReplyCancel?: () => void;
-  // onSubmit accepts a value rather than submitting the current message value
-  //  so that we may trim it precisely before the send happens. Otherwise,
-  //  the consumer would have to handle the trim themselves.
   onSubmit: (message: string) => void;
-  newlineOnEnter?: boolean;
-  /** Temporarily added to allow overriding the text with a translation. */
-  // optional content to display when replying to a message
   replyTo?: React.ReactNode;
-  sendButtonText?: string;
   showReturnKeyInstructions?: boolean;
   showUploadAttachmentButton?: boolean;
   store?: (file, callbacks) => void;
   value: string;
+
+  // Allows overriding the text with a translation
+  labelText?: string;
+  sendButtonText?: string;
 }
 
 export interface MessagingInputHandle {

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -90,16 +90,18 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
     >
       <FlexBox className={cssClass("InnerContainer")}>
         <FlexBox column className={cssClass("InnerContainer--Content")}>
-          <FlexBox alignItems="center" className={cssClass("TopInfo--Container")} grow>
+          <FlexBox alignItems="center" className={cssClass("LabelAndCheckbox--Container")} grow>
             <label
               htmlFor={TEXT_FIELD_NAME}
-              className={cssClass(replyTo ? "TopInfo--Label--hidden" : "TopInfo--Label")}
+              className={cssClass(
+                replyTo ? "LabelAndCheckbox--Label--hidden" : "LabelAndCheckbox--Label",
+              )}
             >
               {labelText}
             </label>
             {checkbox?.isVisible && (
               <Checkbox
-                className={cssClass("TopInfo--Checkbox")}
+                className={cssClass("LabelAndCheckbox--Checkbox")}
                 checked={checkbox.isChecked}
                 onChange={({ checked }) => checkbox.onChange(checked)}
               >


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/M5G-393

**Overview:**
This PR adds an onFocus prop to messagingInput to allow for AIM 1c, where we want to show the checkbox to appear only after the input is focused. Instead of building that into MessagingInput checkbox directly, I expose onFocus and checkbox.isVisible as props to allow the Checkbox to more flexible, in case there is a situation where we would want to always show the checkbox.

While I was at it, I also reorganized the CSS and props because they both felt were unorganized as the MessagingInput has gained so much functionality over the last few months.


**Screenshots/GIFs:**

https://user-images.githubusercontent.com/26425483/123682913-776a8000-d800-11eb-874c-a1d90dac7cb7.mov

More testing will be done as I integrate into LP in follow up PR


**Testing:**

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

**Roll Out:**

- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
