### PR TITLE
M5G-579: Tweak AnnouncementBubble Reply

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.135.0",
+  "version": "2.135.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -107,8 +107,8 @@ button.NormalAnnouncementBubble--deleteMenuItem {
   border-radius: 1.5rem;
   .boxShadow--medium();
   height: 2rem;
-  padding: 0;
-  width: 6.625rem;
+  .padding--x--l();
+  .padding--y--none();
 
   // Center along bottom of AnnouncementBubble container with the following CSS
   left: 50%;


### PR DESCRIPTION
https://clever.atlassian.net/browse/M5G-579

# Overview:

"In the family portal, I noticed that when the language is set to Spanish the reply button on announcements has pretty squished copy because the word "Responder" is used. In English (and all the other languages available in fampo) this issue does not exist as the word for reply is relatively short. I was curious if the reply button could be set using some kind of auto-layout such that the 24px padding on left and right of the text is always maintained regardless of how long the word is (e.g. the "reply" button would grow to accommodate the longer Spanish word). This seems like the most complex and most edge case-y of the three issues listed here so no worries if there is not an easy fix for this one."

# Screenshots/GIFs:

Before - 

![Screen Shot 2021-07-15 at 4 33 54 PM](https://user-images.githubusercontent.com/26425483/125871166-8c507489-1bb6-44fe-8ce2-53e22f28c6e8.png)

After - 

![Screen Shot 2021-07-15 at 4 33 50 PM](https://user-images.githubusercontent.com/26425483/125871178-35216b6b-3de7-4e4b-89a8-322c10680074.png)


# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
