### PR TITLE
Align button content vertically and fix heights

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.149.0",
+  "version": "2.149.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -145,11 +145,11 @@ button {
   &.Button--small {
     font-size: 0.875rem;
     .text--semi-bold;
-    padding: 0.388rem @size_s 0.3rem;
+    padding: 0.40625rem @size_s;
   }
 
   &.Button--regular {
-    padding: @size_s @size_m @size_xs;
+    padding: 0.6875rem @size_m;
   }
 
   &.Button--linkPlain,
@@ -187,7 +187,7 @@ button {
   &.Button--large {
     .borderRadius--xl;
     .text--large;
-    padding: @size_m @size_l @size_s;
+    padding: @size_m @size_l;
   }
 
   /* Match surroundings even more. */


### PR DESCRIPTION

# Overview:
This makes two small tweaks to the `Button` component.
1. Use the same top and bottom padding so that the `Button`'s content is vertically aligned.
2. Set vertical padding values such that the heights are 64px, 44px, and 32px for large, regular, and small buttons respectively.

I accidentally changed the button heights when I removed the thicker bottom border in #708 
# Screenshots/GIFs:
Before (left) vs after (right)
![Screen Shot 2021-08-06 at 5 07 55 PM](https://user-images.githubusercontent.com/32328921/128581421-e14f9a99-9450-4fe9-a67d-b6239b449d55.jpg)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
