### PR TITLE
Add cursor when hovering read receipts; improve accessibility of read receipts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.156.2",
+  "version": "2.156.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -183,10 +183,22 @@ button.NormalAnnouncementBubble--deleteMenuItem {
 }
 
 .NormalAnnouncementBubble--readReceipts--tooltip {
+  cursor: pointer;
   .text--semi-bold();
   padding-right: @size_2xs;
   padding-left: @size_2xs;
   white-space: pre-wrap;
+}
+
+.Button.NormalAnnouncementBubble--readReceipts--button {
+  &:focus {
+    outline: 0.1875rem solid @primary_blue_shade_2;
+    transition: none;
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: 0;
+  }
 }
 
 .NormalAnnouncementBubble--readReceipts--icon {

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -163,15 +163,19 @@ function formReadReceiptsTooltip(
         placement={"top"}
         textAlign={"left"}
       >
-        <div onMouseEnter={onReadReceiptsHover}>
-          <FlexBox role="button" tabIndex={0} onClick={onReadReceiptsClick}>
+        <Button
+          className={cssClass("readReceipts--button")}
+          onClick={onReadReceiptsClick}
+          type="plain"
+        >
+          <div onMouseEnter={onReadReceiptsHover}>
             <Checkmark className={cssClass("readReceipts--icon")} />
             <span className={cssClass("readReceipts--text--desktop")}>
               Read by {readReceiptCount} {recipientString}
             </span>
             <span className={cssClass("readReceipts--text--mobile")}>{readReceiptCount}</span>
-          </FlexBox>
-        </div>
+          </div>
+        </Button>
       </Tooltip>
     </FlexBox>
   );


### PR DESCRIPTION

# Overview:

This PR fixes a few read receipt bug bash issues:
1. changes the hover state to the cursor 
2. changes it so when tabbing through, the read receipts is focused once instead of twice
3. makes it so the onClick fires when pressing enter with a keyboard

# Screenshots/GIFs:


https://user-images.githubusercontent.com/26425483/130156396-05a58ee1-da2d-4cce-8c39-875803165b0e.mov



# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
