### PR TITLE
adding onToggleShow callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.141.0",
+  "version": "2.142.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/AnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/AnnouncementBubble.tsx
@@ -48,6 +48,7 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
           showMoreButtonText={props.showMoreButtonText}
           truncationNoticeText={props.truncationNoticeText}
           truncationTooltipText={props.truncationTooltipText}
+          onToggleShow={props.onToggleShow}
         >
           {props.children}
         </QuotedAnnouncementBubble>

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -25,6 +25,7 @@ export interface Props {
   senderIcon: React.ReactNode;
   senderName: string;
   sentAtTimestamp: Date;
+  onToggleShow?: () => void;
 
   // Temporary props to allow overriding text with translations
   postedInText?: string;
@@ -49,6 +50,7 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
   showMoreButtonText,
   truncationNoticeText,
   truncationTooltipText,
+  onToggleShow,
 }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -155,7 +157,12 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
       )}
       <Button
         className={cssClass("button--outer")}
-        onClick={() => setIsExpanded(!isExpanded)}
+        onClick={() => {
+          if (onToggleShow) {
+            onToggleShow();
+          }
+          setIsExpanded(!isExpanded);
+        }}
         type="linkPlain"
       >
         <span


### PR DESCRIPTION
# Jira: [M5G-570](https://clever.atlassian.net/browse/M5G-570)

# Overview:
Chatted with Nick yesterday and we decided we want to show the translation toggle within the quoted announcement bubble and only when it's expanded. To allow the consumer to keep track of when the bubble is expanded, adding a callback that fires when the user clicks on `show more` / `show less`.

Sidenote: it seems like we never documented the props needed for announcement bubble but I'm also hoping to get this merged some time today, so I made a ticket in our technical backlog to document this eventually: [M5G-633](https://clever.atlassian.net/browse/M5G-633?atlOrigin=eyJpIjoiNmU2NDkyOTBlMTYxNDhiY2EyZjhiYzZiNDBiMzk5MzMiLCJwIjoiaiJ9)

# Screenshots/GIFs:
No screenshots since we're not changing any visual part of the component

# Testing:
Tested locally!

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
