### PR TITLE
Reduce mobile input rounding when text spans multiple lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.139.0",
+  "version": "2.139.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingInput/MessagingInput.less
+++ b/src/MessagingInput/MessagingInput.less
@@ -227,11 +227,6 @@
     min-height: 2rem;
     border-radius: 2rem;
 
-    .TextArea--input {
-      // Ensures that multi-line text doesn't spill outside the boundaries of the rounded text input
-      border-radius: 0.8rem;
-    }
-
     &.TextArea--inFocus {
       .border--m(@neutral_silver);
     }
@@ -240,18 +235,14 @@
   .MessagingInput--TextField.MessagingInput--TextField--WithReply {
     .borderRadius--bottom--xl();
     border-top: none;
-
-    .TextArea--input {
-      .borderRadius--0();
-    }
   }
 
   .MessagingInput--TextField.MessagingInput--TextField--WithAttachments {
     .borderRadius--xl();
+  }
 
-    .TextArea--input {
-      .borderRadius--0();
-    }
+  .MessagingInput--TextField.MessagingInput--TextField--MultiLine {
+    .borderRadius--xl();
   }
 
   .MessagingInput--Container {

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -83,6 +83,9 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
   const attachmentsArePresent = attachments?.length > 0;
   const [isInputActive, setIsInputActive] = useState(false);
 
+  // Update this if relevant styling changes and this heuristic no longer holds
+  const hasMultiLineText = textAreaRef.current?.textAreaHeight() > 40;
+
   return (
     <FlexBox
       className={cx(
@@ -142,6 +145,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
               cssClass("TextField"),
               replyTo && cssClass("TextField--WithReply"),
               attachmentsArePresent && cssClass("TextField--WithAttachments"),
+              hasMultiLineText && cssClass("TextField--MultiLine"),
             )}
             name={TEXT_FIELD_NAME}
             value={value}

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -155,6 +155,11 @@ export class TextArea extends React.Component<Props, State> {
     this.textAreaEl.current.focus();
   }
 
+  // Give consumers that set up a React ref access to the <textarea> height
+  textAreaHeight(): number | undefined {
+    return this.textAreaEl.current?.offsetHeight || undefined;
+  }
+
   currentErrorMessage(): string {
     const { error, value, required } = this.props;
     const { hasBeenFocused } = this.state;


### PR DESCRIPTION
# Jira

[M5G-550](https://clever.atlassian.net/browse/M5G-550) / [M5G-611](https://clever.atlassian.net/browse/M5G-611)

# Overview

We recently restyled the Messaging input (https://github.com/Clever/components/pull/691)! This PR addresses [an edge case surfaced in that original PR](https://github.com/Clever/components/pull/691#pullrequestreview-713934430).

## Before

The new rounded mobile input can look a bit funky when there are multiple lines of text:

<img width="420" alt="before" src="https://user-images.githubusercontent.com/12616928/127016969-d73c6f88-6729-45e7-bea1-4b2dbb875b0c.png">

## After

After discussion with Nick, we've decided to reduce the rounding when there are multiple lines of text, just like we do when there's a reply or attachments:

<img width="430" alt="one-line" src="https://user-images.githubusercontent.com/12616928/127018220-8a476fed-4ec3-427b-bc1f-8ff1217becd0.png">

<img width="420" alt="multi-line" src="https://user-images.githubusercontent.com/12616928/127018217-2ad78340-09a3-41e5-8fc9-aa3ac68c379f.png">

![reduced-rounding](https://user-images.githubusercontent.com/12616928/127017349-1b58ceef-c5c7-44ea-9cde-75cccd5e49a9.gif)

# Testing

_Browser testing_

- [x] Chrome
- [x] Safari
- [ ] IE11

_Other testing_

- [x] Verified that the height detection mechanism works when the screen is zoomed in or out

# Rollout

_Before merging_

- [ ] ~Updated docs~ N/A
- [x] Bumped version in `package.json`

_After merging_

- [ ] Deployed updated docs (`make deploy-docs`)
- [ ] ~Posted in #eng if I made a breaking change to a beta component~ N/A