### PR TITLE
M5G-551 click background to close attachment image preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.134.0",
+  "version": "2.135.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.135.0",
+  "version": "2.136.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AttachmentPreview/AttachmentPreview.less
+++ b/src/AttachmentPreview/AttachmentPreview.less
@@ -63,13 +63,13 @@
   .zIndex--8;
   // render image as large as natural size, or scale down to fit screen
   object-fit: scale-down;
-  width: calc(100% - (2 * @DESKTOP_BUFFER_SIZE));
-  height: fit-content;
-  max-height: calc(100% - (2 * @DESKTOP_BUFFER_SIZE));
   // We apply an absurdly large margin on the left&right so that the image element
   // doesn't occupay any extra horizontal space. Clicks on the margin register on
   // the background component so that the preview will close properly.
   margin: 0 1000rem;
+  height: fit-content;
+  max-width: calc(100% - (2 * @DESKTOP_BUFFER_SIZE));
+  max-height: calc(100% - (2 * @DESKTOP_BUFFER_SIZE));
 }
 
 .AttachmentPreview--ErrorContainer {
@@ -167,7 +167,7 @@
   }
 
   .AttachmentPreview--PreviewWindow img {
-    width: calc(100% - (2 * @MOBILE_BUFFER_SIZE));
+    max-width: calc(100% - (2 * @MOBILE_BUFFER_SIZE));
     max-height: calc(100% - (2 * @MOBILE_BUFFER_SIZE));
   }
 

