### PR TITLE
add fontawesome selector to att preview download button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.132.0",
+  "version": "2.133.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AttachmentPreview/AttachmentPreview.less
+++ b/src/AttachmentPreview/AttachmentPreview.less
@@ -99,7 +99,7 @@
 }
 
 // need to override Button styling, hence all the `color: @neutral_white !important;`
-.AttachmentPreview--DownloadButton {
+.fa.AttachmentPreview--DownloadButton {
   .margin--right--xs();
   line-height: @size_l;
 
@@ -127,7 +127,7 @@
   :active {
     color: @neutral_white !important;
 
-    .AttachmentPreview--DownloadButton {
+    .fa.AttachmentPreview--DownloadButton {
       color: @neutral_white !important;
     }
   }


### PR DESCRIPTION
# Overview:

add selector for font awesome to override fa styling

# Screenshots/GIFs:

### Mobile

Before
![Screen Shot 2021-07-08 at 3 03 26 PM](https://user-images.githubusercontent.com/54862564/124996378-af8e7180-dffd-11eb-907f-7914aaced058.png)

After
![Screen Shot 2021-07-08 at 3 03 29 PM](https://user-images.githubusercontent.com/54862564/124996374-af8e7180-dffd-11eb-9278-6c08de13d768.png)

Before
![Screen Shot 2021-07-08 at 3 03 14 PM](https://user-images.githubusercontent.com/54862564/124996380-b0270800-dffd-11eb-8337-7befe2b69ec1.png)

After
![Screen Shot 2021-07-08 at 3 03 19 PM](https://user-images.githubusercontent.com/54862564/124996379-b0270800-dffd-11eb-8e8d-f677bacb1b3c.png)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
