### PR TITLE
[a11y] [TextInput] Allow 'required' text to be translated

### DIFF
--- a/docs/components/TextInputView.jsx
+++ b/docs/components/TextInputView.jsx
@@ -251,6 +251,13 @@ export default class TextInputView extends Component {
               optional: true,
             },
             {
+              name: "requiredText",
+              type: "String",
+              description:
+                "(Temporary) allows overriding the 'required' label text with translations",
+              optional: true,
+            },
+            {
               name: "showButtonText",
               type: "String",
               description: "(Temporary) allows overriding the Show button text with translations",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.158.0",
+  "version": "2.159.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -33,6 +33,8 @@ export interface Props {
   readOnly?: boolean;
   required?: boolean;
   /** Temporary prop to allow overriding the text with a translation. */
+  requiredText?: string;
+  /** Temporary prop to allow overriding the text with a translation. */
   showButtonText?: string;
   size?: Values<typeof FormElementSize>;
   type?: string;
@@ -67,6 +69,7 @@ const propTypes = {
   placeholderCaps: PropTypes.bool,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
+  requiredText: PropTypes.string,
   showButtonText: PropTypes.string,
   size: PropTypes.oneOf(Object.values(FormElementSize)),
   type: PropTypes.string,
@@ -131,13 +134,13 @@ export class TextInput extends React.Component<Props, State> {
   };
 
   currentErrorMessage(): string {
-    const { error, value, required } = this.props;
+    const { error, value, required, requiredText } = this.props;
     const { hasBeenFocused } = this.state;
 
     let errorMessage = "";
 
     if (required && hasBeenFocused && !value) {
-      errorMessage = "required";
+      errorMessage = requiredText || "required";
     }
 
     if (error) {
@@ -148,11 +151,11 @@ export class TextInput extends React.Component<Props, State> {
   }
 
   renderNote(errorMessage) {
-    const { required, optional } = this.props;
+    const { required, requiredText, optional } = this.props;
     let inputNote;
 
     if (required) {
-      inputNote = <span className="TextInput--required">required</span>;
+      inputNote = <span className="TextInput--required">{requiredText || "required"}</span>;
     }
     if (optional) {
       inputNote = <span className="TextInput--optional">optional</span>;


### PR DESCRIPTION
# Jira:
https://clever.atlassian.net/browse/prtl-672

# Overview:
The username and password inputs in the parent portal login screen need to be marked as required for accessibility, and in order to do so we need a way to translate the word "required". This change will let us pass in translated values for "required".

# Screenshots/GIFs:

# Testing:

![Screen Shot 2021-08-30 at 10 16 21 AM](https://user-images.githubusercontent.com/32328921/131378913-d5af579b-7a4e-49dd-a238-2013f45bf9be.jpg)

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
