### PR TITLE
Fix some DM Deletion styling issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.160.1",
+  "version": "2.160.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingBubble/NormalMessagingBubble.less
+++ b/src/MessagingBubble/NormalMessagingBubble.less
@@ -79,11 +79,15 @@
 }
 
 .NormalMessagingBubble--Message--Metadata--Own {
+  min-width: 3.5rem;
   .margin--right--xs();
+  text-align: right;
 }
 
 .NormalMessagingBubble--Message--Metadata--Other {
+  min-width: 3.5rem;
   .margin--left--xs();
+  text-align: left;
 }
 
 .NormalMessagingBubble--Message--Delete {
@@ -140,7 +144,7 @@
   }
 }
 
-Button.NormalMessagingBubble--Message--ActionButton--Own {
+.Button.NormalMessagingBubble--Message--ActionButton--Own {
   width: 100%;
   text-align: right;
 
@@ -165,7 +169,7 @@ Button.NormalMessagingBubble--Message--ActionButton--Own {
   }
 }
 
-Button.NormalMessagingBubble--Message--ActionButton--Other {
+.Button.NormalMessagingBubble--Message--ActionButton--Other {
   width: 100%;
   text-align: left;
 


### PR DESCRIPTION
# Overview:

Fix some DM Deletion styling issues, pertaining to the Delete/timestamp action button in NormalMessagingBubble.

# Testing:

Tested in both local components instance as well as in local launchpad.

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [n/a] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
