### PR TITLE
Dm deletion initial pass

### DIFF
--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -228,6 +228,8 @@ export default class AnnouncementBubbleView extends React.PureComponent {
             </AnnouncementBubble>
           </ExampleCode>
         </Example>
+        {this._renderProps("normal")}
+
         <Example title="QuotedAnnouncementBubble">
           <ExampleCode>
             <AnnouncementBubble
@@ -299,6 +301,8 @@ export default class AnnouncementBubbleView extends React.PureComponent {
           </ExampleCode>
           {this._renderConfig()}
         </Example>
+        {this._renderProps("quoted")}
+
         <Example title="DeletedAnnouncementBubble">
           <ExampleCode>
             <AnnouncementBubble
@@ -309,7 +313,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
             />
           </ExampleCode>
         </Example>
-        {this._renderProps()}
+        {this._renderProps("deleted")}
       </View>
     );
   }
@@ -336,35 +340,272 @@ export default class AnnouncementBubbleView extends React.PureComponent {
     );
   }
 
-  _renderProps() {
-    return (
-      <PropDocumentation
-        title="<AnnouncementBubble />"
-        availableProps={[
-          {
-            name: "bubbleType",
-            // eslint-disable-next-line quotes
-            type: `"normal" | "quoted" | "deleted"`,
-            description: "Bubble type to use for styling the bubble.",
-          },
-          {
-            name: "deletionNoticeText",
-            // eslint-disable-next-line quotes
-            type: "string",
-            description: "Text content of the bubble.",
-          },
-          {
-            name: "theme",
-            // eslint-disable-next-line quotes
-            type: `"default" | "familyPortal"`,
-            description:
-              "Theme to use for styling the bubble, based on the product context, e.g. Student, Teacher, or Family Portal",
-            optional: true,
-            default: "default",
-          },
-        ]}
-        className={cssClass.PROPS}
-      />
-    );
+  _renderProps(bubbleType) {
+    if (bubbleType === "normal") {
+      return (
+        <PropDocumentation
+          title="<AnnouncementBubble />"
+          availableProps={[
+            {
+              name: "bubbleType",
+              type: "normal",
+              description:
+                "Bubble type to determine which version of the component we render, incl. required props.",
+            },
+            {
+              name: "attachments",
+              type: "React.ReactNode[]",
+              description: "Optional list of ReactNodes to render as sent attachments.",
+              optional: true,
+            },
+            {
+              name: "children",
+              type: "React.ReactNode",
+              description: "ReactNode to render as the content of the NormalAnnouncementBubble.",
+            },
+            {
+              name: "className",
+              type: "string",
+              description: "Optional additional CSS class name to apply to the container.",
+              optional: true,
+            },
+            {
+              name: "inlineErrorMsg",
+              type: "string",
+              description: "Optional error message to be show inline.",
+              optional: true,
+            },
+            {
+              name: "numTranslatedLanguages",
+              type: "number",
+              description:
+                "Optional number of languages that the message has been translated into.",
+              optional: true,
+            },
+            {
+              name: "onDelete",
+              type: "() => void",
+              description: "Optional handler upon trigger of announcement deletion.",
+              optional: true,
+            },
+            {
+              name: "onReadReceiptsClick",
+              type: "() => void",
+              description: "Optional handler upon trigger of read receipts view.",
+              optional: true,
+            },
+            {
+              name: "onReadReceiptsHover",
+              type: "() => void",
+              description: "Optional handler upon hover of read receipts affordance.",
+              optional: true,
+            },
+            {
+              name: "onReply",
+              type: "() => void",
+              description: "Optional handler upon trigger of announcement reply via Reply button.",
+              optional: true,
+            },
+            {
+              name: "readBy",
+              type: "string[]",
+              description: "Optional list of users who have read the given announcement.",
+              optional: true,
+            },
+            {
+              name: "recipientType",
+              // eslint-disable-next-line quotes
+              type: `"student" | "guardian"`,
+              description: "Recipient type for this announcement.",
+            },
+            {
+              name: "repliesDisabledMsg",
+              type: "string",
+              description: "Optional message to show when replies are disabled.",
+              optional: true,
+            },
+            {
+              name: "senderIcon",
+              type: "React.ReactNode",
+              description: "Icon denoting who the announcement sender is.",
+            },
+            {
+              name: "senderName",
+              type: "string",
+              description: "String denoting who the announcement sender is.",
+            },
+            {
+              name: "sentAtTimestamp",
+              type: "string",
+              description: "Timestamp, passed in to denote the announcement send time.",
+            },
+            {
+              name: "theme",
+              // eslint-disable-next-line quotes
+              type: `MessagingTheme = "default" | "familyPortal"`,
+              description: "Theme to use for styling the bubble.",
+              optional: true,
+              defaultValue: "default",
+            },
+          ]}
+          className={cssClass.PROPS}
+        />
+      );
+    }
+
+    if (bubbleType === "quoted") {
+      return (
+        <PropDocumentation
+          title="<AnnouncementBubble />"
+          availableProps={[
+            {
+              name: "bubbleType",
+              type: "quoted",
+              description:
+                "Bubble type to determine which version of the component we render, incl. required props.",
+            },
+            {
+              name: "announcementGroupName",
+              type: "string",
+              description:
+                "String denoting the name of the group which the announcement was sent to.",
+            },
+            {
+              name: "attachments",
+              type: "React.ReactNode[]",
+              description: "Optional list of ReactNodes to render as sent attachments.",
+              optional: true,
+            },
+            {
+              name: "children",
+              type: "React.ReactNode",
+              description: "ReactNode to render as the content of the NormalAnnouncementBubble.",
+            },
+            {
+              name: "className",
+              type: "string",
+              description: "Optional additional CSS class name to apply to the container.",
+              optional: true,
+            },
+            {
+              name: "colorTheme",
+              // eslint-disable-next-line quotes
+              type: `"white" | "light" | "dark"`,
+              description: "Color theme to use for styling the bubble's color.",
+            },
+            {
+              name: "inlineErrorMsg",
+              type: "string",
+              description: "Optional error message to be show inline.",
+              optional: true,
+            },
+            {
+              name: "isMessageTruncated",
+              type: "boolean",
+              description: "Optional bool for whether the message has been truncated or not.",
+              optional: true,
+            },
+            {
+              name: "onToggleShow",
+              type: "() => void",
+              description: "Optional handler upon trigger of toggling Show More/Less.",
+              optional: true,
+            },
+            {
+              name: "senderIcon",
+              type: "React.ReactNode",
+              description: "Icon denoting who the announcement sender is.",
+            },
+            {
+              name: "senderName",
+              type: "string",
+              description: "String denoting who the announcement sender is.",
+            },
+            {
+              name: "sentAtTimestamp",
+              type: "string",
+              description: "Timestamp, passed in to denote the announcement send time.",
+            },
+            {
+              name: "theme",
+              // eslint-disable-next-line quotes
+              type: `MessagingTheme = "default" | "familyPortal"`,
+              description: "Theme to use for styling the bubble.",
+              optional: true,
+              defaultValue: "default",
+            },
+            {
+              name: "postedInText",
+              type: "string",
+              description: "Optional text for which group the announcement was posted in.",
+              optional: true,
+            },
+            {
+              name: "showLessButtonText",
+              type: "string",
+              description: "Optional text for the Show Less button.",
+              optional: true,
+            },
+            {
+              name: "showMoreButtonText",
+              type: "string",
+              description: "Optional text for the Show More button.",
+              optional: true,
+            },
+            {
+              name: "truncationNoticeText",
+              type: "string",
+              description: "Optional text for the truncation notice.",
+              optional: true,
+            },
+            {
+              name: "truncationTooltipText",
+              type: "string",
+              description: "Optional text for the truncation tooltip.",
+              optional: true,
+            },
+          ]}
+          className={cssClass.PROPS}
+        />
+      );
+    }
+
+    if (bubbleType === "deleted") {
+      return (
+        <PropDocumentation
+          title="<AnnouncementBubble />"
+          availableProps={[
+            {
+              name: "bubbleType",
+              type: "deleted",
+              description:
+                "Bubble type to determine which version of the component we render, incl. required props.",
+            },
+            {
+              name: "className",
+              type: "string",
+              description: "Optional additional CSS class name to apply to the container.",
+              optional: true,
+            },
+            {
+              name: "theme",
+              // eslint-disable-next-line quotes
+              type: `MessagingTheme = "default" | "familyPortal"`,
+              description: "Theme to use for styling the bubble.",
+              optional: true,
+              defaultValue: "default",
+            },
+            {
+              name: "deletionNoticeText",
+              type: "string",
+              description: "The text displayed in the DeletedMessagingBubble.",
+            },
+          ]}
+          className={cssClass.PROPS}
+        />
+      );
+    }
+
+    return null;
   }
 }

