### PR TITLE
remove hover state from translation bubble msg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.153.1",
+  "version": "2.154.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -187,18 +187,6 @@ button.NormalAnnouncementBubble--deleteMenuItem {
 .NormalAnnouncementBubble--translatedLanguages--container {
   .margin--top--m();
   .flex--direction--row();
-
-  &:hover .NormalAnnouncementBubble--translatedLanguages--icon {
-    .pathColor(@primary_blue_shade_2);
-  }
-
-  &:hover .NormalAnnouncementBubble--translatedLanguages--text--desktop {
-    color: @primary_blue_shade_2;
-  }
-
-  &:hover .NormalAnnouncementBubble--translatedLanguages--text--mobile {
-    color: @primary_blue_shade_2;
-  }
 }
 
 .NormalAnnouncementBubble--readReceipts--tooltip {


### PR DESCRIPTION
# Overview:
Removing the hover state from the `translated into x languages` tooltip since it's not a clickable element. Double checking with folks to make sure this is the only tweak we want to include here.


# Screenshots/GIFs:
before
<img width="576" alt="Screen Shot 2021-08-17 at 12 05 50 PM" src="https://user-images.githubusercontent.com/29630673/129788995-f56369f6-9721-471f-a978-fcdaeaa09db4.png">

after
<img width="589" alt="Screen Shot 2021-08-17 at 12 05 04 PM" src="https://user-images.githubusercontent.com/29630673/129788988-6d557c36-6bc3-4d15-b14e-e05e12f3988b.png">


# Testing:

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
