### PR TITLE
[a11y] Make the TopBar's active indicator accessible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.140.0",
+  "version": "2.140.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TopBar/TopBarButton.less
+++ b/src/TopBar/TopBarButton.less
@@ -23,7 +23,7 @@
 
 .TopBarButton--activeIndicator {
   opacity: 0.8;
-  background-image: linear-gradient(270deg, #44d7d2 0%, #7fe5e2 100%);
+  background-color: @neutral_white;
   /* stylelint-disable-next-line unit-whitelist */
   box-shadow: 0 1px 6px 2px rgba(33, 70, 189, 0.25);
   border-radius: @size_3xs;


### PR DESCRIPTION
# Jira: 
https://clever.atlassian.net/browse/prtl-727

# Overview:
This change an accessibility fix that increases the contrast ratio between the `<TopBar>`'s active indicator and its background. 

# Screenshots/GIFs:
Before:
![Screen Shot 2021-07-28 at 11 51 07 AM](https://user-images.githubusercontent.com/32328921/127379629-3623e091-9959-42d9-a908-8f3084fb071d.jpg)
After:
![Screen Shot 2021-07-28 at 11 44 39 AM](https://user-images.githubusercontent.com/32328921/127379533-1a8f2a51-7585-4387-8c7f-2b0807eda151.jpg)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