--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -301,7 +301,12 @@ export default class AnnouncementBubbleView extends React.PureComponent {
         </Example>
         <Example title="DeletedAnnouncementBubble">
           <ExampleCode>
-            <AnnouncementBubble className={cssClass.BUBBLE} bubbleType="deleted" theme={theme} />
+            <AnnouncementBubble
+              className={cssClass.BUBBLE}
+              bubbleType="deleted"
+              theme={theme}
+              deletionNoticeText="Ms. Yang deleted this announcement."
+            />
           </ExampleCode>
         </Example>
         {this._renderProps()}
@@ -334,13 +339,19 @@ export default class AnnouncementBubbleView extends React.PureComponent {
   _renderProps() {
     return (
       <PropDocumentation
-        title="<AnnouncementBubble /> Props TODO"
+        title="<AnnouncementBubble />"
         availableProps={[
           {
             name: "bubbleType",
             // eslint-disable-next-line quotes
             type: `"normal" | "quoted" | "deleted"`,
             description: "Bubble type to use for styling the bubble.",
+          },
+          {
+            name: "deletionNoticeText",
+            // eslint-disable-next-line quotes
+            type: "string",
+            description: "Text content of the bubble.",
           },
           {
             name: "theme",

--- a/docs/components/AnnouncementBubbleView.jsx
+++ b/docs/components/AnnouncementBubbleView.jsx
@@ -115,6 +115,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
         <Example title="NormalAnnouncementBubble">
           <ExampleCode>
             <AnnouncementBubble
+              bubbleType={"normal"}
               className={cssClass.BUBBLE}
               senderName={"Ms. Stark"}
               senderIcon={
@@ -133,6 +134,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
             </AnnouncementBubble>
 
             <AnnouncementBubble
+              bubbleType={"normal"}
               className={cssClass.BUBBLE}
               readBy={readBy.slice(0)} // copies readBy so it doesn't change in the next bubble
               recipientType={"guardian"}
@@ -151,6 +153,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
             </AnnouncementBubble>
 
             <AnnouncementBubble
+              bubbleType={"normal"}
               className={cssClass.BUBBLE}
               attachments={attachmentsArray}
               numTranslatedLanguages={10}
@@ -165,7 +168,6 @@ export default class AnnouncementBubbleView extends React.PureComponent {
               }
               onReply={() => console.log("Reply!")}
               sentAtTimestamp={new Date()}
-              bubbleType={"normal"}
               theme={theme}
             >
               Announcements like this one can include attachments to open or download
@@ -173,6 +175,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
 
             {/* attachment-only announcement; one attachment*/}
             <AnnouncementBubble
+              bubbleType={"normal"}
               className={cssClass.BUBBLE}
               attachments={attachmentsArray.slice(0, 1)}
               senderName={"Ms. Stark"}
@@ -184,12 +187,12 @@ export default class AnnouncementBubbleView extends React.PureComponent {
               }
               onReply={() => console.log("Attachments-only announcements work too!")}
               sentAtTimestamp={new Date()}
-              bubbleType={"normal"}
               theme={theme}
             />
 
             {/* attachment-only announcement; multiple attachments*/}
             <AnnouncementBubble
+              bubbleType={"normal"}
               className={cssClass.BUBBLE}
               attachments={attachmentsArray}
               senderName={"Ms. Stark"}
@@ -201,12 +204,12 @@ export default class AnnouncementBubbleView extends React.PureComponent {
               }
               onReply={() => console.log("Attachments-only announcements work too!")}
               sentAtTimestamp={new Date()}
-              bubbleType={"normal"}
               theme={theme}
             />
 
             {/* in-line error*/}
             <AnnouncementBubble
+              bubbleType={"normal"}
               className={cssClass.BUBBLE}
               attachments={attachmentsArray}
               senderName={"Ms. Stark"}
@@ -218,7 +221,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
               }
               onReply={() => console.log("Reply!")}
               sentAtTimestamp={new Date()}
-              theme={"normal"}
+              theme={theme}
               inlineErrorMsg={"Something went wrong. We were unable to translate this message."}
             >
               Announcements like this one can include attachments and in-line errors
@@ -276,7 +279,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
             <br />
 
             <AnnouncementBubble
-              theme={"quoted"}
+              bubbleType={"quoted"}
               attachments={attachmentsArray}
               colorTheme={colorTheme}
               announcementGroupName={"Math Rocks!"}
@@ -289,6 +292,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
               }
               sentAtTimestamp={new Date()}
               inlineErrorMsg={"Something went wrong. We were unable to translate this message."}
+              theme={theme}
             >
               This can also have inline errors.
             </AnnouncementBubble>
@@ -297,7 +301,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
         </Example>
         <Example title="DeletedAnnouncementBubble">
           <ExampleCode>
-            <AnnouncementBubble className={cssClass.BUBBLE} theme={"deleted"} />
+            <AnnouncementBubble className={cssClass.BUBBLE} bubbleType="deleted" theme={theme} />
           </ExampleCode>
         </Example>
         {this._renderProps()}
@@ -306,7 +310,7 @@ export default class AnnouncementBubbleView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { colorTheme, theme } = this.state;
+    const { colorTheme } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>

--- a/docs/components/MessagingBubbleView.jsx
+++ b/docs/components/MessagingBubbleView.jsx
@@ -269,6 +269,8 @@ export default class MessagingBubbleView extends React.PureComponent {
           </ExampleCode>
           {this._renderConfig()}
         </Example>
+        {this._renderProps("normal")}
+
         <Example title="DeletedMessagingBubble">
           <ExampleCode>
             <MessagingBubble
@@ -283,8 +285,7 @@ export default class MessagingBubbleView extends React.PureComponent {
           </ExampleCode>
           {this._renderConfig()}
         </Example>
-
-        {this._renderProps()}
+        {this._renderProps("deleted")}
       </View>
     );
   }
@@ -323,51 +324,109 @@ export default class MessagingBubbleView extends React.PureComponent {
     );
   }
 
-  _renderProps() {
-    return (
-      <PropDocumentation
-        title="<MessagingBubble /> Props"
-        availableProps={[
-          {
-            name: "bubbleType",
-            // eslint-disable-next-line quotes
-            type: `"normal" | "deleted"`,
-            description: "Bubble type to use for styling the bubble.",
-          },
-          {
-            name: "messageOwnership",
-            // eslint-disable-next-line quotes
-            type: `"ownMessage" | "otherMessage"`,
-            description: "Message ownership designation to use for styling the bubble.",
-          },
-          {
-            name: "theme",
-            // eslint-disable-next-line quotes
-            type: `MessagingTheme = "default" | "familyPortal"`,
-            description: "Theme to use for styling the bubble",
-            optional: true,
-            default: "default",
-          },
-          {
-            name: "content",
-            type: "React.ReactNode",
-            description: "MessagingBubble content.",
-          },
-          {
-            name: "className",
-            type: "string",
-            description: "Optional additional CSS class name to apply to the container.",
-            optional: true,
-          },
-          {
-            name: "replyTo",
-            type: "React.ReactNode",
-            description: "Optional prop to use for message reply content.",
-            optional: true,
-          },
-        ]}
-        className={cssClass.PROPS}
-      />
-    );
+  _renderProps(bubbleType) {
+    if (bubbleType === "normal") {
+      return (
+        <PropDocumentation
+          title="<NormalMessagingBubble/> Props"
+          availableProps={[
+            {
+              name: "bubbleType",
+              type: "normal",
+              description:
+                "Bubble type to determine which version of the component we render, incl. required props",
+            },
+            {
+              name: "attachments",
+              type: "React.ReactNode[]",
+              description: "Optional list of ReactNodes to render as sent attachments.",
+              optional: true,
+            },
+            {
+              name: "children",
+              type: "React.ReactNode",
+              description: "ReactNode to render as the content of the NormalMessagingBubble.",
+            },
+            {
+              name: "className",
+              type: "string",
+              description: "Optional additional CSS class name to apply to the container.",
+              optional: true,
+            },
+            {
+              name: "messageOwnership",
+              // eslint-disable-next-line quotes
+              type: `"ownMessage" | "otherMessage"`,
+              description: "Message ownership designation to use for styling the bubble.",
+            },
+            {
+              name: "replyTo",
+              type: "React.ReactNode",
+              description: "Optional reply-to announcement, if this DM was an announcement reply.",
+              option: true,
+            },
+            {
+              name: "theme",
+              // eslint-disable-next-line quotes
+              type: `MessagingTheme = "default" | "familyPortal"`,
+              description: "Theme to use for styling the bubble",
+              optional: true,
+              defaultValue: "default",
+            },
+            {
+              name: "timestamp",
+              type: "string",
+              description: "Timestamp, passed in to denote the message send time.",
+            },
+          ]}
+          className={cssClass.PROPS}
+        />
+      );
+    }
+
+    if (bubbleType === "deleted") {
+      return (
+        <PropDocumentation
+          title="<DeletedMessagingBubble/> Props"
+          availableProps={[
+            {
+              name: "bubbleType",
+              type: "deleted",
+              description:
+                "Bubble type to determine which version of the component we render, incl. required props.",
+            },
+            {
+              name: "className",
+              type: "string",
+              description:
+                "Optional additional CSS class name to apply to the message inside the container.",
+              optional: true,
+            },
+            {
+              name: "messageOwnership",
+              // eslint-disable-next-line quotes
+              type: `"ownMessage" | "otherMessage"`,
+              description: "Message ownership designation to use for styling the bubble.",
+            },
+            {
+              name: "theme",
+              // eslint-disable-next-line quotes
+              type: `MessagingTheme = "default" | "familyPortal"`,
+              description: "Theme to use for styling the bubble.",
+              optional: true,
+              defaultValue: "default",
+            },
+            {
+              name: "deletionNoticeText",
+              type: "string",
+              description: "The text displayed in the DeletedMessagingBubble.",
+            },
+          ]}
+          className={cssClass.PROPS}
+        />
+      );
+    }
+
+    return null;
   }
 }

--- a/docs/components/MessagingBubbleView.jsx
+++ b/docs/components/MessagingBubbleView.jsx
@@ -125,7 +125,7 @@ export default class MessagingBubbleView extends React.PureComponent {
           </CodeSample>
         </header>
 
-        <Example title="Basic Usage:">
+        <Example title="NormalMessagingBubble">
           <ExampleCode>
             <MessagingBubble
               bubbleType="normal"
@@ -231,7 +231,7 @@ export default class MessagingBubbleView extends React.PureComponent {
                     theme={theme}
                     deletionNoticeText={`${
                       messageOwnership === "ownMessage" ? "You" : "Ms. Yang"
-                    } deleted this announcement`}
+                    } deleted this announcement.`}
                   />
                 }
               >
@@ -266,6 +266,20 @@ export default class MessagingBubbleView extends React.PureComponent {
                 "This is a reply to the announcement with an attachment"
               </MessagingBubble>
             )}
+          </ExampleCode>
+          {this._renderConfig()}
+        </Example>
+        <Example title="DeletedMessagingBubble">
+          <ExampleCode>
+            <MessagingBubble
+              className={cssClass.BUBBLE}
+              bubbleType="deleted"
+              theme={theme}
+              deletionNoticeText={`${
+                messageOwnership === "ownMessage" ? "You" : "Ms. Yang"
+              } deleted this message.`}
+              messageOwnership={messageOwnership}
+            />
           </ExampleCode>
           {this._renderConfig()}
         </Example>

--- a/docs/components/MessagingBubbleView.jsx
+++ b/docs/components/MessagingBubbleView.jsx
@@ -35,12 +35,13 @@ export default class MessagingBubbleView extends React.PureComponent {
   static cssClass = cssClass;
 
   state = {
+    isDeletableMessageDeleted: false,
     messageOwnership: "ownMessage",
     theme: "default",
   };
 
   render() {
-    const { messageOwnership, theme } = this.state;
+    const { isDeletableMessageDeleted, messageOwnership, theme } = this.state;
 
     const attachmentsArray = [
       {
@@ -143,6 +144,17 @@ export default class MessagingBubbleView extends React.PureComponent {
             >
               Links like https://clever.com are clickable
             </MessagingBubble>
+            {!isDeletableMessageDeleted && (
+              <MessagingBubble
+                bubbleType="normal"
+                messageOwnership={messageOwnership}
+                className={cssClass.BUBBLE}
+                onClickDeleteButton={(value) => this.setState({ isDeletableMessageDeleted: true })}
+                theme={theme}
+              >
+                This message can be deleted! Try hovering/focusing on the timestamp.
+              </MessagingBubble>
+            )}
             {/* hide quoted annoucement replies from the teacher, as this does not exist in familyPortal */}
             {(theme !== "familyPortal" || messageOwnership !== "otherMessage") && (
               <MessagingBubble

--- a/docs/components/MessagingBubbleView.jsx
+++ b/docs/components/MessagingBubbleView.jsx
@@ -35,12 +35,12 @@ export default class MessagingBubbleView extends React.PureComponent {
   static cssClass = cssClass;
 
   state = {
-    bubbleType: "ownMessage",
+    messageOwnership: "ownMessage",
     theme: "default",
   };
 
   render() {
-    const { bubbleType, theme } = this.state;
+    const { messageOwnership, theme } = this.state;
 
     const attachmentsArray = [
       {
@@ -127,16 +127,27 @@ export default class MessagingBubbleView extends React.PureComponent {
 
         <Example title="Basic Usage:">
           <ExampleCode>
-            <MessagingBubble bubbleType={bubbleType} className={cssClass.BUBBLE} theme={theme}>
+            <MessagingBubble
+              bubbleType="normal"
+              messageOwnership={messageOwnership}
+              className={cssClass.BUBBLE}
+              theme={theme}
+            >
               Hello World!
             </MessagingBubble>
-            <MessagingBubble bubbleType={bubbleType} className={cssClass.BUBBLE} theme={theme}>
+            <MessagingBubble
+              bubbleType="normal"
+              messageOwnership={messageOwnership}
+              className={cssClass.BUBBLE}
+              theme={theme}
+            >
               Links like https://clever.com are clickable
             </MessagingBubble>
             {/* hide quoted annoucement replies from the teacher, as this does not exist in familyPortal */}
-            {(theme !== "familyPortal" || bubbleType !== "otherMessage") && (
+            {(theme !== "familyPortal" || messageOwnership !== "otherMessage") && (
               <MessagingBubble
-                bubbleType={bubbleType}
+                bubbleType="normal"
+                messageOwnership={messageOwnership}
                 className={cssClass.BUBBLE}
                 theme={theme}
                 replyTo={
@@ -160,7 +171,8 @@ export default class MessagingBubbleView extends React.PureComponent {
               </MessagingBubble>
             )}
             <MessagingBubble
-              bubbleType={bubbleType}
+              bubbleType="normal"
+              messageOwnership={messageOwnership}
               className={cssClass.BUBBLE}
               theme={theme}
               attachments={attachmentsArray.slice(0, 3)}
@@ -168,21 +180,24 @@ export default class MessagingBubbleView extends React.PureComponent {
               Check out these attachments!
             </MessagingBubble>
             <MessagingBubble
-              bubbleType={bubbleType}
+              bubbleType="normal"
+              messageOwnership={messageOwnership}
               className={cssClass.BUBBLE}
               theme={theme}
               attachments={attachmentsArray.slice(3)}
             />
             <MessagingBubble
-              bubbleType={bubbleType}
+              bubbleType="normal"
+              messageOwnership={messageOwnership}
               className={cssClass.BUBBLE}
               theme={theme}
               attachments={attachmentsArray.slice(4)}
             />
             {/* hide quoted annoucement replies from the teacher, as this does not exist in familyPortal */}
-            {(theme !== "familyPortal" || bubbleType !== "otherMessage") && (
+            {(theme !== "familyPortal" || messageOwnership !== "otherMessage") && (
               <MessagingBubble
-                bubbleType={bubbleType}
+                bubbleType="normal"
+                messageOwnership={messageOwnership}
                 className={cssClass.BUBBLE}
                 theme={theme}
                 attachments={attachmentsArray.slice(3)}
@@ -204,20 +219,30 @@ export default class MessagingBubbleView extends React.PureComponent {
                 }
               />
             )}
-            {(theme !== "familyPortal" || bubbleType !== "otherMessage") && (
+            {(theme !== "familyPortal" || messageOwnership !== "otherMessage") && (
               <MessagingBubble
-                bubbleType={bubbleType}
+                bubbleType="normal"
+                messageOwnership={messageOwnership}
                 className={cssClass.BUBBLE}
                 theme={theme}
-                replyTo={<AnnouncementBubble bubbleType={"deleted"} theme={theme} />}
+                replyTo={
+                  <AnnouncementBubble
+                    bubbleType={"deleted"}
+                    theme={theme}
+                    deletionNoticeText={`${
+                      messageOwnership === "ownMessage" ? "You" : "Ms. Yang"
+                    } deleted this announcement`}
+                  />
+                }
               >
                 This is a reply to a deleted announcement. This state doesn't currently exist in the
                 product
               </MessagingBubble>
             )}
-            {(theme !== "familyPortal" || bubbleType !== "otherMessage") && (
+            {(theme !== "familyPortal" || messageOwnership !== "otherMessage") && (
               <MessagingBubble
-                bubbleType={bubbleType}
+                bubbleType="normal"
+                messageOwnership={messageOwnership}
                 className={cssClass.BUBBLE}
                 theme={theme}
                 replyTo={
@@ -251,7 +276,7 @@ export default class MessagingBubbleView extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { theme, bubbleType } = this.state;
+    const { theme, messageOwnership } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -259,12 +284,12 @@ export default class MessagingBubbleView extends React.PureComponent {
           Bubble Type:
           <SegmentedControl
             className={cssClass.CONFIG_OPTIONS}
-            onSelect={(value) => this.setState({ bubbleType: value })}
+            onSelect={(value) => this.setState({ messageOwnership: value })}
             options={[
               { content: "Own Message", value: "ownMessage" },
               { content: "Other Message", value: "otherMessage" },
             ]}
-            value={bubbleType}
+            value={messageOwnership}
           />
         </div>
 
@@ -292,8 +317,14 @@ export default class MessagingBubbleView extends React.PureComponent {
           {
             name: "bubbleType",
             // eslint-disable-next-line quotes
-            type: `"ownMessage" | "otherMessage"`,
+            type: `"normal" | "deleted"`,
             description: "Bubble type to use for styling the bubble.",
+          },
+          {
+            name: "messageOwnership",
+            // eslint-disable-next-line quotes
+            type: `"ownMessage" | "otherMessage"`,
+            description: "Message ownership designation to use for styling the bubble.",
           },
           {
             name: "theme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.159.0",
+  "version": "2.160.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/DeletedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/DeletedAnnouncementBubble.less
@@ -19,7 +19,7 @@
 }
 
 // Family Portal styling
-.MessagingBubble--FamilyPortal {
+.NormalMessagingBubble--FamilyPortal {
   .DeletedAnnouncementBubble--container {
     background-color: @family_portal_quoted_announcement;
     color: @family_portal_slate;

--- a/src/AnnouncementBubble/DeletedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/DeletedAnnouncementBubble.less
@@ -8,7 +8,7 @@
 }
 
 .DeletedAnnouncementBubble--icon {
-  margin: 1.125rem 1rem 1.375rem;
+  margin: 1.25rem 0.75rem 1.25rem 1.25rem;
   .text--large();
 }
 

--- a/src/AnnouncementBubble/DeletedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/DeletedAnnouncementBubble.less
@@ -8,12 +8,12 @@
 }
 
 .DeletedAnnouncementBubble--icon {
-  margin: 1.25rem 0.75rem 1.25rem 1.25rem;
+  margin: 1.25rem @size_s 1.25rem 1.25rem;
   .text--large();
 }
 
 .DeletedAnnouncementBubble--text {
-  margin: 1rem 1rem 1rem 0;
+  margin: @size_m @size_m @size_m @size_none;
   .text--line-height-4();
   .text--medium();
 }
@@ -29,7 +29,7 @@
   .DeletedAnnouncementBubble--text {
     .text--smallMedium();
     line-height: @size_m;
-    margin: @size_s 1.3125rem @size_s 0;
+    margin: @size_s 1.3125rem @size_s @size_none;
   }
 
   .DeletedAnnouncementBubble--icon {
@@ -39,12 +39,12 @@
 
 @media only screen and (max-width: @breakpointM) {
   .DeletedAnnouncementBubble--icon {
-    margin: 0.75rem 0.5rem 0.75rem 0.75rem;
+    margin: @size_s @size_xs @size_s @size_s;
     .text--large();
   }
 
   .DeletedAnnouncementBubble--text {
-    margin: 0.75rem 0.75rem 0.75rem 0;
+    margin: @size_s @size_s @size_s @size_none;
     .text--line-height-4();
     .text--medium();
   }

--- a/src/AnnouncementBubble/DeletedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/DeletedAnnouncementBubble.less
@@ -39,7 +39,7 @@
 
 @media only screen and (max-width: @breakpointM) {
   .DeletedAnnouncementBubble--icon {
-    margin: 0.625rem 0.5rem 0.875rem 0.75rem;
+    margin: 0.75rem 0.5rem 0.75rem 0.75rem;
     .text--large();
   }
 

--- a/src/AnnouncementBubble/DeletedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/DeletedAnnouncementBubble.tsx
@@ -12,8 +12,9 @@ function cssClass(element: string) {
 
 export interface Props {
   bubbleType: "deleted";
-  theme?: MessagingTheme;
+
   className?: string;
+  theme?: MessagingTheme;
 
   // Temporary props to allow overriding text with translations
   deletionNoticeText: string;

--- a/src/AnnouncementBubble/DeletedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/DeletedAnnouncementBubble.tsx
@@ -16,7 +16,7 @@ export interface Props {
   className?: string;
 
   // Temporary props to allow overriding text with translations
-  deletionNoticeText?: string;
+  deletionNoticeText: string;
 }
 
 export const DeletedAnnouncementBubble: React.FC<Props> = ({
@@ -31,9 +31,7 @@ export const DeletedAnnouncementBubble: React.FC<Props> = ({
       className={cx(cssClass("container"), className)}
     >
       <FontAwesome name="trash-o" className={cssClass("icon")} aria-hidden="true" />
-      <div className={cssClass("text")}>
-        {deletionNoticeText || "This announcement was deleted."}
-      </div>
+      <div className={cssClass("text")}>{deletionNoticeText}</div>
     </FlexBox>
   );
 };

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -16,6 +16,7 @@ function cssClass(element: string) {
 
 export interface Props {
   bubbleType: "normal";
+
   attachments?: React.ReactNode[];
   children: React.ReactNode;
   className?: string;

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.less
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.less
@@ -116,7 +116,7 @@
   .margin--top--xs();
 }
 
-.MessagingBubble--Message
+.NormalMessagingBubble--Message
   .QuotedAnnouncementBubble--attachmentContainer
   .MessagingAttachment--Container {
   width: 14rem;
@@ -198,7 +198,7 @@
 
 // These styles only apply to Announcement replies sent by the current user, in the Family Portal,
 // i.e. guardians replying to teacher announcements
-.MessagingBubble--Message--Reply--Own
+.NormalMessagingBubble--Message--Reply--Own
   .QuotedAnnouncementBubble--container.QuotedAnnouncementBubble--FamilyPortal {
   background-color: @family_portal_quoted_announcement;
   border-radius: @size_s;
@@ -230,7 +230,7 @@
 
   .QuotedAnnouncementBubble--attachmentContainer,
   .QuotedAnnouncementBubble--attachmentContainer > .MessagingAttachment--ParentContainer,
-  .MessagingBubble--Message
+  .NormalMessagingBubble--Message
     .QuotedAnnouncementBubble--attachmentContainer
     .MessagingAttachment--Container {
     width: 100%;

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -24,10 +24,10 @@ export interface Props {
   colorTheme: "white" | "light" | "dark";
   inlineErrorMsg?: string;
   isMessageTruncated?: boolean;
+  onToggleShow?: () => void;
   senderIcon: React.ReactNode;
   senderName: string;
   sentAtTimestamp: Date;
-  onToggleShow?: () => void;
   theme?: MessagingTheme;
 
   // Temporary props to allow overriding text with translations
@@ -71,7 +71,7 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
     const firstLineBreak = content.indexOf("\n");
 
     /* If we have a line break and the first line of text is shorter than the preview length,
-    pad the first line up until the longest line in the expanded view so the width of the bubble 
+    pad the first line up until the longest line in the expanded view so the width of the bubble
     is the same when expanded and when not. */
     if (firstLineBreak > -1 && firstLineBreak < previewLength - 1) {
       let allLines = content.split("\n");

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -25,12 +25,12 @@
   box-sizing: content-box;
 }
 
-.MessagingBubble--Message .MessagingAttachment--Container {
+.NormalMessagingBubble--Message .MessagingAttachment--Container {
   .margin--top--3xs();
   width: 22.5rem;
 }
 
-.MessagingBubble--Message .MessagingAttachment--ParentContainer {
+.NormalMessagingBubble--Message .MessagingAttachment--ParentContainer {
   max-width: 100%;
   margin-right: 0;
 }
@@ -221,7 +221,7 @@
 }
 
 // Attachment-only messages
-.MessagingBubble--HideBubble
+.NormalMessagingBubble--HideBubble
   .MessagingAttachment--ParentContainer.MessagingAttachment--FamilyPortal:first-of-type {
   .margin--top--none();
 }
@@ -271,7 +271,7 @@
     font-size: @type_small_medium; //14px
   }
 
-  .MessagingBubble--Message--Container--Own .MessagingAttachment--Container {
+  .NormalMessagingBubble--Message--Container--Own .MessagingAttachment--Container {
     margin-left: @size_5xl;
     width: calc(100% - 4rem);
     min-width: 13rem;
@@ -279,7 +279,7 @@
     overflow: hidden;
   }
 
-  .MessagingBubble--Message--Container--Other .MessagingAttachment--Container {
+  .NormalMessagingBubble--Message--Container--Other .MessagingAttachment--Container {
     margin-right: @size_5xl;
     width: calc(100% - 4rem);
     min-width: 13rem;
@@ -288,16 +288,16 @@
   }
 
   // ⬇️ In attachment-only messages, we don't want the margins defined above either ⬇️
-  .MessagingBubble--Message--Timestamp--Own
-    + .MessagingBubble--Message--Attachment--Own
+  .NormalMessagingBubble--Message--Timestamp--Own
+    + .NormalMessagingBubble--Message--Attachment--Own
     .MessagingAttachment--Container {
     margin-left: 0;
     margin-right: 0;
     width: 100%;
   }
 
-  .MessagingBubble--Message--Timestamp--Other
-    + .MessagingBubble--Message--Attachment--Other
+  .NormalMessagingBubble--Message--Timestamp--Other
+    + .NormalMessagingBubble--Message--Attachment--Other
     .MessagingAttachment--Container {
     margin-left: 0;
     margin-right: 0;
@@ -305,15 +305,15 @@
   }
 
   // ⬇️ In quoted announcements, we don't want the margins defined above ⬇️
-  .MessagingBubble--Message--Container--Own
-    .MessagingBubble--Message--Own.MessagingBubble--Message--Reply--Parent
+  .NormalMessagingBubble--Message--Container--Own
+    .NormalMessagingBubble--Message--Own.NormalMessagingBubble--Message--Reply--Parent
     .MessagingAttachment--Container {
     margin-left: 0;
     margin-right: 0;
   }
 
-  .MessagingBubble--Message--Container--Other
-    .MessagingBubble--Message--Other.MessagingBubble--Message--Reply--Parent
+  .NormalMessagingBubble--Message--Container--Other
+    .NormalMessagingBubble--Message--Other.NormalMessagingBubble--Message--Reply--Parent
     .MessagingAttachment--Container {
     margin-left: 0;
     margin-right: 0;

--- a/src/MessagingBubble/DeletedMessagingBubble.less
+++ b/src/MessagingBubble/DeletedMessagingBubble.less
@@ -8,16 +8,9 @@
   flex-direction: row;
 }
 
-.DeletedMessagingBubble--Message--ownMessage {
+.DeletedMessagingBubble--Message {
   .border--m(@neutral_silver);
-  max-width: 16.125rem;
-  border-radius: 0.3125rem; // 5px
-  color: @neutral_medium_gray;
-}
-
-.DeletedMessagingBubble--Message--otherMessage {
-  .border--m(@neutral_silver);
-  max-width: 18.4375rem;
+  max-width: 33rem;
   border-radius: 0.3125rem; // 5px
   color: @neutral_medium_gray;
 }
@@ -33,7 +26,7 @@
   .text--medium();
 }
 
-@media only screen and (min-width: @breakpointM) {
+@media only screen and (max-width: @breakpointM) {
   .DeletedMessagingBubble--icon {
     margin: 0.75rem 0.5rem 0.75rem 0.75rem;
     .text--large();

--- a/src/MessagingBubble/DeletedMessagingBubble.less
+++ b/src/MessagingBubble/DeletedMessagingBubble.less
@@ -1,0 +1,47 @@
+@import (reference) "../less/index";
+
+.DeletedMessagingBubble--Container--ownMessage {
+  flex-direction: row-reverse;
+}
+
+.DeletedMessagingBubble--Container--otherMessage {
+  flex-direction: row;
+}
+
+.DeletedMessagingBubble--Message--ownMessage {
+  .border--m(@neutral_silver);
+  max-width: 16.125rem;
+  border-radius: 0.3125rem; // 5px
+  color: @neutral_medium_gray;
+}
+
+.DeletedMessagingBubble--Message--otherMessage {
+  .border--m(@neutral_silver);
+  max-width: 18.4375rem;
+  border-radius: 0.3125rem; // 5px
+  color: @neutral_medium_gray;
+}
+
+.DeletedMessagingBubble--icon {
+  margin: 1.25rem 0.75rem 1.25rem 1.25rem;
+  .text--large();
+}
+
+.DeletedMessagingBubble--text {
+  margin: 1rem 1rem 1rem 0;
+  .text--line-height-4();
+  .text--medium();
+}
+
+@media only screen and (min-width: @breakpointM) {
+  .DeletedMessagingBubble--icon {
+    margin: 0.75rem 0.5rem 0.75rem 0.75rem;
+    .text--large();
+  }
+
+  .DeletedMessagingBubble--text {
+    margin: 0.75rem 0.75rem 0.75rem 0;
+    .text--line-height-4();
+    .text--medium();
+  }
+}

--- a/src/MessagingBubble/DeletedMessagingBubble.less
+++ b/src/MessagingBubble/DeletedMessagingBubble.less
@@ -16,24 +16,24 @@
 }
 
 .DeletedMessagingBubble--icon {
-  margin: 1.25rem 0.75rem 1.25rem 1.25rem;
+  margin: 1.25rem @size_s 1.25rem 1.25rem;
   .text--large();
 }
 
 .DeletedMessagingBubble--text {
-  margin: 1rem 1rem 1rem 0;
+  margin: @size_m @size_m @size_m @size_none;
   .text--line-height-4();
   .text--medium();
 }
 
 @media only screen and (max-width: @breakpointM) {
   .DeletedMessagingBubble--icon {
-    margin: 0.75rem 0.5rem 0.75rem 0.75rem;
+    margin: @size_s @size_xs @size_s @size_s;
     .text--large();
   }
 
   .DeletedMessagingBubble--text {
-    margin: 0.75rem 0.75rem 0.75rem 0;
+    margin: @size_s @size_s @size_s @size_none;
     .text--line-height-4();
     .text--medium();
   }

--- a/src/MessagingBubble/DeletedMessagingBubble.tsx
+++ b/src/MessagingBubble/DeletedMessagingBubble.tsx
@@ -12,9 +12,10 @@ function cssClass(element: string) {
 
 export interface Props {
   bubbleType: "deleted";
-  theme?: MessagingTheme;
+
   className?: string;
   messageOwnership: "ownMessage" | "otherMessage";
+  theme?: MessagingTheme;
 
   // Temporary props to allow overriding text with translations
   deletionNoticeText: string;

--- a/src/MessagingBubble/DeletedMessagingBubble.tsx
+++ b/src/MessagingBubble/DeletedMessagingBubble.tsx
@@ -28,12 +28,7 @@ export const DeletedMessagingBubble: React.FC<Props> = ({
 }: Props) => {
   return (
     <FlexBox className={cssClass(`Container--${messageOwnership}`)}>
-      <FlexBox
-        grow
-        alignItems="center"
-        justify="start"
-        className={cx(cssClass(`Message--${messageOwnership}`), className)}
-      >
+      <FlexBox alignItems="center" justify="start" className={cx(cssClass("Message"), className)}>
         <FontAwesome name="trash-o" className={cssClass("icon")} aria-hidden="true" />
         <div className={cssClass("text")}>{deletionNoticeText}</div>
       </FlexBox>

--- a/src/MessagingBubble/DeletedMessagingBubble.tsx
+++ b/src/MessagingBubble/DeletedMessagingBubble.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import * as cx from "classnames";
+import * as FontAwesome from "react-fontawesome";
+import { FlexBox } from "../";
+import { MessagingTheme } from "src/utils/messaging";
+
+import "./DeletedMessagingBubble.less";
+
+function cssClass(element: string) {
+  return `DeletedMessagingBubble--${element}`;
+}
+
+export interface Props {
+  bubbleType: "deleted";
+  theme?: MessagingTheme;
+  className?: string;
+  messageOwnership: "ownMessage" | "otherMessage";
+
+  // Temporary props to allow overriding text with translations
+  deletionNoticeText: string;
+}
+
+export const DeletedMessagingBubble: React.FC<Props> = ({
+  className,
+  messageOwnership,
+  deletionNoticeText,
+}: Props) => {
+  return (
+    <FlexBox className={cssClass(`Container--${messageOwnership}`)}>
+      <FlexBox
+        grow
+        alignItems="center"
+        justify="start"
+        className={cx(cssClass(`Message--${messageOwnership}`), className)}
+      >
+        <FontAwesome name="trash-o" className={cssClass("icon")} aria-hidden="true" />
+        <div className={cssClass("text")}>{deletionNoticeText}</div>
+      </FlexBox>
+    </FlexBox>
+  );
+};

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -1,16 +1,28 @@
 import * as React from "react";
 
 import {
+  DeletedMessagingBubble,
+  Props as DeletedMessagingBubbleProps,
+} from "./DeletedMessagingBubble";
+import {
   NormalMessagingBubble,
   Props as NormalMessagingBubbleProps,
 } from "./NormalMessagingBubble";
 
-type MessagingBubbleProps = NormalMessagingBubbleProps;
+type MessagingBubbleProps = DeletedMessagingBubbleProps | NormalMessagingBubbleProps;
 
 export const MessagingBubble: React.FC<MessagingBubbleProps> = (props: MessagingBubbleProps) => {
   switch (props.bubbleType) {
     case "deleted": {
-      return null;
+      return (
+        <DeletedMessagingBubble
+          bubbleType="deleted"
+          className={props.className}
+          theme={props.theme}
+          deletionNoticeText={props.deletionNoticeText}
+          messageOwnership={props.messageOwnership}
+        />
+      );
     }
     default: {
       return (

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -34,6 +34,7 @@ export const MessagingBubble: React.FC<MessagingBubbleProps> = (props: Messaging
           replyTo={props.replyTo}
           attachments={props.attachments}
           messageOwnership={props.messageOwnership}
+          onClickDeleteButton={props.onClickDeleteButton}
           theme={props.theme}
         />
       );

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -1,109 +1,30 @@
 import * as React from "react";
-import * as moment from "moment";
-import Linkify from "react-linkify";
-import * as cx from "classnames";
-import FlexBox from "../flex/FlexBox";
-import { MessagingTheme } from "src/utils/messaging";
-import { matchDecorator, componentDecorator } from "./linkifyUtils";
 
-import "./MessagingBubble.less";
+import {
+  NormalMessagingBubble,
+  Props as NormalMessagingBubbleProps,
+} from "./NormalMessagingBubble";
 
-const cssClasses = {
-  MESSAGE_ATTACHMENT_BASE: "MessagingBubble--Message--Attachment",
-  MESSAGE_BASE: "MessagingBubble--Message",
-  MESSAGE_CONTAINER_BASE: "MessagingBubble--Message--Container",
-  MESSAGE_REPLY_BASE: "MessagingBubble--Message--Reply",
-  MESSAGE_REPLY_PARENT: "MessagingBubble--Message--Reply--Parent",
-  MESSAGE_TIMESTAMP_BASE: "MessagingBubble--Message--Timestamp",
-  MESSAGE_TIME_BUBBLE_CONTAINER_BASE: "MessagingBubble--Message--TimestampBubbleContainer",
-  OWN_SUFFIX: "--Own",
-  OTHER_SUFFIX: "--Other",
-  FAMILY_PORTAL: "MessagingBubble--FamilyPortal",
-  HIDE_BUBBLE: "MessagingBubble--HideBubble",
-};
+type MessagingBubbleProps = NormalMessagingBubbleProps;
 
-interface Props {
-  className?: string;
-  children: React.ReactNode;
-  timestamp: Date;
-  replyTo?: React.ReactNode;
-  attachments?: React.ReactNode[];
-  bubbleType: "ownMessage" | "otherMessage";
-  theme?: MessagingTheme;
-}
-
-// Helper function: Format a Date for our pretty timestamps.
-//  Always returns "xx:xx <AM/PM>" format.
-function _formatDateForTimestamp(date: Date): string {
-  return moment(date).format("h:mm A");
-}
-
-export const MessagingBubble: React.FC<Props> = ({
-  className,
-  children,
-  timestamp,
-  theme,
-  bubbleType,
-  replyTo,
-  attachments,
-}: Props) => {
-  const hideBubble = !children && !replyTo; // if message is only attachments, no body and not a reply
-  const isOwnMessage = bubbleType === "ownMessage";
-  const classSuffix = isOwnMessage ? cssClasses.OWN_SUFFIX : cssClasses.OTHER_SUFFIX;
-  const containerClassNames = cx(
-    className,
-    `${cssClasses.MESSAGE_CONTAINER_BASE}${classSuffix}`,
-    theme === "familyPortal" && cssClasses.FAMILY_PORTAL,
-    hideBubble && cssClasses.HIDE_BUBBLE,
-  );
-
-  const bubbleClassNames = cx(
-    cssClasses.MESSAGE_BASE,
-    `${cssClasses.MESSAGE_BASE}${classSuffix}`,
-    replyTo && cssClasses.MESSAGE_REPLY_PARENT,
-  );
-
-  const replyClassNames = cx(
-    cssClasses.MESSAGE_BASE,
-    `${cssClasses.MESSAGE_REPLY_BASE}${classSuffix}`,
-    children && `${cssClasses.MESSAGE_REPLY_BASE}--MarginBottom`,
-  );
-
-  const timeAndBubbleContainerClasses = cx(
-    `${cssClasses.MESSAGE_TIME_BUBBLE_CONTAINER_BASE}${classSuffix}`,
-  );
-
-  const timestampClassNames = cx(
-    cssClasses.MESSAGE_BASE,
-    `${cssClasses.MESSAGE_TIMESTAMP_BASE}${classSuffix}`,
-  );
-
-  const attachmentClassNames = cx(
-    cssClasses.MESSAGE_BASE,
-    `${cssClasses.MESSAGE_ATTACHMENT_BASE}${classSuffix}`,
-  );
-
-  return (
-    <FlexBox column className={containerClassNames}>
-      <FlexBox className={timeAndBubbleContainerClasses}>
-        {!hideBubble && (
-          <span className={timestampClassNames}>{_formatDateForTimestamp(timestamp)}</span>
-        )}
-        <div className={hideBubble ? null : bubbleClassNames}>
-          {replyTo && <div className={replyClassNames}>{replyTo}</div>}
-          <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
-            {children}
-          </Linkify>
-        </div>
-      </FlexBox>
-      <FlexBox className={timeAndBubbleContainerClasses}>
-        {hideBubble && (
-          <span className={timestampClassNames}>{_formatDateForTimestamp(timestamp)}</span>
-        )}
-        {attachments?.length > 0 && (
-          <FlexBox className={attachmentClassNames}>{attachments}</FlexBox>
-        )}
-      </FlexBox>
-    </FlexBox>
-  );
+export const MessagingBubble: React.FC<MessagingBubbleProps> = (props: MessagingBubbleProps) => {
+  switch (props.bubbleType) {
+    case "deleted": {
+      return null;
+    }
+    default: {
+      return (
+        <NormalMessagingBubble
+          bubbleType="normal"
+          className={props.className}
+          children={props.children}
+          timestamp={props.timestamp}
+          replyTo={props.replyTo}
+          attachments={props.attachments}
+          messageOwnership={props.messageOwnership}
+          theme={props.theme}
+        />
+      );
+    }
+  }
 };

--- a/src/MessagingBubble/NormalMessagingBubble.less
+++ b/src/MessagingBubble/NormalMessagingBubble.less
@@ -1,5 +1,7 @@
 @import (reference) "../less/index";
 
+@ERROR_RED: #df3537;
+
 // shared styling across bubble variations
 .NormalMessagingBubble--Message {
   border-radius: 0.3125rem;
@@ -76,6 +78,47 @@
   .items--start();
 }
 
+.NormalMessagingBubble--Message--Metadata--Own {
+  .margin--right--xs();
+}
+
+.NormalMessagingBubble--Message--Metadata--Other {
+  .margin--left--xs();
+}
+
+Button.NormalMessagingBubble--Message--ActionButton--Own {
+  &:hover,
+  &:focus,
+  &:active {
+    .NormalMessagingBubble--Message--Timestamp {
+      display: none;
+    }
+    .NormalMessagingBubble--Message--Delete {
+      display: unset;
+    }
+  }
+}
+
+Button.NormalMessagingBubble--Message--ActionButton--Other {
+  &:hover,
+  &:focus,
+  &:active {
+    .NormalMessagingBubble--Message--Timestamp {
+      display: none;
+    }
+    .NormalMessagingBubble--Message--Delete {
+      display: unset;
+    }
+  }
+}
+
+.NormalMessagingBubble--Message--Delete {
+  display: none;
+  color: @ERROR_RED;
+  .text--semi-bold();
+  line-height: @size_l;
+}
+
 .NormalMessagingBubble--Message--TimestampBubbleContainer--Own {
   flex-direction: row;
   align-items: center;
@@ -88,20 +131,10 @@
   max-width: 100%;
 }
 
-.NormalMessagingBubble--Message--Timestamp--Own {
+.NormalMessagingBubble--Message--Timestamp {
   color: @neutral_medium_gray;
   font-size: 0.875rem;
-  .margin--right--xs();
-  .text--line-height-1();
-  white-space: nowrap;
-  flex-shrink: 0;
-  min-width: 3.5rem;
-}
-
-.NormalMessagingBubble--Message--Timestamp--Other {
-  color: @neutral_medium_gray;
-  font-size: 0.875rem;
-  .margin--left--xs();
+  font-weight: normal;
   .text--line-height-1();
   white-space: nowrap;
   flex-shrink: 0;

--- a/src/MessagingBubble/NormalMessagingBubble.less
+++ b/src/MessagingBubble/NormalMessagingBubble.less
@@ -1,7 +1,7 @@
 @import (reference) "../less/index";
 
 // shared styling across bubble variations
-.MessagingBubble--Message {
+.NormalMessagingBubble--Message {
   border-radius: 0.3125rem;
   font-size: 1rem;
   max-width: 32.5rem;
@@ -12,25 +12,25 @@
   word-wrap: break-word; // IE name for overflow-wrap
 }
 
-.MessagingBubble--Message--Container--Own {
+.NormalMessagingBubble--Message--Container--Own {
   max-width: 100%;
   .items--end();
 }
 
-.MessagingBubble--Message--Container--Other {
+.NormalMessagingBubble--Message--Container--Other {
   max-width: 100%;
   .items--start();
 }
 
-.MessagingBubble--Message--Other {
+.NormalMessagingBubble--Message--Other {
   background-color: #f3f5fd; /* stylelint-disable-line */
   border-radius: 0.3125rem;
   color: @neutral_black;
   .padding--xs();
 }
 
-.MessagingBubble--Message--Container--Other.MessagingBubble--FamilyPortal {
-  .MessagingBubble--Message--Other {
+.NormalMessagingBubble--Message--Container--Other.NormalMessagingBubble--FamilyPortal {
+  .NormalMessagingBubble--Message--Other {
     background-color: @family_portal_slate;
     border-radius: 1rem;
     color: @neutral_white;
@@ -40,55 +40,55 @@
   }
 }
 
-.MessagingBubble--Message--Own {
+.NormalMessagingBubble--Message--Own {
   background-color: @neutral_dark_gray;
   color: @neutral_white;
   .padding--xs();
 }
 
-.MessagingBubble--Message--Reply--Parent {
+.NormalMessagingBubble--Message--Reply--Parent {
   .padding--m();
 }
 
-.MessagingBubble--Message--Reply--Own {
+.NormalMessagingBubble--Message--Reply--Own {
   background-color: #626776; /* stylelint-disable-line */
   border-radius: 0.3125rem;
   color: @neutral_white;
 }
 
-.MessagingBubble--Message--Reply--Other {
+.NormalMessagingBubble--Message--Reply--Other {
   background-color: #fafbfe; /* stylelint-disable-line */
   border-radius: 0.3125rem;
   color: @neutral_black;
 }
 
-.MessagingBubble--Message--Reply--MarginBottom {
+.NormalMessagingBubble--Message--Reply--MarginBottom {
   .margin--bottom--s();
 }
 
-.MessagingBubble--Message--Attachment--Own {
+.NormalMessagingBubble--Message--Attachment--Own {
   .flex--direction--column();
   .items--end();
 }
 
-.MessagingBubble--Message--Attachment--Other {
+.NormalMessagingBubble--Message--Attachment--Other {
   .flex--direction--column();
   .items--start();
 }
 
-.MessagingBubble--Message--TimestampBubbleContainer--Own {
+.NormalMessagingBubble--Message--TimestampBubbleContainer--Own {
   flex-direction: row;
   align-items: center;
   max-width: 100%;
 }
 
-.MessagingBubble--Message--TimestampBubbleContainer--Other {
+.NormalMessagingBubble--Message--TimestampBubbleContainer--Other {
   flex-direction: row-reverse;
   align-items: center;
   max-width: 100%;
 }
 
-.MessagingBubble--Message--Timestamp--Own {
+.NormalMessagingBubble--Message--Timestamp--Own {
   color: @neutral_medium_gray;
   font-size: 0.875rem;
   .margin--right--xs();
@@ -98,7 +98,7 @@
   min-width: 3.5rem;
 }
 
-.MessagingBubble--Message--Timestamp--Other {
+.NormalMessagingBubble--Message--Timestamp--Other {
   color: @neutral_medium_gray;
   font-size: 0.875rem;
   .margin--left--xs();
@@ -109,8 +109,8 @@
 }
 
 // Family Portal styling
-.MessagingBubble--Message--Container--Own.MessagingBubble--FamilyPortal {
-  .MessagingBubble--Message--Own {
+.NormalMessagingBubble--Message--Container--Own.NormalMessagingBubble--FamilyPortal {
+  .NormalMessagingBubble--Message--Own {
     background-color: @family_portal_own_message;
     border-radius: 1rem;
     color: @family_portal_slate;
@@ -119,17 +119,17 @@
     .padding--y--xs();
   }
 
-  .MessagingBubble--Message--Timestamp--Own {
+  .NormalMessagingBubble--Message--Timestamp--Own {
     margin-right: @size_m;
   }
 
-  .MessagingBubble--Message--Reply--Own {
+  .NormalMessagingBubble--Message--Reply--Own {
     background-color: transparent;
     max-width: 33.5rem;
     margin-left: -0.5rem;
     margin-right: -0.5rem;
 
-    &.MessagingBubble--Message--Reply--MarginBottom {
+    &.NormalMessagingBubble--Message--Reply--MarginBottom {
       .margin--bottom--xs();
     }
 
@@ -141,27 +141,27 @@
 
 // For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
-  .MessagingBubble--Message {
+  .NormalMessagingBubble--Message {
     font-size: 0.875rem;
     line-height: 1rem;
     // This improves how long words/links are broken on Chrome mobile and doesn't affect Safari
     overflow-wrap: anywhere;
   }
 
-  .MessagingBubble--Message--Reply--Parent {
+  .NormalMessagingBubble--Message--Reply--Parent {
     .padding--xs();
   }
 
-  .MessagingBubble--Message--Reply--MarginBottom {
+  .NormalMessagingBubble--Message--Reply--MarginBottom {
     .margin--bottom--xs();
   }
 
-  .MessagingBubble--Message--Attachment--Own {
+  .NormalMessagingBubble--Message--Attachment--Own {
     width: auto;
     .text--truncate();
   }
 
-  .MessagingBubble--Message--Attachment--Other {
+  .NormalMessagingBubble--Message--Attachment--Other {
     width: auto;
     .text--truncate();
   }

--- a/src/MessagingBubble/NormalMessagingBubble.less
+++ b/src/MessagingBubble/NormalMessagingBubble.less
@@ -86,6 +86,69 @@
   .margin--left--xs();
 }
 
+.NormalMessagingBubble--Message--Delete {
+  display: none;
+  color: @ERROR_RED;
+  .text--semi-bold();
+  line-height: @size_l;
+}
+
+// This class may be identical in content to the --Timestamp class,
+// but this one is not rendered invisible by bubble-hover behavior.
+.NormalMessagingBubble--Message--Timestamp--NonInteractive {
+  color: @neutral_medium_gray;
+  font-size: 0.875rem;
+  font-weight: normal;
+  .text--line-height-1();
+  white-space: nowrap;
+  flex-shrink: 0;
+  min-width: 3.5rem;
+}
+
+.NormalMessagingBubble--Message--Timestamp {
+  color: @neutral_medium_gray;
+  font-size: 0.875rem;
+  font-weight: normal;
+  .text--line-height-1();
+  white-space: nowrap;
+  flex-shrink: 0;
+  min-width: 3.5rem;
+}
+
+.NormalMessagingBubble--Message--TimestampBubbleContainer--Own {
+  .padding--left--s();
+  flex-direction: row;
+  align-items: center;
+  max-width: 100%;
+
+  &:hover {
+    .NormalMessagingBubble--Message--Timestamp {
+      display: none;
+    }
+
+    .NormalMessagingBubble--Message--Delete {
+      display: unset;
+    }
+  }
+}
+
+.NormalMessagingBubble--Message--TimestampBubbleContainer--Other {
+  .padding--right--s();
+  flex-direction: row-reverse;
+  align-items: center;
+  max-width: 100%;
+
+  &:hover {
+    .NormalMessagingBubble--Message--Timestamp {
+      display: none;
+    }
+
+    .NormalMessagingBubble--Message--Delete {
+      display: unset;
+    }
+  }
+}
+
 Button.NormalMessagingBubble--Message--ActionButton--Own {
   width: 100%;
   text-align: right;
@@ -95,6 +158,7 @@ Button.NormalMessagingBubble--Message--ActionButton--Own {
     .NormalMessagingBubble--Message--Timestamp {
       display: none;
     }
+
     .NormalMessagingBubble--Message--Delete {
       display: unset;
     }
@@ -119,6 +183,7 @@ Button.NormalMessagingBubble--Message--ActionButton--Other {
     .NormalMessagingBubble--Message--Timestamp {
       display: none;
     }
+
     .NormalMessagingBubble--Message--Delete {
       display: unset;
     }
@@ -132,67 +197,6 @@ Button.NormalMessagingBubble--Message--ActionButton--Other {
       color: @alert_red_shade;
     }
   }
-}
-
-.NormalMessagingBubble--Message--Delete {
-  display: none;
-  color: @ERROR_RED;
-  .text--semi-bold();
-  line-height: @size_l;
-}
-
-.NormalMessagingBubble--Message--TimestampBubbleContainer--Own {
-  .padding--left--s();
-  flex-direction: row;
-  align-items: center;
-  max-width: 100%;
-
-  &:hover {
-    .NormalMessagingBubble--Message--Timestamp {
-      display: none;
-    }
-    .NormalMessagingBubble--Message--Delete {
-      display: unset;
-    }
-  }
-}
-
-.NormalMessagingBubble--Message--TimestampBubbleContainer--Other {
-  .padding--right--s();
-  flex-direction: row-reverse;
-  align-items: center;
-  max-width: 100%;
-
-  &:hover {
-    .NormalMessagingBubble--Message--Timestamp {
-      display: none;
-    }
-    .NormalMessagingBubble--Message--Delete {
-      display: unset;
-    }
-  }
-}
-
-// This class may be identical in content to the --Timestamp class,
-// but this one is not rendered invisible by bubble-hover behavior.
-.NormalMessagingBubble--Message--Timestamp--NonInteractive {
-  color: @neutral_medium_gray;
-  font-size: 0.875rem;
-  font-weight: normal;
-  .text--line-height-1();
-  white-space: nowrap;
-  flex-shrink: 0;
-  min-width: 3.5rem;
-}
-
-.NormalMessagingBubble--Message--Timestamp {
-  color: @neutral_medium_gray;
-  font-size: 0.875rem;
-  font-weight: normal;
-  .text--line-height-1();
-  white-space: nowrap;
-  flex-shrink: 0;
-  min-width: 3.5rem;
 }
 
 // Family Portal styling

--- a/src/MessagingBubble/NormalMessagingBubble.less
+++ b/src/MessagingBubble/NormalMessagingBubble.less
@@ -87,7 +87,9 @@
 }
 
 Button.NormalMessagingBubble--Message--ActionButton--Own {
-  &:hover,
+  width: 100%;
+  text-align: right;
+
   &:focus,
   &:active {
     .NormalMessagingBubble--Message--Timestamp {
@@ -97,10 +99,21 @@ Button.NormalMessagingBubble--Message--ActionButton--Own {
       display: unset;
     }
   }
+
+  // The "Delete" el should change colors upon button hover.
+  &:focus,
+  &:active,
+  &:hover {
+    .NormalMessagingBubble--Message--Delete {
+      color: @alert_red_shade;
+    }
+  }
 }
 
 Button.NormalMessagingBubble--Message--ActionButton--Other {
-  &:hover,
+  width: 100%;
+  text-align: left;
+
   &:focus,
   &:active {
     .NormalMessagingBubble--Message--Timestamp {
@@ -108,6 +121,15 @@ Button.NormalMessagingBubble--Message--ActionButton--Other {
     }
     .NormalMessagingBubble--Message--Delete {
       display: unset;
+    }
+  }
+
+  // The "Delete" el should change colors upon button hover.
+  &:focus,
+  &:active,
+  &:hover {
+    .NormalMessagingBubble--Message--Delete {
+      color: @alert_red_shade;
     }
   }
 }
@@ -120,15 +142,47 @@ Button.NormalMessagingBubble--Message--ActionButton--Other {
 }
 
 .NormalMessagingBubble--Message--TimestampBubbleContainer--Own {
+  .padding--left--s();
   flex-direction: row;
   align-items: center;
   max-width: 100%;
+
+  &:hover {
+    .NormalMessagingBubble--Message--Timestamp {
+      display: none;
+    }
+    .NormalMessagingBubble--Message--Delete {
+      display: unset;
+    }
+  }
 }
 
 .NormalMessagingBubble--Message--TimestampBubbleContainer--Other {
+  .padding--right--s();
   flex-direction: row-reverse;
   align-items: center;
   max-width: 100%;
+
+  &:hover {
+    .NormalMessagingBubble--Message--Timestamp {
+      display: none;
+    }
+    .NormalMessagingBubble--Message--Delete {
+      display: unset;
+    }
+  }
+}
+
+// This class may be identical in content to the --Timestamp class,
+// but this one is not rendered invisible by bubble-hover behavior.
+.NormalMessagingBubble--Message--Timestamp--NonInteractive {
+  color: @neutral_medium_gray;
+  font-size: 0.875rem;
+  font-weight: normal;
+  .text--line-height-1();
+  white-space: nowrap;
+  flex-shrink: 0;
+  min-width: 3.5rem;
 }
 
 .NormalMessagingBubble--Message--Timestamp {
@@ -150,10 +204,6 @@ Button.NormalMessagingBubble--Message--ActionButton--Other {
     font-weight: 400;
     .padding--x--m();
     .padding--y--xs();
-  }
-
-  .NormalMessagingBubble--Message--Timestamp--Own {
-    margin-right: @size_m;
   }
 
   .NormalMessagingBubble--Message--Reply--Own {

--- a/src/MessagingBubble/NormalMessagingBubble.less
+++ b/src/MessagingBubble/NormalMessagingBubble.less
@@ -93,21 +93,12 @@
   line-height: @size_l;
 }
 
-// This class may be identical in content to the --Timestamp class,
-// but this one is not rendered invisible by bubble-hover behavior.
-.NormalMessagingBubble--Message--Timestamp--NonInteractive {
-  color: @neutral_medium_gray;
-  font-size: 0.875rem;
-  font-weight: normal;
-  .text--line-height-1();
-  white-space: nowrap;
-  flex-shrink: 0;
-  min-width: 3.5rem;
-}
-
+// --Timestamp--NonInteractive may be identical in content to --Timestamp,
+// but in contrast it's not rendered invisible by bubble-hover behavior.
+.NormalMessagingBubble--Message--Timestamp--NonInteractive,
 .NormalMessagingBubble--Message--Timestamp {
   color: @neutral_medium_gray;
-  font-size: 0.875rem;
+  .text--smallMedium();
   font-weight: normal;
   .text--line-height-1();
   white-space: nowrap;
@@ -229,7 +220,7 @@ Button.NormalMessagingBubble--Message--ActionButton--Other {
 // For mobile/tablet
 @media only screen and (max-width: @breakpointM) {
   .NormalMessagingBubble--Message {
-    font-size: 0.875rem;
+    .text--smallMedium();
     line-height: 1rem;
     // This improves how long words/links are broken on Chrome mobile and doesn't affect Safari
     overflow-wrap: anywhere;

--- a/src/MessagingBubble/NormalMessagingBubble.tsx
+++ b/src/MessagingBubble/NormalMessagingBubble.tsx
@@ -93,13 +93,13 @@ export const NormalMessagingBubble: React.FC<Props> = ({
   return (
     <FlexBox column className={containerClassNames}>
       <FlexBox className={timeAndBubbleContainerClasses}>
-        {_renderMetadata({
-          renderHere: !hideBubble,
-          timestamp,
-          onClickDeleteButton,
-          metadataClassNames,
-          actionButtonClassNames,
-        })}
+        {!hideBubble &&
+          _renderMetadata({
+            timestamp,
+            onClickDeleteButton,
+            metadataClassNames,
+            actionButtonClassNames,
+          })}
         <div className={hideBubble ? null : bubbleClassNames}>
           {replyTo && <div className={replyClassNames}>{replyTo}</div>}
           <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
@@ -108,13 +108,13 @@ export const NormalMessagingBubble: React.FC<Props> = ({
         </div>
       </FlexBox>
       <FlexBox className={timeAndBubbleContainerClasses}>
-        {_renderMetadata({
-          renderHere: hideBubble,
-          timestamp,
-          onClickDeleteButton,
-          metadataClassNames,
-          actionButtonClassNames,
-        })}
+        {hideBubble &&
+          _renderMetadata({
+            timestamp,
+            onClickDeleteButton,
+            metadataClassNames,
+            actionButtonClassNames,
+          })}
         {attachments?.length > 0 && (
           <FlexBox className={attachmentClassNames}>{attachments}</FlexBox>
         )}
@@ -132,22 +132,16 @@ function _formatDateForTimestamp(date: Date): string {
 // Helper function: renders metadata, consisting of either the action button
 //  or a non-interactive timestamp
 function _renderMetadata({
-  renderHere,
   timestamp,
   onClickDeleteButton,
   metadataClassNames,
   actionButtonClassNames,
 }: {
-  renderHere: boolean;
   timestamp: Date;
   onClickDeleteButton: () => void;
   metadataClassNames: string;
   actionButtonClassNames: string;
 }): React.ReactNode {
-  if (!renderHere) {
-    return null;
-  }
-
   if (!onClickDeleteButton) {
     return _renderNonInteractiveTimestamp({
       timestamp,

--- a/src/MessagingBubble/NormalMessagingBubble.tsx
+++ b/src/MessagingBubble/NormalMessagingBubble.tsx
@@ -24,13 +24,14 @@ const cssClasses = {
 
 export interface Props {
   bubbleType: "normal";
-  className?: string;
-  children: React.ReactNode;
-  timestamp: Date;
-  replyTo?: React.ReactNode;
+
   attachments?: React.ReactNode[];
+  children: React.ReactNode;
+  className?: string;
   messageOwnership: "ownMessage" | "otherMessage";
+  replyTo?: React.ReactNode;
   theme?: MessagingTheme;
+  timestamp: Date;
 }
 
 // Helper function: Format a Date for our pretty timestamps.

--- a/src/MessagingBubble/NormalMessagingBubble.tsx
+++ b/src/MessagingBubble/NormalMessagingBubble.tsx
@@ -1,0 +1,110 @@
+import * as React from "react";
+import * as moment from "moment";
+import Linkify from "react-linkify";
+import * as cx from "classnames";
+import FlexBox from "../flex/FlexBox";
+import { MessagingTheme } from "src/utils/messaging";
+import { matchDecorator, componentDecorator } from "./linkifyUtils";
+
+import "./NormalMessagingBubble.less";
+
+const cssClasses = {
+  MESSAGE_ATTACHMENT_BASE: "NormalMessagingBubble--Message--Attachment",
+  MESSAGE_BASE: "NormalMessagingBubble--Message",
+  MESSAGE_CONTAINER_BASE: "NormalMessagingBubble--Message--Container",
+  MESSAGE_REPLY_BASE: "NormalMessagingBubble--Message--Reply",
+  MESSAGE_REPLY_PARENT: "NormalMessagingBubble--Message--Reply--Parent",
+  MESSAGE_TIMESTAMP_BASE: "NormalMessagingBubble--Message--Timestamp",
+  MESSAGE_TIME_BUBBLE_CONTAINER_BASE: "NormalMessagingBubble--Message--TimestampBubbleContainer",
+  OWN_SUFFIX: "--Own",
+  OTHER_SUFFIX: "--Other",
+  FAMILY_PORTAL: "NormalMessagingBubble--FamilyPortal",
+  HIDE_BUBBLE: "NormalMessagingBubble--HideBubble",
+};
+
+export interface Props {
+  bubbleType: "normal" | "deleted";
+  className?: string;
+  children: React.ReactNode;
+  timestamp: Date;
+  replyTo?: React.ReactNode;
+  attachments?: React.ReactNode[];
+  messageOwnership: "ownMessage" | "otherMessage";
+  theme?: MessagingTheme;
+}
+
+// Helper function: Format a Date for our pretty timestamps.
+//  Always returns "xx:xx <AM/PM>" format.
+function _formatDateForTimestamp(date: Date): string {
+  return moment(date).format("h:mm A");
+}
+
+export const NormalMessagingBubble: React.FC<Props> = ({
+  className,
+  children,
+  timestamp,
+  theme,
+  messageOwnership,
+  replyTo,
+  attachments,
+}: Props) => {
+  const hideBubble = !children && !replyTo; // if message is only attachments, no body and not a reply
+  const isOwnMessage = messageOwnership === "ownMessage";
+  const classSuffix = isOwnMessage ? cssClasses.OWN_SUFFIX : cssClasses.OTHER_SUFFIX;
+  const containerClassNames = cx(
+    className,
+    `${cssClasses.MESSAGE_CONTAINER_BASE}${classSuffix}`,
+    theme === "familyPortal" && cssClasses.FAMILY_PORTAL,
+    hideBubble && cssClasses.HIDE_BUBBLE,
+  );
+
+  const bubbleClassNames = cx(
+    cssClasses.MESSAGE_BASE,
+    `${cssClasses.MESSAGE_BASE}${classSuffix}`,
+    replyTo && cssClasses.MESSAGE_REPLY_PARENT,
+  );
+
+  const replyClassNames = cx(
+    cssClasses.MESSAGE_BASE,
+    `${cssClasses.MESSAGE_REPLY_BASE}${classSuffix}`,
+    children && `${cssClasses.MESSAGE_REPLY_BASE}--MarginBottom`,
+  );
+
+  const timeAndBubbleContainerClasses = cx(
+    `${cssClasses.MESSAGE_TIME_BUBBLE_CONTAINER_BASE}${classSuffix}`,
+  );
+
+  const timestampClassNames = cx(
+    cssClasses.MESSAGE_BASE,
+    `${cssClasses.MESSAGE_TIMESTAMP_BASE}${classSuffix}`,
+  );
+
+  const attachmentClassNames = cx(
+    cssClasses.MESSAGE_BASE,
+    `${cssClasses.MESSAGE_ATTACHMENT_BASE}${classSuffix}`,
+  );
+
+  return (
+    <FlexBox column className={containerClassNames}>
+      <FlexBox className={timeAndBubbleContainerClasses}>
+        {!hideBubble && (
+          <span className={timestampClassNames}>{_formatDateForTimestamp(timestamp)}</span>
+        )}
+        <div className={hideBubble ? null : bubbleClassNames}>
+          {replyTo && <div className={replyClassNames}>{replyTo}</div>}
+          <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
+            {children}
+          </Linkify>
+        </div>
+      </FlexBox>
+      <FlexBox className={timeAndBubbleContainerClasses}>
+        {hideBubble && (
+          <span className={timestampClassNames}>{_formatDateForTimestamp(timestamp)}</span>
+        )}
+        {attachments?.length > 0 && (
+          <FlexBox className={attachmentClassNames}>{attachments}</FlexBox>
+        )}
+      </FlexBox>
+    </FlexBox>
+  );
+};

--- a/src/MessagingBubble/NormalMessagingBubble.tsx
+++ b/src/MessagingBubble/NormalMessagingBubble.tsx
@@ -23,7 +23,7 @@ const cssClasses = {
 };
 
 export interface Props {
-  bubbleType: "normal" | "deleted";
+  bubbleType: "normal";
   className?: string;
   children: React.ReactNode;
   timestamp: Date;

--- a/src/MessagingBubble/NormalMessagingBubble.tsx
+++ b/src/MessagingBubble/NormalMessagingBubble.tsx
@@ -17,6 +17,7 @@ const cssClasses = {
   MESSAGE_METADATA_BASE: "NormalMessagingBubble--Message--Metadata",
   MESSAGE_ACTION_BUTTON_BASE: "NormalMessagingBubble--Message--ActionButton",
   MESSAGE_DELETE: "NormalMessagingBubble--Message--Delete",
+  MESSAGE_TIMESTAMP_NONINTERACTIVE: "NormalMessagingBubble--Message--Timestamp--NonInteractive",
   MESSAGE_TIMESTAMP: "NormalMessagingBubble--Message--Timestamp",
   MESSAGE_TIME_BUBBLE_CONTAINER_BASE: "NormalMessagingBubble--Message--TimestampBubbleContainer",
   OWN_SUFFIX: "--Own",
@@ -129,7 +130,7 @@ function _formatDateForTimestamp(date: Date): string {
 }
 
 // Helper function: renders metadata, consisting of either the action button
-//  or a non-interactable timestamp
+//  or a non-interactive timestamp
 function _renderMetadata({
   renderHere,
   timestamp,
@@ -148,7 +149,7 @@ function _renderMetadata({
   }
 
   if (!onClickDeleteButton) {
-    return _renderNonInteractableTimestamp({
+    return _renderNonInteractiveTimestamp({
       timestamp,
       metadataClassNames,
     });
@@ -161,8 +162,8 @@ function _renderMetadata({
   });
 }
 
-// Helper function: renders a non-interactable timestamp
-function _renderNonInteractableTimestamp({
+// Helper function: renders a non-interactive timestamp
+function _renderNonInteractiveTimestamp({
   timestamp,
   metadataClassNames,
 }: {
@@ -171,7 +172,9 @@ function _renderNonInteractableTimestamp({
 }): React.ReactNode {
   return (
     <div className={metadataClassNames}>
-      <span className={cssClasses.MESSAGE_TIMESTAMP}>{_formatDateForTimestamp(timestamp)}</span>
+      <span className={cssClasses.MESSAGE_TIMESTAMP_NONINTERACTIVE}>
+        {_formatDateForTimestamp(timestamp)}
+      </span>
     </div>
   );
 }

--- a/src/MessagingBubble/linkifyUtils.tsx
+++ b/src/MessagingBubble/linkifyUtils.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import * as LinkifyIt from "linkify-it";
-import "./MessagingBubble.less";
+import "./NormalMessagingBubble.less";
 import "./linkifyUtils.less";
 
 // Customized to not link URLs/emails without protocol (i.e. google.com or dewey@clever.com)

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -14,7 +14,6 @@ type PlacementOptions = "left" | "right" | "center" | "fullWidth";
 interface Props {
   className?: string;
   placement: PlacementOptions;
-  timestamp?: Date;
   readStatusText?: string;
   errorMsg?: string;
   children: React.ReactNode;

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -142,7 +142,6 @@ function _interleaveMessagesWithDividers(
         // Last message in the history gets a ref, to allow scrolling down to bottom message.
         ref={i === messages.length - 1 ? lastMessageRef : undefined}
         placement={message.placement}
-        timestamp={message.timestamp}
         readStatusText={isOwnMessage(message) && message.readStatusText}
         // First message needs 'auto' top margin to have messages fill container from bottom -> top
         className={i === 0 ? cssClasses.FIRST_MESSAGE : undefined}


### PR DESCRIPTION
# Jira

[M5G-643: AnnouncementBubble: styling/copy changes](https://clever.atlassian.net/browse/M5G-643)
[M5G-642: DeletedMessagingBubble: new component](https://clever.atlassian.net/browse/M5G-642)
[M5G-641: NormalMessagingBubble: timestamp/Delete button](https://clever.atlassian.net/browse/M5G-641)

# Overview:

Reviewing commit-by-commit should be easier to follow.

1. Makes changes to (Deleted)AnnouncementBubble styling, regarding copy and styling.
2. Sets up MessagingBubble to use a discriminated union (wrt props) and have different 'forms,' just like AnnouncementBubble already does.
3. Adds DeletedMessagingBubble as a new form of the component.
4. Alters NormalMessagingBubble so that timestamps are (optionally) _Delete_ buttons when focused/hovered/active, to initiate DM deletion.
5. Adjusts the -View components for all of the above changes, plus filling in some pre-existing needs (e.g. prop documentation for -Bubble components).

# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [n/a] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component

# Screenshots/GIFs

## DeletedAnnouncementBubble

NOTE: The -View file for AnnouncementBubble's versions doesn't yet have the own/other distinction, so it's not reflected in these screenshots. It'll be reflected in actual usage in launchpad/fampo.

### Desktop
<img width="623" alt="Screen Shot 2021-08-27 at 4 04 36 PM" src="https://user-images.githubusercontent.com/57963785/131196826-98fd077d-ef00-4ec7-8e4d-2302efa761c1.png">

### Mobile
<img width="659" alt="Screen Shot 2021-08-27 at 4 04 20 PM" src="https://user-images.githubusercontent.com/57963785/131196832-aff3da2b-e9fd-40c8-9ee7-7a9aea1a769c.png">

## DeletedMessagingBubble

### Desktop
<img width="1075" alt="Screen Shot 2021-08-27 at 4 02 53 PM" src="https://user-images.githubusercontent.com/57963785/131196856-d6107ffa-8175-4971-be0b-4c03c20a57a2.png">
<img width="1079" alt="Screen Shot 2021-08-27 at 4 02 58 PM" src="https://user-images.githubusercontent.com/57963785/131196857-fc40a184-f3a4-4f40-92c9-74ba7e944981.png">

### Mobile
<img width="1016" alt="Screen Shot 2021-08-27 at 4 03 59 PM" src="https://user-images.githubusercontent.com/57963785/131196868-61d75676-3605-46c8-9f9e-d79c0babad53.png">
<img width="1077" alt="Screen Shot 2021-08-27 at 4 04 05 PM" src="https://user-images.githubusercontent.com/57963785/131196870-648b5e76-547b-43b0-87b0-4f579286b1aa.png">

### NormalMessagingBubble
![Kapture 2021-08-27 at 16 02 33](https://user-images.githubusercontent.com/57963785/131196902-b00fed98-e7d5-4013-a686-def703f4c695.gif)