--- a/src/AttachmentPreview/AttachmentPreview.less
+++ b/src/AttachmentPreview/AttachmentPreview.less
@@ -43,11 +43,11 @@
 .AttachmentPreview--PreviewWindow {
   .zIndex--6;
   position: fixed;
-  top: calc(@HEADER_BAR_HEIGHT + @DESKTOP_BUFFER_SIZE);
+  top: @HEADER_BAR_HEIGHT;
   left: 50%;
   transform: translateX(-50%);
-  height: calc(100vh - @HEADER_BAR_HEIGHT - (2 * @DESKTOP_BUFFER_SIZE));
-  width: calc(100vw - (2 * @DESKTOP_BUFFER_SIZE));
+  height: calc(100vh - @HEADER_BAR_HEIGHT);
+  width: 100vw;
 }
 
 .AttachmentPreview--ImageContainer {
@@ -61,27 +61,15 @@
 
 .AttachmentPreview--PreviewWindow img {
   .zIndex--8;
-  // render image as larger as natural size, or scale down to fit screen
+  // render image as large as natural size, or scale down to fit screen
   object-fit: scale-down;
-  height: 100%;
-  width: 100%;
-
-  // TODO: fix this in ticket M5G-504
-  // This makes the img div only as large as the image, so none of the background is eclipsed and
-  // the full bg area is clickable.
-  // Unfortunately, its breaking scale-down.
-  // Also, this doesn't work on Edge/IE.
-  // width: fit-content;
-  // width: -moz-fit-content;
-  // width: -webkit-fit-content;
-  // height: fit-content;
-  // height: -moz-fit-content;
-  // height: -webkit-fit-content;
-
-  // TODO: This isn't working because the img element is larger than the rendered image, so the
-  // border radius is being cropped at the corners of the element, not the rendered image. This will
-  // be fixed when above fit-content issues are solved
-  .borderRadius--s();
+  width: calc(100% - (2 * @DESKTOP_BUFFER_SIZE));
+  height: fit-content;
+  max-height: calc(100% - (2 * @DESKTOP_BUFFER_SIZE));
+  // We apply an absurdly large margin on the left&right so that the image element
+  // doesn't occupay any extra horizontal space. Clicks on the margin register on
+  // the background component so that the preview will close properly.
+  margin: 0 1000rem;
 }
 
 .AttachmentPreview--ErrorContainer {
@@ -173,9 +161,14 @@
 
 @media only screen and (max-width: @breakpointM) {
   .AttachmentPreview--PreviewWindow {
-    top: calc(@HEADER_BAR_HEIGHT + @MOBILE_BUFFER_SIZE);
-    height: calc(100vh - (2 * @HEADER_BAR_HEIGHT) - (2 * @MOBILE_BUFFER_SIZE));
-    width: calc(100vw - (2 * @MOBILE_BUFFER_SIZE));
+    top: @HEADER_BAR_HEIGHT;
+    height: calc(100vh - (2 * @HEADER_BAR_HEIGHT));
+    width: 100vw;
+  }
+
+  .AttachmentPreview--PreviewWindow img {
+    width: calc(100% - (2 * @MOBILE_BUFFER_SIZE));
+    max-height: calc(100% - (2 * @MOBILE_BUFFER_SIZE));
   }
 
   .Button.AttachmentPreview--CloseContainer {

--- a/src/AttachmentPreview/AttachmentPreview.less
+++ b/src/AttachmentPreview/AttachmentPreview.less
@@ -64,7 +64,7 @@
   // render image as large as natural size, or scale down to fit screen
   object-fit: scale-down;
   // We apply an absurdly large margin on the left&right so that the image element
-  // doesn't occupay any extra horizontal space. Clicks on the margin register on
+  // doesn't occupy any extra horizontal space. Clicks on the margin register on
   // the background component so that the preview will close properly.
   margin: 0 1000rem;
   height: fit-content;

--- a/src/AttachmentPreview/AttachmentPreview.tsx
+++ b/src/AttachmentPreview/AttachmentPreview.tsx
@@ -14,7 +14,6 @@ export interface Props {
   attachmentURL: string;
   className?: string;
   closeButtonAriaLabel?: string;
-  closeButtonText?: string;
   downloadButtonTextDesktop?: string;
   downloadButtonTextMobile?: string;
   fileType: AttachmentFileType;
@@ -50,7 +49,6 @@ export const AttachmentPreview: React.FC<Props> = ({
   attachmentURL,
   className,
   closeButtonAriaLabel = "close attachment preview",
-  closeButtonText = "Close",
   downloadButtonTextDesktop = "Download",
   downloadButtonTextMobile = "Save",
   fileType,
@@ -99,7 +97,6 @@ export const AttachmentPreview: React.FC<Props> = ({
           onClick={onClose}
         >
           <FontAwesome name="times" className={cssClass.CLOSE_BUTTON} />
-          {closeButtonText}
         </Button>
       </FlexBox>
       <FlexBox className={cssClass.PREVIEW_WINDOW}>

--- a/src/AttachmentPreview/AttachmentPreview.tsx
+++ b/src/AttachmentPreview/AttachmentPreview.tsx
@@ -72,8 +72,8 @@ export const AttachmentPreview: React.FC<Props> = ({
   }, []);
 
   const onBackgroundClick = (event) => {
-    const backgroundWasClicked = event.target === event.currentTarget
-    if(backgroundWasClicked){
+    const backgroundWasClicked = event.target === event.currentTarget;
+    if (backgroundWasClicked) {
       onClose();
     }
   };

--- a/src/AttachmentPreview/AttachmentPreview.tsx
+++ b/src/AttachmentPreview/AttachmentPreview.tsx
@@ -73,6 +73,13 @@ export const AttachmentPreview: React.FC<Props> = ({
     };
   }, []);
 
+  const onBackgroundClick = (event) => {
+    const backgroundWasClicked = event.target === event.currentTarget
+    if(backgroundWasClicked){
+      onClose();
+    }
+  };
+
   return (
     <div className={classnames(cssClass.CONTAINER, className)}>
       <div className={cssClass.BACKGROUND} aria-hidden="true" />
@@ -96,7 +103,7 @@ export const AttachmentPreview: React.FC<Props> = ({
         </Button>
       </FlexBox>
       <FlexBox className={cssClass.PREVIEW_WINDOW}>
-        <FlexBox className={cssClass.IMAGE_CONTAINER}>
+        <FlexBox className={cssClass.IMAGE_CONTAINER} onClick={onBackgroundClick}>
           {!imageLoadError && (
             <img
               src={attachmentURL}

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -125,7 +125,6 @@ export const MessagingAttachment: React.FC<Props> = ({
           attachmentURL={attachmentPreviewProps.attachmentURL}
           className={attachmentPreviewProps.className}
           closeButtonAriaLabel={attachmentPreviewProps.closeButtonAriaLabel}
-          closeButtonText={attachmentPreviewProps.closeButtonText}
           downloadButtonTextDesktop={attachmentPreviewProps.downloadButtonTextDesktop}
           downloadButtonTextMobile={attachmentPreviewProps.downloadButtonTextMobile}
           fileType={fileType}


### PR DESCRIPTION
# Jira: [M5G-551](https://clever.atlassian.net/browse/M5G-551)

# Overview:
This PR ensures that the AttachmentPreview component listens for clicks in the grey area behind the image and closes when somebody clicks that area. The main challenges here were styling challenges and testing to ensure that many browsers and devices worked properly.

# Screenshots/GIFs:

## Components docs
![ezgif com-gif-maker (12)](https://user-images.githubusercontent.com/6520345/126012797-2bc4b8e8-e4e6-4878-a109-b5f2244bcb26.gif)

## Launchpad desktop
![ezgif com-gif-maker (9)](https://user-images.githubusercontent.com/6520345/126010755-2451553f-8262-466e-91da-f2820e098722.gif)

## Launchpad mobile 
![ezgif com-gif-maker (8)](https://user-images.githubusercontent.com/6520345/126010566-d467c0d9-db3e-426a-bd4e-632357e0d988.gif)

## Fampo desktop
![ezgif com-gif-maker (10)](https://user-images.githubusercontent.com/6520345/126012284-2040aa5f-c63b-44cd-8f98-588d546a0ab1.gif)

## Fampo mobile
![ezgif com-gif-maker (11)](https://user-images.githubusercontent.com/6520345/126012625-cc2c5f33-aad0-4a3c-b455-2d712d9944b6.gif)


# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`

- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component

