### PR TITLE
A11y: change timestamp color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.140.1",
+  "version": "2.141.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingBubble/MessagingBubble.less
+++ b/src/MessagingBubble/MessagingBubble.less
@@ -78,7 +78,7 @@
 }
 
 .MessagingBubble--Message--Timestamp--Own {
-  color: @neutral_gray;
+  color: @neutral_medium_gray;
   font-size: 0.875rem;
   .margin--right--xs();
   .text--line-height-1();
@@ -88,7 +88,7 @@
 }
 
 .MessagingBubble--Message--Timestamp--Other {
-  color: @neutral_gray;
+  color: @neutral_medium_gray;
   font-size: 0.875rem;
   .margin--left--xs();
   .text--line-height-1();


### PR DESCRIPTION
# Jira: 

[PRTL-721](https://clever.atlassian.net/browse/PRTL-721)
[PRTL-722](https://clever.atlassian.net/browse/PRTL-722)
[PRTL-777](https://clever.atlassian.net/browse/PRTL-777)
[PRTL-782](https://clever.atlassian.net/browse/PRTL-782)

# Overview:

Change MessagingBubble timestamp color to achieve necessary contrast

# Screenshots/GIFs:

## Before

![Screen Shot 2021-07-28 at 2 12 28 PM](https://user-images.githubusercontent.com/54862564/127396685-2122c931-8a9f-488e-9eec-f904107a822f.png)

## After
![Screen Shot 2021-07-28 at 2 12 37 PM](https://user-images.githubusercontent.com/54862564/127396771-09e53bbc-f1c1-49c6-b6aa-251858900a1f.png)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - New component or backward-compatible component feature change? Run `npm version minor`
    
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
