### PR TITLE
M5G-573: focus state outline color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.146.0",
+  "version": "2.147.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/MessagingThreadHistory.less
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.less
@@ -3,6 +3,10 @@
 .ThreadHistory--Container {
   overflow-y: auto;
   .padding--right--s();
+
+  &:focus {
+    outline: 0.1875rem solid @primary_blue_tint_1;
+  }
 }
 
 .ThreadHistory--Divider {


### PR DESCRIPTION
# Jira: [M5G-573](https://clever.atlassian.net/browse/M5G-573)

# Overview:

Setting focus state outline color to blue

# Screenshots/GIFs:

![Screen Shot 2021-08-05 at 1 33 13 PM](https://user-images.githubusercontent.com/54862564/128417513-616df160-6ee1-4a4f-b863-74a13543341d.png)


# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
