### PR TITLE
M5G-761: hide decorative image for screen reader

### DIFF
--- a/src/MessagingAvatar/MessagingAvatar.tsx
+++ b/src/MessagingAvatar/MessagingAvatar.tsx
@@ -28,7 +28,8 @@ export const MessagingAvatar: React.FC<Props> = ({ className, text, color, image
   if (imageSrc) {
     return (
       <img
-        alt={`${text}'s user avatar`}
+        alt={""}
+        aria-hidden={"true"}
         className={classNames(cssClasses.IMAGE, className)}
         src={imageSrc}
       />


### PR DESCRIPTION
# Jira: [M5G-761](https://clever.atlassian.net/browse/M5G-761)

# Overview:

Decorative images should be hidden for screen readers. To do this, I replaced the alt text with an empty string (if you remove the alt prop all together, the screen reader will read out the url) and added aria-hidden=true

# Screenshots/GIFs:

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
 
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
