### PR TITLE
added analytics prop onReadReceiptsHover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.150.0",
+  "version": "2.151.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/AnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/AnnouncementBubble.tsx
@@ -63,6 +63,7 @@ export const AnnouncementBubble: React.FC<AnnouncementBubbleProps> = (
           className={props.className}
           inlineErrorMsg={props.inlineErrorMsg}
           onDelete={props.onDelete}
+          onReadReceiptsHover={props.onReadReceiptsHover}
           onReply={props.onReply}
           readBy={props.readBy}
           recipientType={props.recipientType}

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -163,7 +163,8 @@ button.NormalAnnouncementBubble--deleteMenuItem {
 
 .NormalAnnouncementBubble--readReceipts--tooltip {
   .text--semi-bold();
-  padding-left: @size_s;
+  padding-right: @size_xs;
+  padding-left: @size_2xs;
 }
 
 .NormalAnnouncementBubble--readReceipts--icon {

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -163,7 +163,7 @@ button.NormalAnnouncementBubble--deleteMenuItem {
 
 .NormalAnnouncementBubble--readReceipts--tooltip {
   .text--semi-bold();
-  padding-right: @size_xs;
+  padding-right: @size_2xs;
   padding-left: @size_2xs;
 }
 

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -146,23 +146,23 @@ function formReadReceiptsTooltip(
   const displayRecipientType = recipientType === "guardian" ? "parent" : recipientType;
   const recipientString = readBy.length === 1 ? displayRecipientType : `${displayRecipientType}s`;
   return (
-    <FlexBox className={cssClass("readReceipts--container")} alignItems="center" justify="end">
-      <div onMouseOver={onReadReceiptsHover}>
-        <Tooltip
-          className={cssClass("readReceipts--tooltip")}
-          content={readReceiptString}
-          placement={"top"}
-          textAlign={"left"}
-        >
-          <FlexBox>
+    <FlexBox alignItems="center" justify="end">
+      <Tooltip
+        className={cssClass("readReceipts--tooltip")}
+        content={readReceiptString}
+        placement={"top"}
+        textAlign={"left"}
+      >
+        <div onMouseEnter={onReadReceiptsHover}>
+          <FlexBox className={cssClass("readReceipts--container")}>
             <Checkmark className={cssClass("readReceipts--icon")} />
             <span className={cssClass("readReceipts--text--desktop")}>
               Read by {readReceiptCount} {recipientString}
             </span>
             <span className={cssClass("readReceipts--text--mobile")}>{readReceiptCount}</span>
           </FlexBox>
-        </Tooltip>
-      </div>
+        </div>
+      </Tooltip>
     </FlexBox>
   );
 }

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -20,6 +20,7 @@ export interface Props {
   className?: string;
   inlineErrorMsg?: string;
   onDelete?: () => void;
+  onReadReceiptsHover?: () => void;
   onReply?: () => void;
   readBy?: string[];
   recipientType: "student" | "guardian";
@@ -38,6 +39,7 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
   className,
   inlineErrorMsg,
   onDelete,
+  onReadReceiptsHover,
   onReply,
   readBy,
   recipientType,
@@ -50,7 +52,7 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
   const deleteMenu = formDeleteMenu(onDelete);
   const replyButton = formReplyButton(onReply, repliesDisabledMsg, replyButtonText);
   const readReceiptsTooltip =
-    readBy?.length > 0 ? formReadReceiptsTooltip(readBy, recipientType) : null;
+    readBy?.length > 0 ? formReadReceiptsTooltip(onReadReceiptsHover, readBy, recipientType) : null;
 
   return (
     <FlexBox
@@ -135,6 +137,7 @@ function formReplyButton(
 }
 
 function formReadReceiptsTooltip(
+  onReadReceiptsHover: () => void,
   readBy: string[],
   recipientType: "student" | "guardian",
 ): JSX.Element {
@@ -144,20 +147,22 @@ function formReadReceiptsTooltip(
   const recipientString = readBy.length === 1 ? displayRecipientType : `${displayRecipientType}s`;
   return (
     <FlexBox className={cssClass("readReceipts--container")} alignItems="center" justify="end">
-      <Tooltip
-        className={cssClass("readReceipts--tooltip")}
-        content={readReceiptString}
-        placement={"top"}
-        textAlign={"left"}
-      >
-        <FlexBox>
-          <Checkmark className={cssClass("readReceipts--icon")} />
-          <span className={cssClass("readReceipts--text--desktop")}>
-            Read by {readReceiptCount} {recipientString}
-          </span>
-          <span className={cssClass("readReceipts--text--mobile")}>{readReceiptCount}</span>
-        </FlexBox>
-      </Tooltip>
+      <div onMouseOver={onReadReceiptsHover}>
+        <Tooltip
+          className={cssClass("readReceipts--tooltip")}
+          content={readReceiptString}
+          placement={"top"}
+          textAlign={"left"}
+        >
+          <FlexBox>
+            <Checkmark className={cssClass("readReceipts--icon")} />
+            <span className={cssClass("readReceipts--text--desktop")}>
+              Read by {readReceiptCount} {recipientString}
+            </span>
+            <span className={cssClass("readReceipts--text--mobile")}>{readReceiptCount}</span>
+          </FlexBox>
+        </Tooltip>
+      </div>
     </FlexBox>
   );
 }


### PR DESCRIPTION
# Jira: [M5G-690](https://clever.atlassian.net/browse/M5G-690)

# Overview:

With the release of M1, we wanted to implement a Segment analytics counter that keeps track of how often a teacher hovers over the tooltip to check read receipts. More info on analytics for RR can be found [here](https://docs.google.com/document/d/1yM_CsSdI0IfUz78INVpYySItH-xhdzOqw34p67IHCSQ/edit?usp=sharing). To do this, we pass in a new `onReadReceiptsHover` prop to the `AnnouncementBubble` component as a function type in order to pass in analytics function from LP. We do this because we cannot import segment in the components repo, so we pass it in through a prop to AnnouncementBubble, as we can only access the hover state within the component itself. We will implement more analytics with the new features that we add in when rolling out M2 in the future. 

With the opportunity of this PR, we also fix some css styling for RR with one element, as we wanted to make the RR more left-aligned, but the padding was too thin upon rollout. Look below for screenshots of new changes.

# Screenshots/GIFs:

![Screen Shot 2021-08-10 at 7 51 03 PM](https://user-images.githubusercontent.com/45299876/128950425-16b230a0-1bd2-4d25-9fc6-c7fe24ae8987.png)
![Screen Shot 2021-08-10 at 7 50 49 PM](https://user-images.githubusercontent.com/45299876/128950429-41245532-7b92-49d2-b7ab-3345171b5c54.png)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
