### PR TITLE
[M5G-666] More inline errors in messaging

### DIFF
--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -272,6 +272,26 @@ export default class AnnouncementBubbleView extends React.PureComponent {
               }
               sentAtTimestamp={new Date()}
             />
+
+            <br />
+
+            <AnnouncementBubble
+              theme={"quoted"}
+              attachments={attachmentsArray}
+              colorTheme={colorTheme}
+              announcementGroupName={"Math Rocks!"}
+              senderName={"Ms. Stark"}
+              senderIcon={
+                <MessagingAvatar
+                  text={"Kristen Stark"}
+                  color={{ color: Colors.PRIMARY_BLUE_TINT_2 }}
+                />
+              }
+              sentAtTimestamp={new Date()}
+              inlineErrorMsg={"Something went wrong. We were unable to translate this message."}
+            >
+              This can also have inline errors.
+            </AnnouncementBubble>
           </ExampleCode>
           {this._renderConfig()}
         </Example>

--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -206,6 +206,25 @@ export default class AnnouncementBubbleView extends React.PureComponent {
               sentAtTimestamp={new Date()}
               theme={"normal"}
             />
+
+            {/* in-line error*/}
+            <AnnouncementBubble
+              className={cssClass.BUBBLE}
+              attachments={attachmentsArray}
+              senderName={"Ms. Stark"}
+              senderIcon={
+                <MessagingAvatar
+                  text={"Kristen Stark"}
+                  color={{ color: Colors.PRIMARY_BLUE_TINT_2 }}
+                />
+              }
+              onReply={() => console.log("Reply!")}
+              sentAtTimestamp={new Date()}
+              theme={"normal"}
+              inlineErrorMsg={"Something went wrong. We were unable to translate this message."}
+            >
+              Announcements like this one can include attachments and in-line errors
+            </AnnouncementBubble>
           </ExampleCode>
         </Example>
         <Example title="QuotedAnnouncementBubble">

--- a/docs/components/MessagingThreadHistoryView.jsx
+++ b/docs/components/MessagingThreadHistoryView.jsx
@@ -31,7 +31,7 @@ function randomElement(items) {
 function newMessage(displayAlertMessageAfter = false) {
   const message = randomElement(["Hello!", "Hi!", "How are you doing?"]);
   const placement = randomElement(["left", "right"]);
-  const errorMsg = message === "Hi!" && placement === "right" ? "Message failed to send" : "";
+  const errorMsg = randomElement(["Message failed to send", ""]);
   newestTime.add(6, "hours");
   currentMessageIndex++;
   return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.149.2",
+  "version": "2.150.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/AnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/AnnouncementBubble.tsx
@@ -60,6 +60,7 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
           theme="normal"
           attachments={props.attachments}
           className={props.className}
+          inlineErrorMsg={props.inlineErrorMsg}
           onDelete={props.onDelete}
           onReply={props.onReply}
           readBy={props.readBy}

--- a/src/AnnouncementBubble/AnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/AnnouncementBubble.tsx
@@ -39,6 +39,7 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
           attachments={props.attachments}
           className={props.className}
           colorTheme={props.colorTheme}
+          inlineErrorMsg={props.inlineErrorMsg}
           isMessageTruncated={props.isMessageTruncated}
           postedInText={props.postedInText}
           senderIcon={props.senderIcon}

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -217,7 +217,7 @@ button.NormalAnnouncementBubble--deleteMenuItem {
   .text--smallMedium();
 }
 
-.NormalAnnouncementBubble--inlineErrorContents {
+.NormalAnnouncementBubble--inlineError--contents {
   .padding--top--2xs();
   width: 32.9375rem;
   justify-content: flex-start;

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -210,6 +210,24 @@ button.NormalAnnouncementBubble--deleteMenuItem {
   color: @neutral_dark_gray;
 }
 
+.NormalAnnouncementBubble--inlineError {
+  color: @alert_red;
+  line-height: 1rem;
+  .margin--top--2xs();
+  .text--smallMedium();
+}
+
+.NormalAnnouncementBubble--inlineErrorContents {
+  .padding--top--2xs();
+  width: 32.9375rem;
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.NormalAnnouncementBubble--inlineError--icon {
+  .margin--right--2xs();
+}
+
 // For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
   .NormalAnnouncementBubble--container {

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -73,7 +73,7 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
       )}
       {inlineErrorMsg && (
         <FlexBox className={cssClass("inlineError")} grow alignItems="center">
-          <div className={cssClass("inlineErrorContents")}>
+          <div className={cssClass("inlineError--contents")}>
             <FontAwesome className={cssClass("inlineError--icon")} name="exclamation-circle " />
             {inlineErrorMsg}
           </div>

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as moment from "moment";
 import * as cx from "classnames";
+import * as FontAwesome from "react-fontawesome";
 import Linkify from "react-linkify";
 import { FlexBox, Button, Menu, Tooltip } from "../";
 import { componentDecorator, matchDecorator } from "../MessagingBubble/linkifyUtils";
@@ -17,6 +18,7 @@ export interface Props {
   attachments?: React.ReactNode[];
   children: React.ReactNode;
   className?: string;
+  inlineErrorMsg?: string;
   onDelete?: () => void;
   onReply?: () => void;
   readBy?: string[];
@@ -34,6 +36,7 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
   attachments,
   children,
   className,
+  inlineErrorMsg,
   onDelete,
   onReply,
   readBy,
@@ -67,6 +70,14 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
         <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
           <div className={cssClass("messageBody")}>{children}</div>
         </Linkify>
+      )}
+      {inlineErrorMsg && (
+        <FlexBox className={cssClass("inlineError")} grow alignItems="center">
+          <div className={cssClass("inlineErrorContents")}>
+            <FontAwesome className={cssClass("inlineError--icon")} name="exclamation-circle " />
+            {inlineErrorMsg}
+          </div>
+        </FlexBox>
       )}
       {attachments?.length > 0 && (
         <FlexBox className={cssClass("attachmentContainer")}>{attachments}</FlexBox>

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -78,6 +78,32 @@
   margin-left: 0.3125rem;
 }
 
+.QuotedAnnouncementBubble--inlineError--light,
+.QuotedAnnouncementBubble--inlineError--white {
+  color: @alert_red;
+  line-height: 1rem;
+  .text--smallMedium();
+  .margin--bottom--xs();
+}
+
+.QuotedAnnouncementBubble--inlineError--dark {
+  color: @neutral_white;
+  line-height: 1rem;
+  .text--smallMedium();
+  .margin--bottom--xs();
+}
+
+.QuotedAnnouncementBubble--inlineErrorContents {
+  .padding--top--2xs();
+  width: 32.9375rem;
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.QuotedAnnouncementBubble--inlineError--icon {
+  .margin--right--2xs();
+}
+
 .QuotedAnnouncementBubble--attachmentContainer {
   max-width: 100%;
   .margin--bottom--xs();

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -95,9 +95,12 @@
 
 .QuotedAnnouncementBubble--inlineErrorContents {
   .padding--top--2xs();
-  width: 32.9375rem;
   justify-content: flex-start;
   text-align: left;
+  white-space: pre-wrap;
+  word-wrap: break-word; // IE version
+  word-break: normal;
+  overflow-wrap: anywhere;
 }
 
 .QuotedAnnouncementBubble--inlineError--icon {

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -93,7 +93,7 @@
   .margin--bottom--xs();
 }
 
-.QuotedAnnouncementBubble--inlineErrorContents {
+.QuotedAnnouncementBubble--inlineError--contents {
   .padding--top--2xs();
   justify-content: flex-start;
   text-align: left;

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -143,7 +143,7 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
         <>
           {isExpanded && inlineErrorMsg && (
             <FlexBox className={cssClass(`inlineError--${colorTheme}`)} grow alignItems="center">
-              <div className={cssClass("inlineErrorContents")}>
+              <div className={cssClass("inlineError--contents")}>
                 <FontAwesome className={cssClass("inlineError--icon")} name="exclamation-circle " />
                 {inlineErrorMsg}
               </div>

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -21,6 +21,7 @@ export interface Props {
   children: React.ReactNode;
   className?: string;
   colorTheme: "white" | "light" | "dark";
+  inlineErrorMsg?: string;
   isMessageTruncated?: boolean;
   senderIcon: React.ReactNode;
   senderName: string;
@@ -41,6 +42,7 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
   children,
   className,
   colorTheme,
+  inlineErrorMsg,
   isMessageTruncated,
   postedInText,
   senderIcon,
@@ -139,6 +141,14 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
       )}
       {(isExpanded || !content) && (
         <>
+          {isExpanded && inlineErrorMsg && (
+            <FlexBox className={cssClass(`inlineError--${colorTheme}`)} grow alignItems="center">
+              <div className={cssClass("inlineErrorContents")}>
+                <FontAwesome className={cssClass("inlineError--icon")} name="exclamation-circle " />
+                {inlineErrorMsg}
+              </div>
+            </FlexBox>
+          )}
           {attachments?.length > 0 && (
             <FlexBox
               className={cx(

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -44,8 +44,8 @@
 }
 
 .MessageMetadata--ErrorContents {
+  .padding--top--2xs();
   width: 32.9375rem;
-  text-align: right;
 }
 
 .MessageMetadata--Error {
@@ -57,10 +57,12 @@
 
 .MessageMetadata--Error--right {
   justify-content: flex-end;
+  text-align: right;
 }
 
 .MessageMetadata--Error--left {
   justify-content: flex-start;
+  text-align: left;
 }
 
 .MessageMetadata--Error--fullWidth,

--- a/src/MessagingThreadHistory/MessageMetadata.less
+++ b/src/MessagingThreadHistory/MessageMetadata.less
@@ -46,6 +46,7 @@
 .MessageMetadata--ErrorContents {
   .padding--top--2xs();
   width: 32.9375rem;
+  .margin--right--3xl();
 }
 
 .MessageMetadata--Error {


### PR DESCRIPTION
# Jira:
https://clever.atlassian.net/browse/M5G-666
https://www.figma.com/file/X5yHaqtEAyCAtjBFeXRb2s/Messages-v2-(Translations)?node-id=399%3A5690

# Overview:
1) Fix in-line errors in MessagingThreadHistory for other messages so they are styled properly
2) Add in-line (in-bubble) errors in NormalAnnouncementBubble and QuotedAnnouncementBubble. To do so, I added a new optional prop `inlineErrorMessage` which if provided will add an error message in the bubble above attachments but below message body and truncation indication if present. 

# Screenshots/GIFs:
Desktop:

<img width="662" alt="Screen Shot 2021-08-09 at 1 16 12 PM" src="https://user-images.githubusercontent.com/35714960/128757508-df8b52e1-7fad-44bd-8250-ba9baaf96adc.png">
<img width="730" alt="Screen Shot 2021-08-09 at 1 16 39 PM" src="https://user-images.githubusercontent.com/35714960/128757509-08a132cd-eaf0-494f-8511-010197e4be63.png">
<img width="585" alt="Screen Shot 2021-08-09 at 12 18 07 PM" src="https://user-images.githubusercontent.com/35714960/128757510-54f6950e-0ae4-4128-84f7-8600aaca9e10.png">
<img width="700" alt="Screen Shot 2021-08-09 at 12 27 06 PM" src="https://user-images.githubusercontent.com/35714960/128757514-180678a7-8c9a-4a54-8db4-ae786b511c22.png">

Mobile:

<img width="376" alt="Screen Shot 2021-08-09 at 3 16 38 PM" src="https://user-images.githubusercontent.com/35714960/128763192-53ea9c46-ccb7-42ca-b0c6-dda5e1cc4ef5.png">
<img width="383" alt="Screen Shot 2021-08-09 at 3 17 01 PM" src="https://user-images.githubusercontent.com/35714960/128763195-095a1083-2c97-4d59-aa50-d9dd693b9155.png">
<img width="385" alt="Screen Shot 2021-08-09 at 3 21 27 PM" src="https://user-images.githubusercontent.com/35714960/128763196-615aa8fa-7911-47b9-b71a-21ddfa6a7a02.png">
<img width="368" alt="Screen Shot 2021-08-09 at 3 21 37 PM" src="https://user-images.githubusercontent.com/35714960/128763197-542e3a17-3f84-4889-9b73-a2c8c58ea1dd.png">


# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
