### PR TITLE
modified AnnouncementBubble to inlude RR and updated documentation

### DIFF
--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -120,6 +120,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
               className={cssClass.BUBBLE}
               readBy={["Jim Carrey", "Drake", "Ash Ketchum", "Tony Stark", "Roger Federer"]}
               userType={"teacher"}
+              recipientType={"student"}
               senderName={"Ms. Stark"}
               senderIcon={
                 <MessagingAvatar

--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -118,8 +118,18 @@ export default class AnnouncementBubbleView extends React.PureComponent {
 
             <AnnouncementBubble
               className={cssClass.BUBBLE}
-              readBy={["Jim Carrey", "Drake", "Ash Ketchum", "Tony Stark", "Roger Federer"]}
-              userType={"teacher"}
+              readBy={[
+                "Arsalan",
+                "Nikhil",
+                "Spencer",
+                "Ashley",
+                "Jonathan",
+                "Brian",
+                "Chloe",
+                "Cory",
+                "Jonah",
+                "Nick",
+              ]}
               recipientType={"student"}
               senderName={"Ms. Stark"}
               senderIcon={

--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -118,6 +118,24 @@ export default class AnnouncementBubbleView extends React.PureComponent {
 
             <AnnouncementBubble
               className={cssClass.BUBBLE}
+              readBy={["Jim Carrey", "Drake", "Ash Ketchum", "Tony Stark", "Roger Federer"]}
+              userType={"teacher"}
+              senderName={"Ms. Stark"}
+              senderIcon={
+                <MessagingAvatar
+                  text={"Kristen Stark"}
+                  color={{ color: Colors.PRIMARY_BLUE_TINT_2 }}
+                />
+              }
+              sentAtTimestamp={new Date()}
+              theme={"normal"}
+            >
+              Read Receipts also show up for teachers as well! A tooltip of these names sorted
+              alphabetically by first name will render upon hover.
+            </AnnouncementBubble>
+
+            <AnnouncementBubble
+              className={cssClass.BUBBLE}
               attachments={attachmentsArray}
               senderName={"Ms. Stark"}
               senderIcon={

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.148.0",
+  "version": "2.149.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "typescript": "3.x",
     "url-loader": "^0.5.7",
     "webpack": "^5.24.2",
-    "webpack-cli": "^4.5.0",
+    "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   },
   "peer-dependencies": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "typescript": "3.x",
     "url-loader": "^0.5.7",
     "webpack": "^5.24.2",
-    "webpack-cli": "^4.7.2",
+    "webpack-cli": "^4.5.0",
     "webpack-dev-server": "^3.11.2"
   },
   "peer-dependencies": {

--- a/src/AnnouncementBubble/AnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/AnnouncementBubble.tsx
@@ -69,7 +69,6 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
           senderIcon={props.senderIcon}
           senderName={props.senderName}
           sentAtTimestamp={props.sentAtTimestamp}
-          userType={props.userType}
         >
           {props.children}
         </NormalAnnouncementBubble>

--- a/src/AnnouncementBubble/AnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/AnnouncementBubble.tsx
@@ -63,6 +63,7 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
           onDelete={props.onDelete}
           onReply={props.onReply}
           readBy={props.readBy}
+          recipientType={props.recipientType}
           repliesDisabledMsg={props.repliesDisabledMsg}
           replyButtonText={props.replyButtonText}
           senderIcon={props.senderIcon}

--- a/src/AnnouncementBubble/AnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/AnnouncementBubble.tsx
@@ -62,11 +62,13 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
           className={props.className}
           onDelete={props.onDelete}
           onReply={props.onReply}
+          readBy={props.readBy}
           repliesDisabledMsg={props.repliesDisabledMsg}
           replyButtonText={props.replyButtonText}
           senderIcon={props.senderIcon}
           senderName={props.senderName}
           sentAtTimestamp={props.sentAtTimestamp}
+          userType={props.userType}
         >
           {props.children}
         </NormalAnnouncementBubble>

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -156,7 +156,6 @@ button.NormalAnnouncementBubble--deleteMenuItem {
   white-space: nowrap;
 
   .tooltip-inner {
-    width: 18.75rem;
     padding: @size_2xs @size_s;
   }
 }

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -166,11 +166,18 @@ button.NormalAnnouncementBubble--deleteMenuItem {
   .margin--right--2xs();
   width: 0.865rem;
   height: 0.663rem;
+  .margin--top--2xs();
 }
 
-.NormalAnnouncementBubble--readReceipts--text {
+.NormalAnnouncementBubble--readReceipts--text--desktop {
   color: @neutral_medium_gray;
   .text--medium;
+}
+
+.NormalAnnouncementBubble--readReceipts--text--mobile {
+  color: @neutral_medium_gray;
+  .text--medium;
+  display: none;
 }
 
 .NormalAnnouncementBubble--readReceiptContainer {
@@ -183,7 +190,12 @@ button.NormalAnnouncementBubble--deleteMenuItem {
     outline: 0;
   }
 
-  &:hover .NormalAnnouncementBubble--readReceipts--text {
+  &:hover .NormalAnnouncementBubble--readReceipts--text--desktop {
+    color: @primary_blue_shade_2;
+    outline: 0;
+  }
+
+  &:hover .NormalAnnouncementBubble--readReceipts--text--mobile {
     color: @primary_blue_shade_2;
     outline: 0;
   }
@@ -193,6 +205,7 @@ button.NormalAnnouncementBubble--deleteMenuItem {
   color: @neutral_dark_gray;
 }
 
+// For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
   .NormalAnnouncementBubble--container {
     width: 96%;
@@ -207,5 +220,13 @@ button.NormalAnnouncementBubble--deleteMenuItem {
     color: @neutral_dark_gray;
     .margin--top--m();
     .text--line-height-4();
+  }
+
+  .NormalAnnouncementBubble--readReceipts--text--desktop {
+    display: none;
+  }
+
+  .NormalAnnouncementBubble--readReceipts--text--mobile {
+    display: block;
   }
 }

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -138,22 +138,6 @@ button.NormalAnnouncementBubble--deleteMenuItem {
   }
 }
 
-.NormalAnnouncementBubble--readReceiptContainer {
-  margin-top: 1rem;
-  width: 100%;
-  .flex--direction--row();
-
-  &:hover .NormalAnnouncementBubble--readReceipts--icon {
-    .pathColor(@primary_blue_shade_2);
-    outline: 0;
-  }
-
-  &:hover .NormalAnnouncementBubble--readReceipts--text {
-    color: @primary_blue_shade_2;
-    outline: 0;
-  }
-}
-
 .NormalAnnouncementBubble--replyButton--icon {
   margin-right: 0.3125rem;
 }
@@ -187,6 +171,22 @@ button.NormalAnnouncementBubble--deleteMenuItem {
 .NormalAnnouncementBubble--readReceipts--text {
   color: @neutral_medium_gray;
   .text--medium;
+}
+
+.NormalAnnouncementBubble--readReceiptContainer {
+  margin-top: 1rem;
+  width: 100%;
+  .flex--direction--row();
+
+  &:hover .NormalAnnouncementBubble--readReceipts--icon {
+    .pathColor(@primary_blue_shade_2);
+    outline: 0;
+  }
+
+  &:hover .NormalAnnouncementBubble--readReceipts--text {
+    color: @primary_blue_shade_2;
+    outline: 0;
+  }
 }
 
 .NormalAnnouncementBubble--replyButton--text--disabled {

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -1,5 +1,12 @@
 @import (reference) "../less/index";
 
+.pathColor(@color) {
+  path {
+    stroke: transparent;
+    fill: @color;
+  }
+}
+
 .NormalAnnouncementBubble--container {
   max-width: 31rem; /* is 33 rem total width including 1 rem padding on either side */
   .boxShadow--medium();
@@ -131,6 +138,22 @@ button.NormalAnnouncementBubble--deleteMenuItem {
   }
 }
 
+.NormalAnnouncementBubble--readReceiptContainer {
+  margin-top: 1rem;
+  width: 100%;
+  .flex--direction--row();
+
+  &:hover .NormalAnnouncementBubble--readReceipts--icon {
+    .pathColor(@primary_blue_shade_2);
+    outline: 0;
+  }
+
+  &:hover .NormalAnnouncementBubble--readReceipts--text {
+    color: @primary_blue_shade_2;
+    outline: 0;
+  }
+}
+
 .NormalAnnouncementBubble--replyButton--icon {
   margin-right: 0.3125rem;
 }
@@ -149,9 +172,21 @@ button.NormalAnnouncementBubble--deleteMenuItem {
   white-space: nowrap;
 
   .tooltip-inner {
-    max-width: 30rem;
+    width: 18.75rem;
     padding: @size_2xs @size_s;
   }
+}
+
+.NormalAnnouncementBubble--readReceipts--icon {
+  .pathColor(@neutral_medium_gray);
+  .margin--right--2xs();
+  width: 0.865rem;
+  height: 0.663rem;
+}
+
+.NormalAnnouncementBubble--readReceipts--text {
+  color: @neutral_medium_gray;
+  .text--medium;
 }
 
 .NormalAnnouncementBubble--replyButton--text--disabled {

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -156,6 +156,7 @@ button.NormalAnnouncementBubble--deleteMenuItem {
   white-space: nowrap;
 
   .tooltip-inner {
+    max-width: 30rem;
     padding: @size_2xs @size_s;
   }
 }

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -4,6 +4,7 @@ import * as cx from "classnames";
 import Linkify from "react-linkify";
 import { FlexBox, Button, Menu, Tooltip } from "../";
 import { componentDecorator, matchDecorator } from "../MessagingBubble/linkifyUtils";
+import Checkmark from "../Checkbox/CheckMark";
 
 import "./NormalAnnouncementBubble.less";
 
@@ -18,10 +19,12 @@ export interface Props {
   className?: string;
   onDelete?: () => void;
   onReply?: () => void;
+  readBy?: string[];
   repliesDisabledMsg?: string;
   senderIcon: React.ReactNode;
   senderName: string;
   sentAtTimestamp: Date;
+  userType: "teacher" | "student" | "guardian";
 
   // Temporary props to allow overriding text with translations
   replyButtonText?: string;
@@ -33,14 +36,18 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
   className,
   onDelete,
   onReply,
+  readBy,
   repliesDisabledMsg,
   replyButtonText,
   senderIcon,
   senderName,
   sentAtTimestamp,
+  userType,
 }: Props) => {
   const deleteMenu = formDeleteMenu(onDelete);
   const replyButton = formReplyButton(onReply, repliesDisabledMsg, replyButtonText);
+  const readReceiptsTooltip =
+    userType === "teacher" && readBy && readBy.length > 0 ? formReadReceiptsTooltip(readBy) : null;
 
   return (
     <FlexBox
@@ -64,6 +71,7 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
       {attachments?.length > 0 && (
         <FlexBox className={cssClass("attachmentContainer")}>{attachments}</FlexBox>
       )}
+      {readReceiptsTooltip}
       {replyButton}
     </FlexBox>
   );
@@ -115,6 +123,29 @@ function formReplyButton(
   return undefined;
 }
 
+function formReadReceiptsTooltip(readBy: string[]): JSX.Element {
+  const readReceiptCount = readBy.length;
+  const readReceiptString = convertReadReceiptArrayToString(readBy);
+  return (
+    <FlexBox className={cssClass("readReceiptContainer")} alignItems="center" justify="end">
+      <Checkmark className={cssClass("readReceipts--icon")} />
+      <Tooltip content={readReceiptString} placement={"top"} textAlign={"center"}>
+        <span className={cssClass("readReceipts--text")}>Read by {readReceiptCount} people</span>
+      </Tooltip>
+    </FlexBox>
+  );
+}
+
+function convertReadReceiptArrayToString(readBy: string[]): string {
+  readBy.sort((a, b) => {
+    return a.toLowerCase().localeCompare(b.toLowerCase());
+  });
+  const readReceiptCount = readBy.length;
+  readBy[readReceiptCount - 1] = `and ${readBy[readReceiptCount - 1]}`;
+
+  return readBy.join(", ");
+}
+
 function ReplyButton({
   onReply,
   replyButtonText,
@@ -152,8 +183,8 @@ function DisabledReplyButton({
     >
       <Tooltip
         content={disabledMsg}
-        placement={"top"}
-        textAlign={"center"}
+        placement={Tooltip.Placement.TOP}
+        textAlign={Tooltip.Align.CENTER}
         tooltipClassName={cssClass("tooltip")}
       >
         <FlexBox alignItems="center" justify="center">

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -25,7 +25,6 @@ export interface Props {
   senderIcon: React.ReactNode;
   senderName: string;
   sentAtTimestamp: Date;
-  userType: "teacher" | "student" | "guardian";
 
   // Temporary props to allow overriding text with translations
   replyButtonText?: string;
@@ -44,14 +43,11 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
   senderIcon,
   senderName,
   sentAtTimestamp,
-  userType,
 }: Props) => {
   const deleteMenu = formDeleteMenu(onDelete);
   const replyButton = formReplyButton(onReply, repliesDisabledMsg, replyButtonText);
   const readReceiptsTooltip =
-    userType === "teacher" && readBy && readBy.length > 0
-      ? formReadReceiptsTooltip(readBy, recipientType)
-      : null;
+    readBy?.length > 0 ? formReadReceiptsTooltip(readBy, recipientType) : null;
 
   return (
     <FlexBox
@@ -133,7 +129,7 @@ function formReadReceiptsTooltip(
 ): JSX.Element {
   const readReceiptCount = readBy.length;
   const readReceiptString = convertReadReceiptArrayToString(readBy);
-  const recipientString = readBy.length === 1 ? `${recipientType}` : `${recipientType}s`;
+  const recipientString = readBy.length === 1 ? recipientType : `${recipientType}s`;
   return (
     <FlexBox className={cssClass("readReceiptContainer")} alignItems="center" justify="end">
       <Checkmark className={cssClass("readReceipts--icon")} />
@@ -193,8 +189,8 @@ function DisabledReplyButton({
     >
       <Tooltip
         content={disabledMsg}
-        placement={Tooltip.Placement.TOP}
-        textAlign={Tooltip.Align.CENTER}
+        placement={"top"}
+        textAlign={"center"}
         tooltipClassName={cssClass("tooltip")}
       >
         <FlexBox alignItems="center" justify="center">

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -132,11 +132,14 @@ function formReadReceiptsTooltip(
   const recipientString = readBy.length === 1 ? recipientType : `${recipientType}s`;
   return (
     <FlexBox className={cssClass("readReceiptContainer")} alignItems="center" justify="end">
-      <Checkmark className={cssClass("readReceipts--icon")} />
       <Tooltip content={readReceiptString} placement={"top"} textAlign={"center"}>
-        <span className={cssClass("readReceipts--text")}>
-          Read by {readReceiptCount} {recipientString}
-        </span>
+        <FlexBox className={cssClass("readReceiptContainer--inner")}>
+          <Checkmark className={cssClass("readReceipts--icon")} />
+          <span className={cssClass("readReceipts--text--desktop")}>
+            Read by {readReceiptCount} {recipientString}
+          </span>
+          <span className={cssClass("readReceipts--text--mobile")}>{readReceiptCount}</span>
+        </FlexBox>
       </Tooltip>
     </FlexBox>
   );

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -20,6 +20,7 @@ export interface Props {
   onDelete?: () => void;
   onReply?: () => void;
   readBy?: string[];
+  recipientType: "student" | "guardian";
   repliesDisabledMsg?: string;
   senderIcon: React.ReactNode;
   senderName: string;
@@ -37,6 +38,7 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
   onDelete,
   onReply,
   readBy,
+  recipientType,
   repliesDisabledMsg,
   replyButtonText,
   senderIcon,
@@ -47,7 +49,9 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
   const deleteMenu = formDeleteMenu(onDelete);
   const replyButton = formReplyButton(onReply, repliesDisabledMsg, replyButtonText);
   const readReceiptsTooltip =
-    userType === "teacher" && readBy && readBy.length > 0 ? formReadReceiptsTooltip(readBy) : null;
+    userType === "teacher" && readBy && readBy.length > 0
+      ? formReadReceiptsTooltip(readBy, recipientType)
+      : null;
 
   return (
     <FlexBox
@@ -123,14 +127,20 @@ function formReplyButton(
   return undefined;
 }
 
-function formReadReceiptsTooltip(readBy: string[]): JSX.Element {
+function formReadReceiptsTooltip(
+  readBy: string[],
+  recipientType: "student" | "guardian",
+): JSX.Element {
   const readReceiptCount = readBy.length;
   const readReceiptString = convertReadReceiptArrayToString(readBy);
+  const recipientString = readBy.length === 1 ? `${recipientType}` : `${recipientType}s`;
   return (
     <FlexBox className={cssClass("readReceiptContainer")} alignItems="center" justify="end">
       <Checkmark className={cssClass("readReceipts--icon")} />
       <Tooltip content={readReceiptString} placement={"top"} textAlign={"center"}>
-        <span className={cssClass("readReceipts--text")}>Read by {readReceiptCount} people</span>
+        <span className={cssClass("readReceipts--text")}>
+          Read by {readReceiptCount} {recipientString}
+        </span>
       </Tooltip>
     </FlexBox>
   );


### PR DESCRIPTION
# Jira: [M5G-672](https://clever.atlassian.net/browse/M5G-672)

# Overview:
In order for the `readBy` data fetched using the selector in LP to show up for each announcement as read receipts, we must modify each AnnouncementBubble component in the components directory (more information for this can be found [here](https://github.com/Clever/launchpad/pull/4151)). We create new props `userType`, `readBy` and `recipientType` in the AnnouncementBubble component. `userType` checks if we should display RR or not, `readBy` is a string array that contains the names of people who have read the announcement and `recipientType` checks who the RRs are for. We sort `readBy` by first name and then display as a tooltip component from Dewey. Our implementation considers base cases as well (when `readBy` is empty or has 1 person). 

# Photos:

## Desktop:

<img width="571" alt="Screen Shot 2021-08-05 at 8 53 01 PM" src="https://user-images.githubusercontent.com/45299876/128453558-4f90494e-b6b9-4a64-99e0-5955d98baefe.png">

<img width="607" alt="Screen Shot 2021-08-05 at 8 52 46 PM" src="https://user-images.githubusercontent.com/45299876/128453535-d88666ad-7183-4b11-9ac7-edfb9551b850.png">

## Mobile:
![image](https://user-images.githubusercontent.com/45299876/128560303-1dec246a-db2a-4ee3-8c7a-2aa536fe81b5.png)


# Testing:

- [ ] Feature responds and behaves as intended with hover feature (changing color and displaying tooltip popup)
- [ ] For an empty `readBy` field, the read receipts tooltip is hidden
- [ ] For a `readBy` array of length 1, we display "Read by 1 student/guardian"
- [ ] For max number of users (200-300), read receipts tooltip reformats to accommodate longer RR string (Read by 300 students/guardians)

# ReadReceipts:

Read more about calculating read receipts [here](https://docs.google.com/document/d/1jS2vi_tE8isbU306vsTS0vxbWUybpRplBXcvptIXjpI/edit)


