### PR TITLE
PRTL-729: "show more" button focus state contrast

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.144.0",
+  "version": "2.145.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/prop-types": "^15.5.1",
     "classnames": "~2.2.5",
     "core-js": "^2.4.1",
-    "downshift": "^6.1.0",
+    "downshift": "6.1.3",
     "focus-trap-react": "^6.0.0",
     "less": "^3.8.1",
     "linkify-it": "^3.0.2",

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -141,8 +141,13 @@
     outline: none;
   }
 
-  &:focus > .QuotedAnnouncementBubble--button--inner {
-    outline: 0.1875rem solid @accent_purple_shade_2;
+  &:focus > .QuotedAnnouncementBubble--button--inner.QuotedAnnouncementBubble--button--light,
+  &:focus > .QuotedAnnouncementBubble--button--inner.QuotedAnnouncementBubble--button--white {
+    outline: 0.1875rem solid @primary_blue_shade_2;
+  }
+
+  &:focus > .QuotedAnnouncementBubble--button--inner.QuotedAnnouncementBubble--button--dark {
+    outline: 0.1875rem solid @neutral_white;
   }
 }
 


### PR DESCRIPTION
# Jira: [PRTL-729](https://clever.atlassian.net/browse/PRTL-729)

# Overview:

Changing QuotedAnnouncementBubble "Show more" button focus state outline for contrast. For `light` and `white` themes, the color is now `@primary_blue_shade_2`, and for `dark` theme the color is `@neutral_white`. 

# Screenshots/GIFs:

## Before
![Screen Shot 2021-08-03 at 3 13 56 PM](https://user-images.githubusercontent.com/54862564/128093161-7f9bcda7-6f01-45db-8fbb-07b3e8cc4d09.png)
![Screen Shot 2021-08-03 at 3 13 51 PM](https://user-images.githubusercontent.com/54862564/128093164-bf2eac89-f07a-45b5-87c1-f4bb0193a87a.png)
![Screen Shot 2021-08-03 at 3 13 46 PM](https://user-images.githubusercontent.com/54862564/128093167-dd366eea-005d-40c4-b5e4-bc0f579130c8.png)


## After
![Screen Shot 2021-08-03 at 3 08 00 PM](https://user-images.githubusercontent.com/54862564/128093069-ea4a7234-02bc-4b6a-9c3c-99750301a543.png)
![Screen Shot 2021-08-03 at 3 07 56 PM](https://user-images.githubusercontent.com/54862564/128093071-d3456ad3-7df8-46ec-b35b-096edda2bd3c.png)
![Screen Shot 2021-08-03 at 3 07 51 PM](https://user-images.githubusercontent.com/54862564/128093072-75bb5b27-b9aa-48a9-8b55-6f1970a97742.png)


# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [x] Firefox
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Bumped version in `package.json`
    - New component or backward-compatible component feature change? Run `npm version minor`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
