### PR TITLE
M5G-535 fix attachment and reply draft x buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.137.2",
+  "version": "2.138.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -85,7 +85,6 @@
   cursor: pointer;
   background-color: @neutral_medium_gray;
   color: @neutral_white;
-  border: none;
   padding: 0;
   border: @size_3xs solid white;
 
@@ -95,7 +94,6 @@
   &:focus,
   &:active {
     background-color: @neutral_black;
-    border-color: @neutral_black;
   }
 }
 

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -92,7 +92,8 @@
 
 .MessagingInput--Reply--CloseIcon {
   .text--smallMedium();
-  margin-left: 0.0625rem; // 1 px because the FA icon is slightly off center
+  position: relative;
+  top: -0.0625rem;
 }
 
 // ----- Text input and send button


### PR DESCRIPTION
# Jira: [M5G-535](https://clever.atlassian.net/browse/M5G-535)

# Overview:
This PR corrects two small problems with x buttons in our messaging flow.

1. When a teacher is drafting a message with an attachment, the hover state was previously causing the button to look like it was growing. I removed the black border that was previously added to the hover state to fix this issue.
2. When a student was drafting a reply to an announcement, the x button on the reply preview was not centered previously

# Screenshots/GIFs:
## Attachment draft x button
### Launchpad before
![ezgif com-gif-maker (14)](https://user-images.githubusercontent.com/6520345/126721143-8831ec8b-3255-4848-8b18-99640842f408.gif)


### Launchpad after
![ezgif com-gif-maker (13)](https://user-images.githubusercontent.com/6520345/126721120-6ef6422f-dc7d-4edc-8208-10716115b970.gif)


## Reply to announcement draft x button
### Launchpad Before
![image](https://user-images.githubusercontent.com/6520345/126720569-e9cf3719-d2d2-4862-959e-efaf725468b0.png)

### Launchpad After
![image](https://user-images.githubusercontent.com/6520345/126720625-7422fe7e-d195-4889-9931-1a3c0ce94cc8.png)


# Testing:

- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Bumped version in `package.json`

- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
