### PR TITLE
[a11y] Increase contrast ratio in switch icon in the unchecked state 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.137.1",
+  "version": "2.137.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Switch/Switch.less
+++ b/src/Switch/Switch.less
@@ -64,7 +64,7 @@
 
 .Switch--uncheckedIcon {
   .transition-stroke-fill;
-  .pathColor(@neutral_dark_gray);
+  .pathColor(@neutral_black);
   width: 0.625rem;
   height: 0.625rem;
   pointer-events: none;


### PR DESCRIPTION
https://clever.atlassian.net/browse/prtl-769

# Overview:
This change makes the `<Switch>` more accessible by increasing the contrast ratio between the checkmark and its background.
Same fix as #693 

# Screenshots/GIFs:
before
![Screen Shot 2021-07-22 at 3 34 28 PM](https://user-images.githubusercontent.com/32328921/126723700-cd67f776-c855-414b-973a-d2d28a84b9ee.jpg)
after
![Screen Shot 2021-07-22 at 3 35 02 PM](https://user-images.githubusercontent.com/32328921/126723701-1fd8a548-a183-44d8-9875-639354e833b0.jpg)


# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
