### PR TITLE
Increase contrast ratio in switch icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.137.0",
+  "version": "2.137.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Switch/Switch.less
+++ b/src/Switch/Switch.less
@@ -53,7 +53,7 @@
 
 .Switch--checkedIcon {
   .transition-stroke-fill;
-  .pathColor(@alert_green_shade_2);
+  .pathColor(@neutral_black);
   width: 0.875rem;
   height: 0.688rem;
   pointer-events: none;


### PR DESCRIPTION
https://clever.atlassian.net/browse/prtl-769

# Overview:
This change makes the `<Switch>` more accessible by increasing the contrast ratio between the checkmark and its background.

# Screenshots/GIFs:
Before
![Screen Shot 2021-07-22 at 3 47 51 PM](https://user-images.githubusercontent.com/32328921/126718936-1751a3ef-9e6c-4cae-9062-aad1bbc4cd7a.jpg)

After
![Screen Shot 2021-07-22 at 3 47 24 PM](https://user-images.githubusercontent.com/32328921/126718935-86e75979-15aa-47dd-8491-3d11b5d035bd.jpg)




# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
