### PR TITLE
[M5G-700] Show a11y outlines on tab only, not click

### DIFF
--- a/docs/components/ButtonView.jsx
+++ b/docs/components/ButtonView.jsx
@@ -41,8 +41,14 @@ export default function ButtonView() {
           <Button type="linkPlain" href="http://google.com" value="Plain Link" />
         </ExampleCode>
         <p>
-          Here is a{" "}
-          <Button type="linkPlain" href="//google.com" value="underlined plain link" underlined />{" "}
+          <br />
+          Here is an{" "}
+          <Button
+            type="linkPlain"
+            href="//google.com"
+            value="underlined plain link"
+            underlined
+          />{" "}
           with no margin/padding.
           <br />
           Better suited for inline links than the regular{" "}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.155.0",
+  "version": "2.156.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -136,6 +136,15 @@ button.NormalAnnouncementBubble--deleteMenuItem {
     background-color: #fed559;
     .boxShadow--heavy();
   }
+
+  &:focus {
+    outline: 0.1875rem solid @primary_blue_shade_2;
+    transition: none;
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: 0;
+  }
 }
 
 .NormalAnnouncementBubble--replyButton--icon {

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -169,8 +169,12 @@ button {
     }
 
     &:focus {
-      outline: @borderRadiusM solid @accent_purple_shade_2;
+      outline: @borderRadiusM solid @primary_blue_shade_2;
       transition: none;
+    }
+
+    &:focus:not(:focus-visible) {
+      outline: 0;
     }
   }
 

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -140,6 +140,15 @@ button {
       color: @primary_blue_shade_3;
       background-color: fade(@primary_blue, 5%);
     }
+
+    &:focus {
+      outline: 0.1875rem solid @primary_blue_shade_2;
+      transition: none;
+    }
+
+    &:focus:not(:focus-visible) {
+      outline: 0;
+    }
   }
 
   &.Button--small {

--- a/src/MessagingThreadHistory/MessagingThreadHistory.less
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.less
@@ -5,7 +5,11 @@
   .padding--right--s();
 
   &:focus {
-    outline: 0.1875rem solid @primary_blue_tint_1;
+    outline: 0.1875rem solid @primary_blue_shade_2;
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: 0;
   }
 }
 


### PR DESCRIPTION
# Jira: 
https://clever.atlassian.net/browse/M5G-700
https://clever.atlassian.net/browse/PRTL-730
https://clever.atlassian.net/browse/PRTL-731

# Overview:
This PR hides a11y outlines on click so we only show them on tab. Also changes the outline color to be `@primary_blue_shade_2` for all these outlines. 

source: https://css-tricks.com/the-focus-visible-trick/

# Screenshots/GIFs:


https://user-images.githubusercontent.com/35714960/129939180-08cd5c19-d883-4392-93ba-9c9fd0965eb8.mov


https://user-images.githubusercontent.com/35714960/129939183-81b5923f-9fe3-4a9b-9143-020122266e62.mov


https://user-images.githubusercontent.com/35714960/129939185-9dae7bb7-dcbb-49e5-943a-de0cabd19cc9.mov



# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
