### PR TITLE
[a11y] [TextInput] Support additional keyboard event handler props

### DIFF
--- a/docs/components/TextInputView.jsx
+++ b/docs/components/TextInputView.jsx
@@ -208,9 +208,21 @@ export default class TextInputView extends Component {
               optional: true,
             },
             {
+              name: "onKeyDown",
+              type: "Function",
+              description: "Function called upon keydown in the element",
+              optional: true,
+            },
+            {
               name: "onKeyPress",
               type: "Function",
               description: "Called when a key is pressed",
+              optional: true,
+            },
+            {
+              name: "onKeyUp",
+              type: "Function",
+              description: "Function called upon keyup in the element",
               optional: true,
             },
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.153.1",
+  "version": "2.154.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -22,7 +22,9 @@ export interface Props {
   label?: string;
   name: string;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
   onKeyPress?: React.KeyboardEventHandler<HTMLInputElement>;
+  onKeyUp?: React.KeyboardEventHandler<HTMLInputElement>;
   onFocus?: React.FocusEventHandler<HTMLInputElement>;
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
   optional?: boolean;
@@ -55,7 +57,9 @@ const propTypes = {
   label: PropTypes.string,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
+  onKeyDown: PropTypes.func,
   onKeyPress: PropTypes.func,
+  onKeyUp: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
   optional: PropTypes.bool,
@@ -242,7 +246,9 @@ export class TextInput extends React.Component<Props, State> {
           name={this.props.name}
           onBlur={this.onBlur}
           onChange={this.props.onChange}
+          onKeyDown={this.props.onKeyDown}
           onKeyPress={this.props.onKeyPress}
+          onKeyUp={this.props.onKeyUp}
           onFocus={this.onFocus}
           placeholder={this.props.placeholder}
           readOnly={this.props.readOnly}


### PR DESCRIPTION
# Jira:
https://clever.atlassian.net/browse/prtl-647

# Overview:
Let's have `TextInput` support `onKeyDown` and `onKeyUp` event handlers just as
`TextArea` does https://github.com/Clever/components/blob/ae5c29e6bdcb342c4cee407ba40b381104bc6e38/src/TextArea/TextArea.tsx#L25-L27
I'm going to try and use one of these new props as part of an accessibility fix.

# Screenshots/GIFs:

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
