### PR TITLE
[a11y] Improve contrast ratio of Buttons and make a designer's dreams come true 🎨 👩‍🎨 💭

### DIFF
--- a/genColors.ts
+++ b/genColors.ts
@@ -51,6 +51,7 @@ const Colors = {
     ALERT_RED_SHADE_2: "#AE121F",
     ALERT_RED_TINT_1: "#ED4B59",
     ALERT_RED_TINT_2: "#F56A75",
+    ALERT_RED_SHADE: "#B30C10",
   },
 
   // Secondary colors:

--- a/genColors.ts
+++ b/genColors.ts
@@ -82,11 +82,11 @@ const DeprecatedColors = {
 const jsColors = [];
 const lessColors = [];
 
-Object.keys(Colors).forEach(category => {
+Object.keys(Colors).forEach((category) => {
   jsColors.push(`  // ${category} colors:`);
   lessColors.push(`// ${category} colors:`);
 
-  Object.keys(Colors[category]).forEach(colorName => {
+  Object.keys(Colors[category]).forEach((colorName) => {
     const colorValue = Colors[category][colorName];
     jsColors.push(`  ${colorName}: "${colorValue}",`);
     lessColors.push(`@${colorName.toLowerCase()}: ${colorValue};`);
@@ -99,7 +99,7 @@ Object.keys(Colors).forEach(category => {
 jsColors.push("  // DEPRECATED COLORS:");
 lessColors.push("// DEPRECATED COLORS:");
 
-Object.keys(DeprecatedColors).forEach(colorName => {
+Object.keys(DeprecatedColors).forEach((colorName) => {
   const colorValue = DeprecatedColors[colorName];
   jsColors.push(`  ${colorName}: "${colorValue}",`);
   lessColors.push(`@${colorName.toLowerCase()}: ${colorValue};`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.143.3",
+  "version": "2.144.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -27,7 +27,6 @@ button {
     .margin--none;
     .padding--none;
     .text--medium;
-    border-bottom-width: @borderWidthL;
     box-sizing: border-box;
     cursor: pointer;
     display: inline-block;
@@ -69,7 +68,6 @@ button {
   &.Button--primary {
     background-color: @primary_blue;
     border-color: @primary_blue;
-    border-bottom-color: @primary_blue_shade_1;
     color: @neutral_white;
 
     &:hover,
@@ -77,7 +75,6 @@ button {
     &:active {
       background-color: @primary_blue_shade_2;
       border-color: @primary_blue_shade_2;
-      border-bottom-color: @primary_blue_shade_2;
       color: @neutral_white;
     }
   }
@@ -85,7 +82,6 @@ button {
   &.Button--secondary {
     background-color: @neutral_white;
     border-color: @primary_blue_tint_2;
-    border-bottom-color: @primary_blue;
     color: @primary_blue;
 
     &:hover,
@@ -93,7 +89,6 @@ button {
     &:active {
       background-color: @primary_blue_tint_2;
       border-color: @primary_blue_tint_2;
-      border-bottom-color: @primary_blue_tint_1;
       color: @neutral_white;
     }
   }
@@ -101,7 +96,6 @@ button {
   &.Button--destructive {
     background-color: @alert_red;
     border-color: @alert_red;
-    border-bottom-color: @alert_red_shade_1;
     color: @neutral_white;
 
     &:hover,
@@ -109,7 +103,6 @@ button {
     &:active {
       background-color: @alert_red_shade_1;
       border-color: @alert_red_shade_1;
-      border-bottom-color: @alert_red_shade_2;
       color: @neutral_white;
     }
   }
@@ -117,7 +110,6 @@ button {
   &.Button--secondaryDestructive {
     background-color: @neutral_white;
     border-color: @alert_red;
-    border-bottom-color: @alert_red;
     color: @alert_red;
 
     &:hover,
@@ -125,7 +117,6 @@ button {
     &:active {
       background-color: @alert_red_shade_2;
       border-color: @alert_red;
-      border-bottom-color: @alert_red;
       color: @neutral_white;
     }
   }

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -1,6 +1,8 @@
 @import "../less/fonts.less";
 @import (reference) "../less/index";
 
+@alert_red_hover: #880b0e;
+
 .buttonColor(@backgroundColor: @primary_blue, @disabled: false) {
   background-color: @backgroundColor;
   border-color: @backgroundColor;
@@ -81,42 +83,42 @@ button {
 
   &.Button--secondary {
     background-color: @neutral_white;
-    border-color: @primary_blue_tint_2;
+    border-color: @primary_blue;
     color: @primary_blue;
 
     &:hover,
     &:focus,
     &:active {
-      background-color: @primary_blue_tint_2;
-      border-color: @primary_blue_tint_2;
+      background-color: @primary_blue;
+      border-color: @primary_blue;
       color: @neutral_white;
     }
   }
 
   &.Button--destructive {
-    background-color: @alert_red;
-    border-color: @alert_red;
+    background-color: @alert_red_shade;
+    border-color: @alert_red_shade;
     color: @neutral_white;
 
     &:hover,
     &:focus,
     &:active {
-      background-color: @alert_red_shade_1;
-      border-color: @alert_red_shade_1;
+      background-color: @alert_red_hover;
+      border-color: @alert_red_hover;
       color: @neutral_white;
     }
   }
 
   &.Button--secondaryDestructive {
     background-color: @neutral_white;
-    border-color: @alert_red;
-    color: @alert_red;
+    border-color: @alert_red_shade;
+    color: @alert_red_shade;
 
     &:hover,
     &:focus,
     &:active {
-      background-color: @alert_red_shade_2;
-      border-color: @alert_red;
+      background-color: @alert_red_shade;
+      border-color: @alert_red_shade;
       color: @neutral_white;
     }
   }

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -4,7 +4,7 @@
 @ICON_REGULAR_SIZE: @size_2xl;
 @HOVER_BACKGROUND_COLOR: #f9faff;
 @ERROR_RED: #df3537;
-@ERROR_RED_TEXT: #b30c10;
+@ERROR_RED_TEXT: @alert_red_shade;
 
 .MessagingAttachment--ParentContainer {
   position: relative;

--- a/src/less/colors.less
+++ b/src/less/colors.less
@@ -38,6 +38,7 @@
 @alert_red_shade_2: #ae121f;
 @alert_red_tint_1: #ed4b59;
 @alert_red_tint_2: #f56a75;
+@alert_red_shade: #b30c10;
 
 // Accent colors:
 @accent_teal: #29c6c1;

--- a/src/utils/Colors.ts
+++ b/src/utils/Colors.ts
@@ -39,6 +39,7 @@ const Colors = {
   ALERT_RED_SHADE_2: "#AE121F",
   ALERT_RED_TINT_1: "#ED4B59",
   ALERT_RED_TINT_2: "#F56A75",
+  ALERT_RED_SHADE: "#B30C10",
 
   // Accent colors:
   ACCENT_TEAL: "#29C6C1",


### PR DESCRIPTION
# Jira:
https://clever.atlassian.net/browse/PRTL-771

# Overview:
This pull request includes two changes:
1. (Accessibility) Increase contrast ratios of secondary, destructive, and destructive secondary buttons.
2. (Make a designer's dreams come true) Remove the bottom inner shadow effect to give buttons a flat look.

I added a new color variable for #B30C10 since it's used in more than one place and it's in the list of new colors in Figma. I didn't add a color variable for #880B0E because it's only used in this one place at the moment.

# Screenshots/GIFs:
Before default:
![Screen Shot 2021-08-02 at 11 28 28 AM](https://user-images.githubusercontent.com/32328921/127907489-a822ded2-49c5-4074-957c-38c22e4f543f.jpg)
Before hover:
![Screen Shot 2021-08-02 at 11 28 56 AM](https://user-images.githubusercontent.com/32328921/127907488-148614e9-3f61-47e2-8cd3-0945bbfdc63f.jpg)

After default:
![Screen Shot 2021-08-02 at 11 27 25 AM](https://user-images.githubusercontent.com/32328921/127907492-58864d80-dcac-4931-b276-1794eac1ea84.jpg)
After hover:
![Screen Shot 2021-08-02 at 11 27 53 AM](https://user-images.githubusercontent.com/32328921/127907490-0d531e08-0b1c-4cb8-9a4e-df47bafd7658.jpg)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
