### PR TITLE
M5G-430: error state, onPreviewAttachment

### DIFF
--- a/docs/components/AttachmentPreviewView.jsx
+++ b/docs/components/AttachmentPreviewView.jsx
@@ -11,6 +11,7 @@ const cssClass = {
   CONTAINER: "AttachmentPreviewView",
   INTRO: "AttachmentPreviewView--intro",
   PROPS: "AttachmentPreviewView--props",
+  ERROR_BUTTON: "AttachmentPreviewView--errorButton",
 };
 
 export default class AttachmentPreviewView extends React.PureComponent {
@@ -18,16 +19,25 @@ export default class AttachmentPreviewView extends React.PureComponent {
 
   state = {
     showingPreview: false,
+    fileToRender: null,
   };
 
   render() {
-    const { showingPreview } = this.state;
+    const { showingPreview, fileToRender } = this.state;
 
     const file = {
       id: "12345",
       title: "Raccooooooon.jpg",
       fileType: "jpg",
       url: "https://s3.amazonaws.com/assets.clever.com/Raccooooooon.jpg",
+    };
+
+    const errorFile = {
+      id: "12345",
+      title: "Raccooooooon.jpg",
+      fileType: "jpg",
+      url:
+        "https://s3.amazonaws.com/assets.clever.com/Raccooooooonlaskjdalskjdaslkdjaslkdjsaldkj.jpg",
     };
 
     return (
@@ -53,13 +63,21 @@ export default class AttachmentPreviewView extends React.PureComponent {
 
         <Example title="Basic Usage:">
           <ExampleCode>
-            <Button onClick={() => this.setState({ showingPreview: true })}>Show preview</Button>
+            <Button onClick={() => this.setState({ showingPreview: true, fileToRender: file })}>
+              Show preview
+            </Button>
+            <Button
+              className={cssClass.ERROR_BUTTON}
+              onClick={() => this.setState({ showingPreview: true, fileToRender: errorFile })}
+            >
+              Show error preview
+            </Button>
             {showingPreview && (
               <AttachmentPreview
-                attachmentID={file.id}
-                attachmentName={file.title}
-                attachmentURL={file.url}
-                fileType={file.fileType}
+                attachmentID={fileToRender.id}
+                attachmentName={fileToRender.title}
+                attachmentURL={fileToRender.url}
+                fileType={fileToRender.fileType}
                 onClickDownload={() => console.log("Downloaded attachment!")}
                 onClose={() => this.setState({ showingPreview: false })}
               />

--- a/docs/components/AttachmentPreviewView.jsx
+++ b/docs/components/AttachmentPreviewView.jsx
@@ -96,11 +96,6 @@ export default class AttachmentPreviewView extends React.PureComponent {
         title="<AttachmentPreview /> Props"
         availableProps={[
           {
-            name: "attachmentID",
-            type: "string",
-            description: "Unique ID for a given attachment",
-          },
-          {
             name: "attachmentName",
             type: "string",
             description: "The name of the attachment file",

--- a/docs/components/AttachmentPreviewView.jsx
+++ b/docs/components/AttachmentPreviewView.jsx
@@ -144,7 +144,7 @@ export default class AttachmentPreviewView extends React.PureComponent {
           },
           {
             name: "onClickDownload",
-            type: "(attachmentID: string) => void",
+            type: "() => void",
             description: "Function to run on clicking the download button",
           },
           {

--- a/docs/components/AttachmentPreviewView.less
+++ b/docs/components/AttachmentPreviewView.less
@@ -7,3 +7,7 @@
 .AttachmentPreviewView--props {
   .margin--top--l;
 }
+
+.Button.AttachmentPreviewView--errorButton {
+  margin-left: @size_m;
+}

--- a/docs/components/MessagingAttachmentView.jsx
+++ b/docs/components/MessagingAttachmentView.jsx
@@ -205,19 +205,21 @@ export default class MessagingAttachmentView extends React.PureComponent {
             },
             {
               name: "onClickDownload",
-              type: "(attachmentID: string) => void",
+              type: "() => void",
               description:
                 "Callback to be called upon clicking download on a MessagingAttachment. Passed down to AttachmentPreview",
             },
             {
               name: "onPreviewAttachment",
               type: "() => void",
-              description: "Callback to be called upon previewing an attachment",
+              description: "Optional callback to be called upon previewing an attachment",
+              optional: true,
             },
             {
               name: "onRemoveAttachment",
-              type: "(attachmentID: string) => void",
-              description: "Callback to be called upon clicking the Remove Attachment (X) button",
+              type: "() => void",
+              description:
+                "Optional callback to be called upon clicking the Remove Attachment (X) button",
               optional: true,
             },
             {

--- a/docs/components/MessagingAttachmentView.jsx
+++ b/docs/components/MessagingAttachmentView.jsx
@@ -63,7 +63,8 @@ export default class MessagingAttachmentView extends React.PureComponent {
                   key: "1",
                   attachmentID: "1",
                   fileType: "doc",
-                  onClickAttachment: () => console.log("clicked!"),
+                  onClickDownload: () => console.log("downloaded!"),
+                  onPreviewAttachment: () => console.log("previewed!"),
                   title:
                     "MyCoolDoclajsdjasldjaslkdjasldkjasldjaslkdjasldjasldjalskjdalskjdaslkjasljd.doc",
                   subtitle: "Click to download",
@@ -74,7 +75,8 @@ export default class MessagingAttachmentView extends React.PureComponent {
                   attachmentURL:
                     "https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2Fppcorn.com%2Fus%2Fwp-content%2Fuploads%2Fsites%2F14%2F2016%2F01%2Fcute-raccoon-ppcorn.jpg&f=1&nofb=1",
                   fileType: "png",
-                  onClickAttachment: () => console.log("clicked!"),
+                  onClickDownload: () => console.log("downloaded!"),
+                  onPreviewAttachment: () => console.log("previewed!"),
                   title: "Flyer.png",
                   subtitle: "Click to view",
                 },
@@ -82,7 +84,8 @@ export default class MessagingAttachmentView extends React.PureComponent {
                   key: "3",
                   attachmentID: "3",
                   fileType: "m4a",
-                  onClickAttachment: () => console.log("clicked!"),
+                  onClickDownload: () => console.log("downloaded!"),
+                  onPreviewAttachment: () => console.log("previewed!"),
                   title: "Morning message.m4a",
                   subtitle: "Click to download",
                 },
@@ -93,7 +96,8 @@ export default class MessagingAttachmentView extends React.PureComponent {
                   attachmentURL={attachment.attachmentURL}
                   fileType={attachment.fileType}
                   icon={attachment.icon}
-                  onClickAttachment={attachment.onClickAttachment}
+                  onClickDownload={attachment.onClickDownload}
+                  onPreviewAttachment={attachment.onPreviewAttachment}
                   title={attachment.title}
                   subtitle={attachment.subtitle}
                 />
@@ -200,9 +204,15 @@ export default class MessagingAttachmentView extends React.PureComponent {
               optional: true,
             },
             {
-              name: "onClickAttachment",
+              name: "onClickDownload",
               type: "(attachmentID: string) => void",
-              description: "Callback to be called upon clicking the Attachment",
+              description:
+                "Callback to be called upon clicking download on a MessagingAttachment. Passed down to AttachmentPreview",
+            },
+            {
+              name: "onPreviewAttachment",
+              type: "() => void",
+              description: "Callback to be called upon previewing an attachment",
             },
             {
               name: "onRemoveAttachment",

--- a/docs/components/MessagingAttachmentView.jsx
+++ b/docs/components/MessagingAttachmentView.jsx
@@ -176,11 +176,6 @@ export default class MessagingAttachmentView extends React.PureComponent {
           title="<MessagingAttachment /> Props"
           availableProps={[
             {
-              name: "attachmentID",
-              type: "string",
-              description: "Unique ID used to identify this attachment",
-            },
-            {
               name: "attachmentURL",
               type: "string",
               description: "URL for the attachment",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.125.0",
+  "version": "2.126.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AttachmentPreview/AttachmentPreview.less
+++ b/src/AttachmentPreview/AttachmentPreview.less
@@ -84,6 +84,20 @@
   .borderRadius--s();
 }
 
+.AttachmentPreview--ErrorContainer {
+  padding: @size_l;
+  background: @neutral_white;
+  line-height: @size_l;
+  border-radius: @size_xs;
+  color: @alert_red_shade_1;
+  font-weight: 600;
+}
+
+.AttachmentPreview--ErrorIcon {
+  font-size: @size_l;
+  .margin--right--xs();
+}
+
 // need to override Button styling, hence all the `color: @neutral_white !important;`
 .AttachmentPreview--DownloadButton {
   .margin--right--xs();

--- a/src/AttachmentPreview/AttachmentPreview.tsx
+++ b/src/AttachmentPreview/AttachmentPreview.tsx
@@ -10,7 +10,6 @@ import { AttachmentFileType, FileAttachmentIcon } from "../MessagingAttachment/M
 import "./AttachmentPreview.less";
 
 export interface Props {
-  attachmentID: string;
   attachmentName: string;
   attachmentURL: string;
   className?: string;
@@ -45,7 +44,6 @@ const ESC = 27;
  * Currently only used for images, but eventually will be used for PDFs and other attachment types.
  */
 export const AttachmentPreview: React.FC<Props> = ({
-  attachmentID,
   attachmentName,
   attachmentURL,
   className,

--- a/src/AttachmentPreview/AttachmentPreview.tsx
+++ b/src/AttachmentPreview/AttachmentPreview.tsx
@@ -1,6 +1,6 @@
 import * as classnames from "classnames";
 import * as React from "react";
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 import * as FontAwesome from "react-fontawesome";
 
 import { Button } from "../Button/Button";
@@ -33,6 +33,8 @@ export const cssClass = {
   CLOSE_BUTTON: "AttachmentPreview--CloseButton",
   PREVIEW_WINDOW: "AttachmentPreview--PreviewWindow",
   IMAGE_CONTAINER: "AttachmentPreview--ImageContainer",
+  ERROR_CONTAINER: "AttachmentPreview--ErrorContainer",
+  ERROR_ICON: "AttachmentPreview--ErrorIcon",
   FOOTER_BAR: "AttachmentPreview--FooterBar",
 };
 
@@ -54,6 +56,8 @@ export const AttachmentPreview: React.FC<Props> = ({
   onClickDownload,
   onClose,
 }) => {
+  const [imageLoadError, setImageLoadError] = useState(false);
+
   function handleKeyUp(e) {
     if (e.keyCode === ESC) {
       onClose();
@@ -78,6 +82,7 @@ export const AttachmentPreview: React.FC<Props> = ({
         </FlexItem>
         <Button
           type="linkPlain"
+          disabled={imageLoadError}
           className={cssClass.DOWNLOAD_CONTAINER}
           onClick={() => onClickDownload(attachmentID)}
         >
@@ -95,7 +100,18 @@ export const AttachmentPreview: React.FC<Props> = ({
       </FlexBox>
       <FlexBox className={cssClass.PREVIEW_WINDOW}>
         <FlexBox className={cssClass.IMAGE_CONTAINER}>
-          <img src={attachmentURL} alt={"attachment preview"} />
+          {!imageLoadError && (
+            <img
+              src={attachmentURL}
+              alt={"attachment preview"}
+              onError={() => setImageLoadError(true)}
+            />
+          )}
+          {imageLoadError && (
+            <FlexBox className={cssClass.ERROR_CONTAINER}>
+              <FontAwesome name={"frown-o"} className={cssClass.ERROR_ICON} /> Image load error
+            </FlexBox>
+          )}
         </FlexBox>
       </FlexBox>
       <FlexBox className={cssClass.FOOTER_BAR}>

--- a/src/AttachmentPreview/AttachmentPreview.tsx
+++ b/src/AttachmentPreview/AttachmentPreview.tsx
@@ -117,6 +117,7 @@ export const AttachmentPreview: React.FC<Props> = ({
       <FlexBox className={cssClass.FOOTER_BAR}>
         <Button
           type="linkPlain"
+          disabled={imageLoadError}
           className={cssClass.DOWNLOAD_CONTAINER}
           onClick={() => onClickDownload(attachmentID)}
         >

--- a/src/AttachmentPreview/AttachmentPreview.tsx
+++ b/src/AttachmentPreview/AttachmentPreview.tsx
@@ -18,7 +18,7 @@ export interface Props {
   downloadButtonTextDesktop?: string;
   downloadButtonTextMobile?: string;
   fileType: AttachmentFileType;
-  onClickDownload: (attachmentID: string) => void;
+  onClickDownload: () => void;
   onClose: () => void;
 }
 
@@ -84,7 +84,7 @@ export const AttachmentPreview: React.FC<Props> = ({
           type="linkPlain"
           disabled={imageLoadError}
           className={cssClass.DOWNLOAD_CONTAINER}
-          onClick={() => onClickDownload(attachmentID)}
+          onClick={onClickDownload}
         >
           <FontAwesome className={cssClass.DOWNLOAD_BUTTON} name="download" />{" "}
           {downloadButtonTextDesktop}
@@ -119,7 +119,7 @@ export const AttachmentPreview: React.FC<Props> = ({
           type="linkPlain"
           disabled={imageLoadError}
           className={cssClass.DOWNLOAD_CONTAINER}
-          onClick={() => onClickDownload(attachmentID)}
+          onClick={onClickDownload}
         >
           <FontAwesome className={cssClass.DOWNLOAD_BUTTON} name="download" />{" "}
           <span>{downloadButtonTextMobile}</span>

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -18,7 +18,8 @@ type Props = {
   fileType: AttachmentFileType;
   icon?: React.ReactNode;
   isUpload?: boolean;
-  onClickAttachment: (attachmentID: string) => void;
+  onPreviewAttachment: () => void;
+  onClickDownload: (attachmentID: string) => void;
   onRemoveAttachment?: (attachmentID: string) => void;
   subtitle?: string;
   title?: string;
@@ -32,7 +33,8 @@ export const MessagingAttachment: React.FC<Props> = ({
   errorMsg,
   fileType,
   icon,
-  onClickAttachment,
+  onPreviewAttachment,
+  onClickDownload,
   onRemoveAttachment,
   title,
   subtitle,
@@ -65,8 +67,9 @@ export const MessagingAttachment: React.FC<Props> = ({
         onClick={() => {
           if (isImageAttachment) {
             setAttachmentPreviewIsShowing(true);
+            onPreviewAttachment();
           } else {
-            onClickAttachment(attachmentID);
+            onClickDownload(attachmentID);
           }
         }}
       >
@@ -91,7 +94,7 @@ export const MessagingAttachment: React.FC<Props> = ({
           attachmentURL={attachmentURL}
           fileType={fileType}
           onClickDownload={() => {
-            onClickAttachment(attachmentID);
+            onClickDownload(attachmentID);
           }}
           onClose={() => setAttachmentPreviewIsShowing(false)}
         />

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -18,9 +18,9 @@ type Props = {
   fileType: AttachmentFileType;
   icon?: React.ReactNode;
   isUpload?: boolean;
-  onPreviewAttachment: () => void;
-  onClickDownload: (attachmentID: string) => void;
-  onRemoveAttachment?: (attachmentID: string) => void;
+  onPreviewAttachment?: () => void;
+  onClickDownload: () => void;
+  onRemoveAttachment?: () => void;
   subtitle?: string;
   title?: string;
   uploadComplete?: boolean;
@@ -67,9 +67,11 @@ export const MessagingAttachment: React.FC<Props> = ({
         onClick={() => {
           if (isImageAttachment) {
             setAttachmentPreviewIsShowing(true);
-            onPreviewAttachment();
+            if (onPreviewAttachment) {
+              onPreviewAttachment();
+            }
           } else {
-            onClickDownload(attachmentID);
+            onClickDownload();
           }
         }}
       >
@@ -93,9 +95,7 @@ export const MessagingAttachment: React.FC<Props> = ({
           attachmentName={title}
           attachmentURL={attachmentURL}
           fileType={fileType}
-          onClickDownload={() => {
-            onClickDownload(attachmentID);
-          }}
+          onClickDownload={onClickDownload}
           onClose={() => setAttachmentPreviewIsShowing(false)}
         />
       )}

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -12,7 +12,6 @@ function cssClass(element: string) {
 }
 
 type Props = {
-  attachmentID: string;
   attachmentURL: string;
   errorMsg?: string;
   fileType: AttachmentFileType;
@@ -28,7 +27,6 @@ type Props = {
 
 // TODO: replace with a discriminated union to keep the props neat
 export const MessagingAttachment: React.FC<Props> = ({
-  attachmentID,
   attachmentURL,
   errorMsg,
   fileType,
@@ -51,7 +49,7 @@ export const MessagingAttachment: React.FC<Props> = ({
       {onRemoveAttachment && (
         <button
           className={cssClass("CloseButton")}
-          onClick={(e) => handleRemoveClick(e, onRemoveAttachment, attachmentID)}
+          onClick={(e) => handleRemoveClick(e, onRemoveAttachment)}
           aria-label={`close attachment with title: "${title}"`}
         >
           <FontAwesome name="times" className={cssClass("CloseIcon")} />
@@ -91,7 +89,6 @@ export const MessagingAttachment: React.FC<Props> = ({
       </FlexBox>
       {attachmentPreviewIsShowing && isImageAttachment && (
         <AttachmentPreview
-          attachmentID={attachmentID}
           attachmentName={title}
           attachmentURL={attachmentURL}
           fileType={fileType}
@@ -103,9 +100,9 @@ export const MessagingAttachment: React.FC<Props> = ({
   );
 };
 
-function handleRemoveClick(e, onRemoveAttachment, attachmentID) {
+function handleRemoveClick(e, onRemoveAttachment) {
   e.stopPropagation();
-  onRemoveAttachment(attachmentID);
+  onRemoveAttachment();
 }
 
 // /// Sub-components, exported icon components to be used by consumers /// //


### PR DESCRIPTION
# Jira: 

[M5G-430](https://clever.atlassian.net/browse/M5G-430)

# Overview:

In this PR, I do three things.

1. Add a simple (temporary) error state, for when a url is invalid/does not lead to a valid image
  * Download button is disabled in this state
2. change MessagingAttachment's prop `onClickAttachment` to `onClickDownload`, and add a new prop `onPreviewAttachment`
3. Remove unnecessary passing of `attachmentID` to various `on...` functions

# Screenshots/GIFs:
![Screen Shot 2021-07-02 at 12 02 47 PM](https://user-images.githubusercontent.com/54862564/124320537-eca3c100-db30-11eb-8d6a-0fce4f58cee4.png)


# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Edge

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
