### PR TITLE
M5G: fix blank preview

### DIFF
--- a/docs/components/MessagingAttachmentView.jsx
+++ b/docs/components/MessagingAttachmentView.jsx
@@ -177,9 +177,9 @@ export default class MessagingAttachmentView extends React.PureComponent {
           title="<MessagingAttachment /> Props"
           availableProps={[
             {
-              name: "attachmentURL",
-              type: "string",
-              description: "URL for the attachment",
+              name: "attachmentPreviewProps",
+              type: "AttachmentPreviewProps (defined below)",
+              description: "Passthrough props for the AttachmentPreview",
             },
             {
               name: "errorMsg",
@@ -271,6 +271,38 @@ export default class MessagingAttachmentView extends React.PureComponent {
               name: "errorMsg",
               type: "string",
               description: "Used to determine whether or not to render the error state",
+              optional: true,
+            },
+          ]}
+          className={cssClass.PROPS}
+        />
+        <PropDocumentation
+          title="AttachmentPreviewProps type"
+          availableProps={[
+            {
+              name: "attachmentURL",
+              type: "string",
+              description: "URL for the attachment",
+            },
+            {
+              name: "closeButtonAriaLabel",
+              type: "string",
+              description: "Optional ARIA label for close button",
+              defaultValue: "close attachment preview",
+              optional: true,
+            },
+            {
+              name: "downloadButtonTextDeskop",
+              type: "string",
+              description: "Optional text for download button on desktop",
+              defaultValue: "Download",
+              optional: true,
+            },
+            {
+              name: "downloadButtonTextMobile",
+              type: "string",
+              description: "Optional text for download button on mobile",
+              defaultValue: "Save",
               optional: true,
             },
           ]}

--- a/docs/components/MessagingAttachmentView.jsx
+++ b/docs/components/MessagingAttachmentView.jsx
@@ -150,7 +150,7 @@ export default class MessagingAttachmentView extends React.PureComponent {
                 <MessagingAttachment
                   key={attachment.key}
                   attachmentID={attachment.attachmentID}
-                  icon={attachment.icon}
+                  fileType={attachment.fileType}
                   onClickAttachment={attachment.onClickAttachment}
                   onRemoveAttachment={attachment.onRemoveAttachment}
                   title={attachment.title}

--- a/docs/components/MessagingAttachmentView.jsx
+++ b/docs/components/MessagingAttachmentView.jsx
@@ -61,7 +61,7 @@ export default class MessagingAttachmentView extends React.PureComponent {
               {[
                 {
                   key: "1",
-                  attachmentID: "1",
+                  attachmentPreviewProps: { attachmentURL: "google.com" },
                   fileType: "doc",
                   onClickDownload: () => console.log("downloaded!"),
                   onPreviewAttachment: () => console.log("previewed!"),
@@ -71,9 +71,9 @@ export default class MessagingAttachmentView extends React.PureComponent {
                 },
                 {
                   key: "2",
-                  attachmentID: "2",
-                  attachmentURL:
-                    "https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2Fppcorn.com%2Fus%2Fwp-content%2Fuploads%2Fsites%2F14%2F2016%2F01%2Fcute-raccoon-ppcorn.jpg&f=1&nofb=1",
+                  attachmentPreviewProps: {
+                    attachmentURL: "https://s3.amazonaws.com/assets.clever.com/Raccooooooon.jpg",
+                  },
                   fileType: "png",
                   onClickDownload: () => console.log("downloaded!"),
                   onPreviewAttachment: () => console.log("previewed!"),
@@ -82,7 +82,7 @@ export default class MessagingAttachmentView extends React.PureComponent {
                 },
                 {
                   key: "3",
-                  attachmentID: "3",
+                  attachmentPreviewProps: { attachmentURL: "google.com" },
                   fileType: "m4a",
                   onClickDownload: () => console.log("downloaded!"),
                   onPreviewAttachment: () => console.log("previewed!"),
@@ -92,8 +92,7 @@ export default class MessagingAttachmentView extends React.PureComponent {
               ].map((attachment) => (
                 <MessagingAttachment
                   key={attachment.key}
-                  attachmentID={attachment.attachmentID}
-                  attachmentURL={attachment.attachmentURL}
+                  attachmentPreviewProps={attachment.attachmentPreviewProps}
                   fileType={attachment.fileType}
                   icon={attachment.icon}
                   onClickDownload={attachment.onClickDownload}
@@ -108,7 +107,7 @@ export default class MessagingAttachmentView extends React.PureComponent {
               {[
                 {
                   key: "4",
-                  attachmentID: "4",
+                  attachmentPreviewProps: { attachmentURL: "abc.com" },
                   fileType: "doc",
                   onClickAttachment: () => console.log("clicked!"),
                   onRemoveAttachment: () => console.log("removed!"),
@@ -118,7 +117,9 @@ export default class MessagingAttachmentView extends React.PureComponent {
                 },
                 {
                   key: "5",
-                  attachmentID: "5",
+                  attachmentPreviewProps: {
+                    attachmentURL: "https://s3.amazonaws.com/assets.clever.com/Raccooooooon.jpg",
+                  },
                   fileType: "png",
                   onClickAttachment: () => console.log("clicked!"),
                   onRemoveAttachment: () => console.log("removed!"),
@@ -128,7 +129,7 @@ export default class MessagingAttachmentView extends React.PureComponent {
                 },
                 {
                   key: "6",
-                  attachmentID: "6",
+                  attachmentPreviewProps: { attachmentURL: "cnn.com" },
                   fileType: "m4a",
                   onClickAttachment: () => console.log("clicked!"),
                   onRemoveAttachment: () => console.log("removed!"),
@@ -139,7 +140,7 @@ export default class MessagingAttachmentView extends React.PureComponent {
                 },
                 {
                   key: "7",
-                  attachmentID: "7",
+                  attachmentPreviewProps: { attachmentURL: "bbc.com" },
                   fileType: "doc",
                   onClickAttachment: () => console.log("clicked!"),
                   onRemoveAttachment: () => console.log("removed!"),
@@ -149,9 +150,9 @@ export default class MessagingAttachmentView extends React.PureComponent {
               ].map((attachment) => (
                 <MessagingAttachment
                   key={attachment.key}
-                  attachmentID={attachment.attachmentID}
+                  attachmentPreviewProps={attachment.attachmentPreviewProps}
                   fileType={attachment.fileType}
-                  onClickAttachment={attachment.onClickAttachment}
+                  onClickDownload={attachment.onClickAttachment}
                   onRemoveAttachment={attachment.onRemoveAttachment}
                   title={attachment.title}
                   subtitle={attachment.subtitle}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.130.0",
+  "version": "2.131.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -113,7 +113,7 @@
   color: @neutral_white;
 }
 
-.QuotedAnnouncementBubble--attachmentContainer--dark img {
+.QuotedAnnouncementBubble--attachmentContainer--dark img.MessagingAttachment--AttachmentTypeIcon {
   filter: brightness(0) invert(1); /* makes the file icon white without needing a different <img> src attr */
 }
 

--- a/src/AttachmentPreview/AttachmentPreview.less
+++ b/src/AttachmentPreview/AttachmentPreview.less
@@ -66,10 +66,6 @@
   height: 100%;
   width: 100%;
 
-  // needed to override .QuotedAnnouncementBubble--attachmentContainer--dark img styling
-  -webkit-filter: none;
-  filter: none;
-
   // TODO: fix this in ticket M5G-504
   // This makes the img div only as large as the image, so none of the background is eclipsed and
   // the full bg area is clickable.

--- a/src/AttachmentPreview/AttachmentPreview.less
+++ b/src/AttachmentPreview/AttachmentPreview.less
@@ -66,6 +66,10 @@
   height: 100%;
   width: 100%;
 
+  // needed to override .QuotedAnnouncementBubble--attachmentContainer--dark img styling
+  -webkit-filter: none;
+  filter: none;
+
   // TODO: fix this in ticket M5G-504
   // This makes the img div only as large as the image, so none of the background is eclipsed and
   // the full bg area is clickable.

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -11,8 +11,17 @@ function cssClass(element: string) {
   return `MessagingAttachment--${element}`;
 }
 
-type Props = {
+type AttachmentPreviewProps = {
+  // TODO: should any of these be optional vs required (different then they currently are)?
   attachmentURL: string;
+  closeButtonAriaLabel?: string;
+  downloadButtonTextDeskop?: string;
+  downloadButtonTextMobile?: string;
+};
+
+type Props = {
+  // TODO: if any of the above props are required, this should be required. Else it could be optional?
+  attachmentPreviewProps: AttachmentPreviewProps;
   errorMsg?: string;
   fileType: AttachmentFileType;
   icon?: React.ReactNode;
@@ -27,7 +36,7 @@ type Props = {
 
 // TODO: replace with a discriminated union to keep the props neat
 export const MessagingAttachment: React.FC<Props> = ({
-  attachmentURL,
+  attachmentPreviewProps,
   errorMsg,
   fileType,
   icon,
@@ -91,7 +100,10 @@ export const MessagingAttachment: React.FC<Props> = ({
       {attachmentPreviewIsShowing && isPreviewableAttachment && (
         <AttachmentPreview
           attachmentName={title}
-          attachmentURL={attachmentURL}
+          attachmentURL={attachmentPreviewProps.attachmentURL}
+          closeButtonAriaLabel={attachmentPreviewProps.closeButtonAriaLabel}
+          downloadButtonTextDesktop={attachmentPreviewProps.downloadButtonTextDeskop}
+          downloadButtonTextMobile={attachmentPreviewProps.downloadButtonTextMobile}
           fileType={fileType}
           onClickDownload={onClickDownload}
           onClose={() => setAttachmentPreviewIsShowing(false)}

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -12,7 +12,6 @@ function cssClass(element: string) {
 }
 
 type AttachmentPreviewProps = {
-  // TODO: should any of these be optional vs required (different then they currently are)?
   attachmentURL: string;
   closeButtonAriaLabel?: string;
   downloadButtonTextDeskop?: string;
@@ -20,7 +19,6 @@ type AttachmentPreviewProps = {
 };
 
 type Props = {
-  // TODO: if any of the above props are required, this should be required. Else it could be optional?
   attachmentPreviewProps: AttachmentPreviewProps;
   errorMsg?: string;
   fileType: AttachmentFileType;

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -78,6 +78,7 @@ export const MessagingAttachment: React.FC<Props> = ({
             <FileAttachmentIcon
               fileType={fileType}
               isUpload={isUpload}
+              uploadError={!!errorMsg}
               uploadComplete={uploadComplete}
             />
           )}
@@ -208,7 +209,7 @@ type AttachmentIconProps = {
   fileType: string;
   isUpload?: boolean;
   uploadComplete?: boolean;
-  errorMsg?: string;
+  uploadError?: boolean;
   className?: string;
 };
 
@@ -217,12 +218,12 @@ export function FileAttachmentIcon({
   fileType,
   isUpload,
   uploadComplete,
-  errorMsg,
+  uploadError,
   className,
 }: AttachmentIconProps) {
   const iconType = fileTypeToIconType(fileType);
 
-  if (!!errorMsg) {
+  if (uploadError) {
     return (
       <FontAwesome name="exclamation-circle" className={cx(cssClass("ErrorCircle"), "fa-lg")} />
     );

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -71,8 +71,10 @@ export const MessagingAttachment: React.FC<Props> = ({
           isUpload && !uploadComplete && cssClass("IsUploading"),
           !!errorMsg && cssClass("Error"),
         )}
-        onClick={() => {
-          if (isPreviewableAttachment) {
+        onClick={(e) => {
+          if (isUpload && !uploadComplete) {
+            e.stopPropagation();
+          } else if (isPreviewableAttachment) {
             setAttachmentPreviewIsShowing(true);
             if (onPreviewAttachment) {
               onPreviewAttachment();


### PR DESCRIPTION
# Overview:

For students and guardians, AttachmentPreviews on QuotedAnnouncementBubbles were showing up blank, instead of rendering the image. This is because some styling (`.QuotedAnnouncementBubble--attachmentContainer--dark img`) was being applied to the image. I overrode this styling in AttachmentPreview.less

**Question**: Would it be better to add classes to the QuotedAnnouncementBubble image, and the AttachmentContainer image, and then using those class names in the respective selectors? I'm down to do it that way if you think its better

# Screenshots/GIFs:

## Launchpad:
Before
<img width="1496" alt="Screen Shot 2021-07-07 at 1 55 23 PM" src="https://user-images.githubusercontent.com/54862564/124828649-68847b80-df2c-11eb-882b-25629435881d.png">

After
<img width="1495" alt="Screen Shot 2021-07-07 at 1 55 34 PM" src="https://user-images.githubusercontent.com/54862564/124828641-66bab800-df2c-11eb-9538-fd5d50e0f102.png">

## Fampo
Before
<img width="1497" alt="Screen Shot 2021-07-07 at 1 54 36 PM" src="https://user-images.githubusercontent.com/54862564/124828654-691d1200-df2c-11eb-8cfb-dc5fb2263b83.png">

After
<img width="1496" alt="Screen Shot 2021-07-07 at 1 53 02 PM" src="https://user-images.githubusercontent.com/54862564/124828657-69b5a880-df2c-11eb-9f52-382e6e479ca0.png">

## Icon fixes
<img width="1138" alt="Screen Shot 2021-07-07 at 3 28 03 PM" src="https://user-images.githubusercontent.com/54862564/124836752-5ad4f300-df38-11eb-8f0c-c4bd63cb511f.png">

## AttachmentPreviewProps documentation
<img width="1048" alt="Screen Shot 2021-07-07 at 4 19 12 PM" src="https://user-images.githubusercontent.com/54862564/124840199-45af9280-df3f-11eb-9d53-fc7dfb8dffd3.png">


# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Edge
  - [x] Firefox

# Roll Out:

- Before merging:
  - [x] Bumped version in `package.json`
    - New component or backward-compatible component feature change? Run `npm version minor`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
