### PR TITLE
remove unused border

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.141.0",
+  "version": "2.142.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput2/TextInput2.less
+++ b/src/TextInput2/TextInput2.less
@@ -2,8 +2,6 @@
 
 .TextInput2--container {
   font-family: "Proxima Nova";
-
-  .border--s(@neutral_off_white);
 }
 
 .TextInput2--infoRow {


### PR DESCRIPTION
# Overview:
I noticed that there's a slightly subtle border that blends into white backgrounds but is actually not wanted

# Screenshots/GIFs:
Here's the border when I turned the color to red
![image](https://user-images.githubusercontent.com/13126257/127439647-1154d99c-399c-4e55-b676-17d4dc088e66.png)

on white backgrounds, to the eye it's hard to discern:
![image](https://user-images.githubusercontent.com/13126257/127439669-c5353805-6bc0-4dff-b2cd-ea1cc75c1369.png)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
