### PR TITLE
[a11y] Improve TobBar contrast ratio

### DIFF
--- a/docs/components/TopBarView.less
+++ b/docs/components/TopBarView.less
@@ -63,7 +63,7 @@ label.TopBarView--config {
 .TopBarView--searchBox {
   border: none;
   .borderRadius--l();
-  background: rgba(255, 255, 255, 0.25);
+  .border--s(@neutral_white);
   max-width: 12rem;
   min-width: 6rem;
   overflow: hidden;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.143.0",
+  "version": "2.143.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TopBar/index.less
+++ b/src/TopBar/index.less
@@ -42,7 +42,6 @@
   .text--regular;
   .text--truncate;
   color: @neutral_white;
-  font-style: italic;
 }
 
 // PLAIN theme:

--- a/src/TopBar/index.less
+++ b/src/TopBar/index.less
@@ -6,7 +6,9 @@
   min-width: 0;
   transition: all @timingPromptly ease-out;
   .padding--x--2xs;
-  background-image: linear-gradient(90deg, #3980e6 0%, #3965e6 50%, #394de5 100%);
+  // TODO: Consider creating a color variable if this should be a color used elsewhere.
+  /* stylelint-disable-next-line declaration-property-value-whitelist */
+  background-color: #3761e9;
 
   /* stylelint-disable unit-whitelist */
   box-shadow: 0 1px 6px 2px rgba(33, 70, 189, 0.25);


### PR DESCRIPTION
# Jira:
https://clever.atlassian.net/browse/prtl-736

# Overview:
This replaces the `<TopBar>`s color gradient with a new flat blue color to improve its contrast ratio. We're also going to unitalicize the title.

Another change I've made is to the searchbar in the docs so that it matches the new styling that will soon be rolled out in the portal.

I'm double-checking with design to confirm that this is the blue color that we want to use.

# Screenshots/GIFs:
Before:
![Screen Shot 2021-07-28 at 11 19 59 PM](https://user-images.githubusercontent.com/32328921/127442517-49b5889c-a906-4054-9f1d-97a4dcde3285.jpg)
After:
![Screen Shot 2021-07-28 at 11 19 29 PM](https://user-images.githubusercontent.com/32328921/127442514-9c785431-8564-436a-8816-9b0e81f05c41.jpg)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
