### PR TITLE
M5 g components fixes

### DIFF
--- a/docs/components/MessagingAttachmentView.jsx
+++ b/docs/components/MessagingAttachmentView.jsx
@@ -292,7 +292,7 @@ export default class MessagingAttachmentView extends React.PureComponent {
               optional: true,
             },
             {
-              name: "downloadButtonTextDeskop",
+              name: "downloadButtonTextDesktop",
               type: "string",
               description: "Optional text for download button on desktop",
               defaultValue: "Download",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.131.0",
+  "version": "2.132.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -51,7 +51,9 @@
 }
 
 .NormalAnnouncementBubble--attachmentContainer > .MessagingAttachment--ParentContainer,
-.MessagingAttachment--ParentContainer > .MessagingAttachment--Container {
+.NormalAnnouncementBubble--attachmentContainer
+  > .MessagingAttachment--ParentContainer
+  > .MessagingAttachment--Container {
   width: 100%;
   margin-right: 0;
   .text--truncate();

--- a/src/AttachmentPreview/AttachmentPreview.tsx
+++ b/src/AttachmentPreview/AttachmentPreview.tsx
@@ -89,7 +89,7 @@ export const AttachmentPreview: React.FC<Props> = ({
         </Button>
         <Button
           type="linkPlain"
-          aria-label={closeButtonAriaLabel}
+          ariaLabel={closeButtonAriaLabel}
           className={cssClass.CLOSE_BUTTON}
           onClick={onClose}
         >

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -14,7 +14,7 @@ function cssClass(element: string) {
 type AttachmentPreviewProps = {
   attachmentURL: string;
   closeButtonAriaLabel?: string;
-  downloadButtonTextDeskop?: string;
+  downloadButtonTextDesktop?: string;
   downloadButtonTextMobile?: string;
 };
 
@@ -102,7 +102,7 @@ export const MessagingAttachment: React.FC<Props> = ({
           attachmentName={title}
           attachmentURL={attachmentPreviewProps.attachmentURL}
           closeButtonAriaLabel={attachmentPreviewProps.closeButtonAriaLabel}
-          downloadButtonTextDesktop={attachmentPreviewProps.downloadButtonTextDeskop}
+          downloadButtonTextDesktop={attachmentPreviewProps.downloadButtonTextDesktop}
           downloadButtonTextMobile={attachmentPreviewProps.downloadButtonTextMobile}
           fileType={fileType}
           onClickDownload={onClickDownload}


### PR DESCRIPTION
# Overview:

* Fix attachment width (selector was too general and was getting all attachments, not just AnnouncementBubble attachments)
* aria-label -> ariaLabel
* deskop typo

# Screenshots/GIFs:

![Screen Shot 2021-07-08 at 1 46 12 PM](https://user-images.githubusercontent.com/54862564/124993660-879d0f00-dff9-11eb-8ce5-13e0221c2732.png)
![Screen Shot 2021-07-08 at 1 47 38 PM](https://user-images.githubusercontent.com/54862564/124993663-88ce3c00-dff9-11eb-999f-5753f0ccbf8d.png)
![Screen Shot 2021-07-08 at 1 48 07 PM](https://user-images.githubusercontent.com/54862564/124993665-88ce3c00-dff9-11eb-8a76-9833eb12423a.png)
![Screen Shot 2021-07-08 at 1 48 33 PM](https://user-images.githubusercontent.com/54862564/124993667-8966d280-dff9-11eb-9ca2-8578b231aeb9.png)


# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - New component or backward-compatible component feature change? Run `npm version minor`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
