### PR TITLE
M5G-573: Make ThreadHistory focusable by keyboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.145.0",
+  "version": "2.146.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -106,6 +106,7 @@ export const MessagingThreadHistory = React.forwardRef(
         )}
         ref={containerRef}
         onScroll={onScroll}
+        tabIndex={0}
       >
         {messagesWithDividers}
       </div>


### PR DESCRIPTION
# Jira: [M5G-573](https://clever.atlassian.net/browse/M5G-573)

# Overview:

Previously the MessagingThreadHistory was not focusable using the keyboard. I added tabIndex={0} to it, so now you can focus using the keyboard!

# Screenshots/GIFs:

![Screen Shot 2021-08-04 at 4 51 55 PM](https://user-images.githubusercontent.com/54862564/128270202-a51d9f79-ca85-42f1-810c-4f36821d95b0.png)


# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - New component or backward-compatible component feature change? Run `npm version minor`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
