### PR TITLE
[a11y] Indicate when a topbar button corresponds to the currently active page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.138.0",
+  "version": "2.138.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TopBar/TopBarButton.tsx
+++ b/src/TopBar/TopBarButton.tsx
@@ -58,6 +58,7 @@ export class TopBarButton extends React.PureComponent<Props> {
           ref={(ref) => {
             this._containerRef = ref;
           }}
+          aria-current={active && "page"}
         >
           {children}
         </Wrapper>


### PR DESCRIPTION
# Jira: https://clever.atlassian.net/browse/prtl-657

# Overview:
There is a visual indication that a TopBar button is active, but that information is missing for screen reader users. This change includes the `aria-current="page"` attribute to the active TopBar button to make the TopBar more accessible to screen reader users. 

# Screenshots/GIFs:

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
