### PR TITLE
add aria-pressed value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.136.0",
+  "version": "2.137.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -148,6 +148,7 @@ export const MessagingThreadListItem: React.FC<
         )}
         onClick={onClick}
         alignItems={ItemAlign.CENTER}
+        aria-pressed={selected}
       >
         <div className={cssClasses.ICON}>{icon}</div>
         <FlexItem grow className={cssClasses.DETAILS_CONTAINER}>


### PR DESCRIPTION
# Jira: [M5G-576](https://clever.atlassian.net/browse/M5G-576)

# Overview:

It is not clear to screen readers when a MessagingThreadListItem is selected/pressed, so we want to set the prop `aria-pressed` on the element. 

This was simple to do by adding `aria-pressed={selected}` to the top-level container

# Screenshots/GIFs:

![Screen Shot 2021-07-20 at 6 02 14 PM](https://user-images.githubusercontent.com/54862564/126414153-ff6a8da6-e96d-4b65-a995-38102fbf2ec4.png)

Above you can see one MTLI is selected and the other is not. In the DOM you can see the selected one has `aria-pressed={true}` and the other has `aria-pressed={false}`

# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Edge
  - [x] Firefox

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - backward-compatible component feature change? Run `npm version minor`
    
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
