### PR TITLE
M5G-500 Messaging style polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.126.0",
+  "version": "2.128.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.128.0",
+  "version": "2.129.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.127.0",
+  "version": "2.126.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -220,7 +220,7 @@
   .MessagingBubble--Message--Container--Other .MessagingAttachment--Container {
     margin-right: @size_5xl;
   }
-  
+
   // ⬇️ In quoted announcements, we don't want the margins defined above ⬇️
   .MessagingBubble--Message--Container--Own
     .MessagingBubble--Message--Own.MessagingBubble--Message--Reply--Parent

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -220,4 +220,19 @@
   .MessagingBubble--Message--Container--Other .MessagingAttachment--Container {
     margin-right: @size_5xl;
   }
+  
+  // ⬇️ In quoted announcements, we don't want the margins defined above ⬇️
+  .MessagingBubble--Message--Container--Own
+    .MessagingBubble--Message--Own.MessagingBubble--Message--Reply--Parent
+    .MessagingAttachment--Container {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .MessagingBubble--Message--Container--Other
+    .MessagingBubble--Message--Other.MessagingBubble--Message--Reply--Parent
+    .MessagingAttachment--Container {
+    margin-left: 0;
+    margin-right: 0;
+  }
 }

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -42,14 +42,28 @@
   text-align: right;
   color: @neutral_medium_gray;
 }
+.MessageMetadata--ErrorContents {
+  width: 32.9375rem;
+  text-align: right;
+}
 
 .MessageMetadata--Error {
   color: @alert_red;
   line-height: 1rem;
-  margin-left: auto;
-  .margin--right--2xs();
   .margin--top--2xs();
   .text--smallMedium();
+}
+
+.MessageMetadata--Error--right {
+  justify-content: flex-end;
+}
+
+.MessageMetadata--Error--left {
+  justify-content: flex-start;
+}
+
+.MessageMetadata--Error--fullWidth, .MessageMetadata--Error--center {
+  justify-content: center;
 }
 
 .MessageMetadata--Error--Icon {

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -42,6 +42,7 @@
   text-align: right;
   color: @neutral_medium_gray;
 }
+
 .MessageMetadata--ErrorContents {
   width: 32.9375rem;
   text-align: right;

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -62,7 +62,8 @@
   justify-content: flex-start;
 }
 
-.MessageMetadata--Error--fullWidth, .MessageMetadata--Error--center {
+.MessageMetadata--Error--fullWidth,
+.MessageMetadata--Error--center {
   justify-content: center;
 }
 

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -26,16 +26,25 @@ export const MessageMetadata: React.FC<
     <div ref={ref} className={classNames(cssClass("Message--container"), className)}>
       <div className={cssClass(`Message--${placement}`)}>{children}</div>
       {readStatusText && <div className={cssClass("ReadReceipt")}>{readStatusText}</div>}
-      {errorMsg && formErrorContainer(errorMsg)}
+      {errorMsg && formErrorContainer(errorMsg, placement)}
     </div>
   );
 });
 
-function formErrorContainer(errorMsg: React.ReactNode): JSX.Element {
+function formErrorContainer(
+  errorMsg: React.ReactNode,
+  placement: "left" | "right" | "center" | "fullWidth",
+): JSX.Element {
   return (
-    <FlexBox className={cssClass("Error")} grow alignItems="center" justify="start">
-      <FontAwesome className={cssClass("Error--Icon")} name="exclamation-circle " />
-      {errorMsg}
+    <FlexBox
+      className={classNames(cssClass("Error"), cssClass(`Error--${placement}`))}
+      grow
+      alignItems="center"
+    >
+      <div className={cssClass("ErrorContents")}>
+        <FontAwesome className={cssClass("Error--Icon")} name="exclamation-circle " />
+        {errorMsg}
+      </div>
     </FlexBox>
   );
 }

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -33,10 +33,7 @@ export const MessageMetadata: React.FC<
   );
 });
 
-function formErrorContainer(
-  errorMsg: React.ReactNode,
-  placement: PlacementOptions,
-): JSX.Element {
+function formErrorContainer(errorMsg: React.ReactNode, placement: PlacementOptions): JSX.Element {
   return (
     <FlexBox
       className={classNames(cssClass("Error"), cssClass(`Error--${placement}`))}

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -9,9 +9,11 @@ function cssClass(element: string) {
   return `MessageMetadata--${element}`;
 }
 
+type PlacementOptions = "left" | "right" | "center" | "fullWidth";
+
 interface Props {
   className?: string;
-  placement: "left" | "right" | "center" | "fullWidth";
+  placement: PlacementOptions;
   timestamp?: Date;
   readStatusText?: string;
   errorMsg?: string;
@@ -33,7 +35,7 @@ export const MessageMetadata: React.FC<
 
 function formErrorContainer(
   errorMsg: React.ReactNode,
-  placement: "left" | "right" | "center" | "fullWidth",
+  placement: PlacementOptions,
 ): JSX.Element {
   return (
     <FlexBox


### PR DESCRIPTION
# Jira: [M5G-500](https://clever.atlassian.net/browse/M5G-500)

# Overview:
This PR addresses two styling problems that emerged this week.

1. The attachments in quoted announcements were narrower than we wanted them to be.
![image](https://user-images.githubusercontent.com/6520345/124318626-c3cdfc80-db2d-11eb-8732-e465d255320c.png)

2. The error messages below announcements were not contained below the announcement bubble.
![image](https://user-images.githubusercontent.com/6520345/124318686-dba58080-db2d-11eb-91a9-7d96ca36f647.png)


I resolved 1. by removing a margin for QuotedAnnouncements.

I resolved 2. by placing a container around the error message and adding some positioning info to the classes and styling them appropriately. 

# Screenshots/GIFs:
## Attachments in quoted announcements
### Teacher desktop
![image](https://user-images.githubusercontent.com/6520345/124319103-96358300-db2e-11eb-9ca1-a4568332b126.png)

### Teacher mobile
![image](https://user-images.githubusercontent.com/6520345/124319073-8453e000-db2e-11eb-8946-79774956def1.png)

### Student desktop
![image](https://user-images.githubusercontent.com/6520345/124319251-cb41d580-db2e-11eb-92fa-0fdee8af0d50.png)


### Student mobile
![image](https://user-images.githubusercontent.com/6520345/124319200-bcf3b980-db2e-11eb-8a5d-52a98cfa31a8.png)

## Announcement error messages
### Desktop
![image](https://user-images.githubusercontent.com/6520345/124318897-3a6afa00-db2e-11eb-9713-7c25fa7d8a9e.png)
### Mobile
![image](https://user-images.githubusercontent.com/6520345/124318956-54a4d800-db2e-11eb-9067-44aa1c9390b0.png)
### No regression in normal messaging errors
#### Desktop
![image](https://user-images.githubusercontent.com/6520345/124319675-6f2b8100-db2f-11eb-941b-ff8feb19795a.png)

#### Mobile
![image](https://user-images.githubusercontent.com/6520345/124319715-80748d80-db2f-11eb-8b4d-c273ce09442b.png)


# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`

- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
