### PR TITLE
M5G: Attachment Bug Wars: Episode 1 - The Phantom Menace

### DIFF
--- a/docs/components/MessagingAttachmentView.jsx
+++ b/docs/components/MessagingAttachmentView.jsx
@@ -73,6 +73,7 @@ export default class MessagingAttachmentView extends React.PureComponent {
                   key: "2",
                   attachmentPreviewProps: {
                     attachmentURL: "https://s3.amazonaws.com/assets.clever.com/Raccooooooon.jpg",
+                    className: "anotherGoodClassName",
                   },
                   fileType: "png",
                   onClickDownload: () => console.log("downloaded!"),
@@ -152,7 +153,10 @@ export default class MessagingAttachmentView extends React.PureComponent {
                 },
                 {
                   key: "7",
-                  attachmentPreviewProps: { attachmentURL: "bbc.com" },
+                  attachmentPreviewProps: {
+                    attachmentURL: "bbc.com",
+                  },
+                  className: "aNiceClassName",
                   fileType: "doc",
                   onClickAttachment: () => console.log("clicked!"),
                   onRemoveAttachment: () => console.log("removed!"),
@@ -163,6 +167,7 @@ export default class MessagingAttachmentView extends React.PureComponent {
                 <MessagingAttachment
                   key={attachment.key}
                   attachmentPreviewProps={attachment.attachmentPreviewProps}
+                  className={attachment.className}
                   fileType={attachment.fileType}
                   onClickDownload={attachment.onClickAttachment}
                   onRemoveAttachment={attachment.onRemoveAttachment}
@@ -295,6 +300,12 @@ export default class MessagingAttachmentView extends React.PureComponent {
               name: "attachmentURL",
               type: "string",
               description: "URL for the attachment",
+            },
+            {
+              name: "className",
+              type: "string",
+              description: "Optional ClassName for the AttachmentPreview",
+              optional: true,
             },
             {
               name: "closeButtonAriaLabel",

--- a/docs/components/MessagingAttachmentView.jsx
+++ b/docs/components/MessagingAttachmentView.jsx
@@ -89,6 +89,18 @@ export default class MessagingAttachmentView extends React.PureComponent {
                   title: "Morning message.m4a",
                   subtitle: "Click to download",
                 },
+                {
+                  key: "4",
+                  attachmentPreviewProps: {
+                    attachmentURL:
+                      "https://s3.amazonaws.com/assets.clever.com/Raccooooooonadsdasdd.jpg",
+                  },
+                  fileType: "png",
+                  onClickDownload: () => console.log("downloaded!"),
+                  onPreviewAttachment: () => console.log("previewed!"),
+                  title: "ErrorImage.png",
+                  subtitle: "Click to view",
+                },
               ].map((attachment) => (
                 <MessagingAttachment
                   key={attachment.key}
@@ -289,6 +301,13 @@ export default class MessagingAttachmentView extends React.PureComponent {
               type: "string",
               description: "Optional ARIA label for close button",
               defaultValue: "close attachment preview",
+              optional: true,
+            },
+            {
+              name: "closeButtonText",
+              type: "string",
+              description: "Optional text for close button",
+              defaultValue: "Close",
               optional: true,
             },
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.133.0",
+  "version": "2.134.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AttachmentPreview/AttachmentPreview.less
+++ b/src/AttachmentPreview/AttachmentPreview.less
@@ -133,13 +133,26 @@
   }
 }
 
-.Button.AttachmentPreview--CloseButton {
+.fa.AttachmentPreview--CloseButton {
+  .margin--right--xs();
+  line-height: @size_l;
+
+  // override Button styling
+  transition: none;
+  color: @neutral_white !important;
+
+  :hover,
+  :active {
+    color: @neutral_white !important;
+  }
+}
+
+.Button.AttachmentPreview--CloseContainer {
   .flexbox();
   color: @neutral_white !important;
   display: inline-block;
   cursor: pointer;
   height: @size_l;
-  width: @size_l;
   line-height: @size_l;
   margin-right: @size_ml;
   text-align: center;
@@ -165,7 +178,7 @@
     width: calc(100vw - (2 * @MOBILE_BUFFER_SIZE));
   }
 
-  .Button.AttachmentPreview--CloseButton {
+  .Button.AttachmentPreview--CloseContainer {
     .margin--right--m();
   }
 

--- a/src/AttachmentPreview/AttachmentPreview.less
+++ b/src/AttachmentPreview/AttachmentPreview.less
@@ -93,7 +93,7 @@
   font-weight: 600;
 }
 
-.AttachmentPreview--ErrorIcon {
+.fa.AttachmentPreview--ErrorIcon {
   font-size: @size_l;
   .margin--right--xs();
 }

--- a/src/AttachmentPreview/AttachmentPreview.tsx
+++ b/src/AttachmentPreview/AttachmentPreview.tsx
@@ -81,12 +81,7 @@ export const AttachmentPreview: React.FC<Props> = ({
         <FlexItem grow className={cssClass.ATTACHMENT_NAME}>
           {attachmentName}
         </FlexItem>
-        <Button
-          type="linkPlain"
-          disabled={imageLoadError}
-          className={cssClass.DOWNLOAD_CONTAINER}
-          onClick={onClickDownload}
-        >
+        <Button type="linkPlain" className={cssClass.DOWNLOAD_CONTAINER} onClick={onClickDownload}>
           <FontAwesome className={cssClass.DOWNLOAD_BUTTON} name="download" />{" "}
           {downloadButtonTextDesktop}
         </Button>
@@ -117,12 +112,7 @@ export const AttachmentPreview: React.FC<Props> = ({
         </FlexBox>
       </FlexBox>
       <FlexBox className={cssClass.FOOTER_BAR}>
-        <Button
-          type="linkPlain"
-          disabled={imageLoadError}
-          className={cssClass.DOWNLOAD_CONTAINER}
-          onClick={onClickDownload}
-        >
+        <Button type="linkPlain" className={cssClass.DOWNLOAD_CONTAINER} onClick={onClickDownload}>
           <FontAwesome className={cssClass.DOWNLOAD_BUTTON} name="download" />{" "}
           <span>{downloadButtonTextMobile}</span>
         </Button>

--- a/src/AttachmentPreview/AttachmentPreview.tsx
+++ b/src/AttachmentPreview/AttachmentPreview.tsx
@@ -14,6 +14,7 @@ export interface Props {
   attachmentURL: string;
   className?: string;
   closeButtonAriaLabel?: string;
+  closeButtonText?: string;
   downloadButtonTextDesktop?: string;
   downloadButtonTextMobile?: string;
   fileType: AttachmentFileType;
@@ -29,6 +30,7 @@ export const cssClass = {
   ATTACHMENT_NAME: "AttachmentPreview--AttachmentName",
   DOWNLOAD_CONTAINER: "AttachmentPreview--DownloadContainer",
   DOWNLOAD_BUTTON: "AttachmentPreview--DownloadButton",
+  CLOSE_CONTAINER: "AttachmentPreview--CloseContainer",
   CLOSE_BUTTON: "AttachmentPreview--CloseButton",
   PREVIEW_WINDOW: "AttachmentPreview--PreviewWindow",
   IMAGE_CONTAINER: "AttachmentPreview--ImageContainer",
@@ -48,6 +50,7 @@ export const AttachmentPreview: React.FC<Props> = ({
   attachmentURL,
   className,
   closeButtonAriaLabel = "close attachment preview",
+  closeButtonText = "Close",
   downloadButtonTextDesktop = "Download",
   downloadButtonTextMobile = "Save",
   fileType,
@@ -89,11 +92,12 @@ export const AttachmentPreview: React.FC<Props> = ({
         </Button>
         <Button
           type="linkPlain"
+          className={cssClass.CLOSE_CONTAINER}
           ariaLabel={closeButtonAriaLabel}
-          className={cssClass.CLOSE_BUTTON}
           onClick={onClose}
         >
-          <FontAwesome name="times" />
+          <FontAwesome name="times" className={cssClass.CLOSE_BUTTON} />
+          {closeButtonText}
         </Button>
       </FlexBox>
       <FlexBox className={cssClass.PREVIEW_WINDOW}>

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -13,6 +13,7 @@ function cssClass(element: string) {
 
 type AttachmentPreviewProps = {
   attachmentURL: string;
+  className?: string;
   closeButtonAriaLabel?: string;
   closeButtonText?: string;
   downloadButtonTextDesktop?: string;
@@ -21,6 +22,7 @@ type AttachmentPreviewProps = {
 
 type Props = {
   attachmentPreviewProps: AttachmentPreviewProps;
+  className?: string;
   errorMsg?: string;
   fileType: AttachmentFileType;
   icon?: React.ReactNode;
@@ -36,6 +38,7 @@ type Props = {
 // TODO: replace with a discriminated union to keep the props neat
 export const MessagingAttachment: React.FC<Props> = ({
   attachmentPreviewProps,
+  className,
   errorMsg,
   fileType,
   icon,
@@ -52,7 +55,11 @@ export const MessagingAttachment: React.FC<Props> = ({
 
   return (
     <FlexBox
-      className={cx(cssClass("ParentContainer"), isUpload && cssClass("ParentContainer--IsUpload"))}
+      className={cx(
+        cssClass("ParentContainer"),
+        isUpload && cssClass("ParentContainer--IsUpload"),
+        className,
+      )}
     >
       {onRemoveAttachment && (
         <button
@@ -102,6 +109,7 @@ export const MessagingAttachment: React.FC<Props> = ({
         <AttachmentPreview
           attachmentName={title}
           attachmentURL={attachmentPreviewProps.attachmentURL}
+          className={attachmentPreviewProps.className}
           closeButtonAriaLabel={attachmentPreviewProps.closeButtonAriaLabel}
           closeButtonText={attachmentPreviewProps.closeButtonText}
           downloadButtonTextDesktop={attachmentPreviewProps.downloadButtonTextDesktop}

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -14,6 +14,7 @@ function cssClass(element: string) {
 type AttachmentPreviewProps = {
   attachmentURL: string;
   closeButtonAriaLabel?: string;
+  closeButtonText?: string;
   downloadButtonTextDesktop?: string;
   downloadButtonTextMobile?: string;
 };
@@ -102,6 +103,7 @@ export const MessagingAttachment: React.FC<Props> = ({
           attachmentName={title}
           attachmentURL={attachmentPreviewProps.attachmentURL}
           closeButtonAriaLabel={attachmentPreviewProps.closeButtonAriaLabel}
+          closeButtonText={attachmentPreviewProps.closeButtonText}
           downloadButtonTextDesktop={attachmentPreviewProps.downloadButtonTextDesktop}
           downloadButtonTextMobile={attachmentPreviewProps.downloadButtonTextMobile}
           fileType={fileType}

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -4,6 +4,7 @@ import * as cx from "classnames";
 
 import { AttachmentPreview } from "../AttachmentPreview";
 import { FlexBox } from "../flex";
+import KeyCode from "../utils/KeyCode";
 
 import "./MessagingAttachment.less";
 
@@ -77,16 +78,29 @@ export const MessagingAttachment: React.FC<Props> = ({
           isUpload && !uploadComplete && cssClass("IsUploading"),
           !!errorMsg && cssClass("Error"),
         )}
-        onClick={(e) => {
-          if (isUpload && !uploadComplete) {
-            e.stopPropagation();
-          } else if (isPreviewableAttachment) {
-            setAttachmentPreviewIsShowing(true);
-            if (onPreviewAttachment) {
-              onPreviewAttachment();
-            }
-          } else {
-            onClickDownload();
+        tabIndex={0}
+        onClick={(e) =>
+          handleClickAttachment(
+            e,
+            isUpload,
+            uploadComplete,
+            isPreviewableAttachment,
+            setAttachmentPreviewIsShowing,
+            onPreviewAttachment,
+            onClickDownload,
+          )
+        }
+        onKeyDown={(e) => {
+          if (e.key === KeyCode.ENTER) {
+            handleClickAttachment(
+              e,
+              isUpload,
+              uploadComplete,
+              isPreviewableAttachment,
+              setAttachmentPreviewIsShowing,
+              onPreviewAttachment,
+              onClickDownload,
+            );
           }
         }}
       >
@@ -122,6 +136,27 @@ export const MessagingAttachment: React.FC<Props> = ({
     </FlexBox>
   );
 };
+
+function handleClickAttachment(
+  e,
+  isUpload,
+  uploadComplete,
+  isPreviewableAttachment,
+  setAttachmentPreviewIsShowing,
+  onPreviewAttachment,
+  onClickDownload,
+) {
+  if (isUpload && !uploadComplete) {
+    e.stopPropagation();
+  } else if (isPreviewableAttachment) {
+    setAttachmentPreviewIsShowing(true);
+    if (onPreviewAttachment) {
+      onPreviewAttachment();
+    }
+  } else {
+    onClickDownload();
+  }
+}
 
 function handleRemoveClick(e, onRemoveAttachment) {
   e.stopPropagation();


### PR DESCRIPTION
# Jira: [TKT-000](https://clever.atlassian.net/browse/TKT-000)

# Overview:

- Close text for AttachmentPreview
- Enable download for imageLoadError files
  - Also added a demo attachment with a bad URL to demo this state
- Fix error icon styling
- add className to MessagingAttachment and attachmentPreviewProps
- tabbable MessagingAttachments
  - Tested this with Axe extension and VoiceOver, as suggested by Chloe 🙏  

# Screenshots/GIFs:

Close text (I didn't take a mobile screenshot, but I tested it and it works)
![Screen Shot 2021-07-09 at 4 21 46 PM](https://user-images.githubusercontent.com/54862564/125144389-973c5680-e0d2-11eb-904e-be0d47b8fd70.png)

ImageLoadError (you can't see but the download button works)
Also error text and icon are aligned
![Screen Shot 2021-07-09 at 4 22 25 PM (2)](https://user-images.githubusercontent.com/54862564/125144408-ade2ad80-e0d2-11eb-8c48-2e25ee201f5b.png)

Tabbable MessagingAttachments (Accessibility FTW!)
![Screen Shot 2021-07-09 at 4 23 03 PM](https://user-images.githubusercontent.com/54862564/125144364-7f64d280-e0d2-11eb-9048-77d519887795.png)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - New component or backward-compatible component feature change? Run `npm version minor`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
