### PR TITLE
M5G: Dynamic sizing of MessagingAttachments (part 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.134.0",
+  "version": "2.135.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -215,10 +215,14 @@
 
   .MessagingBubble--Message--Container--Own .MessagingAttachment--Container {
     margin-left: @size_5xl;
+    width: calc(100% - 4rem);
+    overflow: hidden;
   }
 
   .MessagingBubble--Message--Container--Other .MessagingAttachment--Container {
     margin-right: @size_5xl;
+    width: calc(100% - 4rem);
+    overflow: hidden;
   }
 
   // ⬇️ In attachment-only messages, we don't want the margins defined above either ⬇️
@@ -227,6 +231,7 @@
     .MessagingAttachment--Container {
     margin-left: 0;
     margin-right: 0;
+    width: 100%;
   }
 
   .MessagingBubble--Message--Timestamp--Other
@@ -234,6 +239,7 @@
     .MessagingAttachment--Container {
     margin-left: 0;
     margin-right: 0;
+    width: 100%;
   }
 
   // ⬇️ In quoted announcements, we don't want the margins defined above ⬇️

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -216,12 +216,16 @@
   .MessagingBubble--Message--Container--Own .MessagingAttachment--Container {
     margin-left: @size_5xl;
     width: calc(100% - 4rem);
+    min-width: 13rem;
+    max-width: 21.125rem;
     overflow: hidden;
   }
 
   .MessagingBubble--Message--Container--Other .MessagingAttachment--Container {
     margin-right: @size_5xl;
     width: calc(100% - 4rem);
+    min-width: 13rem;
+    max-width: 21.125rem;
     overflow: hidden;
   }
 


### PR DESCRIPTION
# Jira: [M5G-546](https://clever.atlassian.net/browse/M5G-546)

# Overview:

Longer MessagingAttachments were looking pretty borked on mobile...

![Screen Shot 2021-07-12 at 5 11 02 PM](https://user-images.githubusercontent.com/54862564/125370822-31e7a000-e334-11eb-8a66-6724e008064a.png)

Width was being set by a desktop selector, so I added width to the mobile selectors. Also made sure attachment-only-messages don't take the margin into account (`calc...`) because they already have space for the timestamp

**NOTE: this does not make the MessagingAttachment grow/shrink with the message text content. I couldn't figure that out within a reasonable amount of time, so because its not a launch blocker, I'm gonna leave it for another time. What this PR does is make MessagingAttachments 1) align correctly at the edges (not get cut off), and render with a width of 230px for attachments with short titles, between 230-360px for medium titles (based on the length of the title), and cutoff at 360px for long titles, with truncated text and ellipsis.**

# Screenshots/GIFs:

Correct max/min widths
![Screen Shot 2021-07-12 at 5 03 28 PM](https://user-images.githubusercontent.com/54862564/125370915-7410e180-e334-11eb-8421-0257877b957f.png)
![Screen Shot 2021-07-12 at 5 03 38 PM](https://user-images.githubusercontent.com/54862564/125370917-74a97800-e334-11eb-8653-9284f3e319ca.png)

Also same for teachers
![Screen Shot 2021-07-12 at 5 07 49 PM](https://user-images.githubusercontent.com/54862564/125370943-85f28480-e334-11eb-81cb-b94e6f8fa1c7.png)
![Screen Shot 2021-07-12 at 5 07 55 PM](https://user-images.githubusercontent.com/54862564/125370941-8559ee00-e334-11eb-804e-6e2cb8a527d5.png)


# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Edge

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - New component or backward-compatible component feature change? Run `npm version minor`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
