### PR TITLE
[a11y] Increase contrast ratio of focused menu item

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.143.2",
+  "version": "2.143.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Menu/MenuItem.less
+++ b/src/Menu/MenuItem.less
@@ -24,7 +24,6 @@ button.Menu--MenuItem--default {
   &:focus {
     background-color: fade(@primary_blue_tint_2, 10%);
     box-shadow: inset @borderWidthL 0 fade(@primary_blue_tint_2, 50%);
-    // box-shadow: inset @borderWidthL 0 @primary_blue_tint_2;
     color: @primary_blue_shade_1;
   }
 

--- a/src/Menu/MenuItem.less
+++ b/src/Menu/MenuItem.less
@@ -23,14 +23,14 @@ button.Menu--MenuItem--default {
 
   &:focus {
     background-color: fade(@primary_blue_tint_2, 10%);
-    box-shadow: inset @borderWidthL 0 fade(@primary_blue_tint_2, 50%);
-    color: @primary_blue_shade_1;
+    box-shadow: inset @borderWidthL 0 @primary_blue_shade_2;
+    color: @primary_blue_shade_2;
   }
 
   &:active {
     background-color: fade(@primary_blue_tint_2, 20%);
-    box-shadow: inset @borderWidthL 0 @primary_blue_shade_1;
-    color: @primary_blue_shade_2;
+    box-shadow: inset @borderWidthL 0 @primary_blue_shade_3;
+    color: @primary_blue_shade_3;
   }
 
   &:disabled {
@@ -43,10 +43,10 @@ button.Menu--MenuItem--default {
 .Menu--MenuItem--default.Menu--MenuItem--selected {
   .text--semi-bold();
   box-shadow: inset @borderWidthL 0 @primary_blue;
-  color: @primary_blue_shade_2;
+  color: @primary_blue;
 
   &:focus {
-    box-shadow: inset @borderWidthL 0 @primary_blue;
-    color: @primary_blue_shade_2;
+    box-shadow: inset @borderWidthL 0 @primary_blue_shade_3;
+    color: @primary_blue_shade_3;
   }
 }


### PR DESCRIPTION
# Jira:
https://clever.atlassian.net/browse/prtl-726

# Overview:
This change increases the contrast ratio of the focused menu item to make the component more accessible. I made some tweaks to the selected and active states to darken those as well.

# Screenshots/GIFs:
Focus state before:
![Screen Shot 2021-07-29 at 5 21 51 PM](https://user-images.githubusercontent.com/32328921/127581611-9f449e17-49ce-4c13-8b80-d56a1cf3fa75.jpg)

Focus state after:
![Screen Shot 2021-07-29 at 5 19 35 PM](https://user-images.githubusercontent.com/32328921/127581473-98ec90f2-baba-4f6c-8d71-e6973e00e598.jpg)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
