### PR TITLE
[a11y] [RadioGroup] Support lang attribute

### DIFF
--- a/docs/components/RadioGroupView.jsx
+++ b/docs/components/RadioGroupView.jsx
@@ -21,6 +21,7 @@ const OPTION_TYPE = `{
   id: string,
   disabled?: boolean,
   label: string,
+  lang?: string,
   value?: any,
 }`;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.161.0",
+  "version": "2.162.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/RadioGroup/Radio.tsx
+++ b/src/RadioGroup/Radio.tsx
@@ -13,6 +13,7 @@ export interface Props<IDType extends string = string, ValueType = any> {
   onSelect?: (id: IDType, value: ValueType) => void;
   tabIndex?: number;
   value?: ValueType;
+  lang?: string;
 }
 
 const cssClass = {
@@ -50,7 +51,7 @@ export default class Radio<
   }
 
   render() {
-    const { checked, children, className, disabled, tabIndex } = this.props;
+    const { checked, children, className, disabled, tabIndex, lang } = this.props;
 
     return (
       <button
@@ -67,6 +68,7 @@ export default class Radio<
         onFocus={this._onClick}
         role="radio"
         tabIndex={tabIndex}
+        lang={lang}
       >
         <div className={cssClass.OUTER}>
           <div className={cssClass.INNER} />

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -12,6 +12,8 @@ interface Option<IDType extends string = string, ValueType = any> {
   id: IDType;
   disabled?: boolean;
   label: React.ReactNode;
+  /** A BCP47 language tag. */
+  lang?: string;
   value?: ValueType;
 }
 
@@ -95,6 +97,7 @@ export default class RadioGroup<
               ref={(ref) => this._handleRadioRef(ref)}
               tabIndex={o.id === focusableOptionID ? 0 : -1}
               value={o.value}
+              lang={o.lang}
             >
               {o.label}
             </Radio>


### PR DESCRIPTION
# Jira:
https://clever.atlassian.net/browse/prtl-670

# Overview:
This change allows the `lang` attribute to be set on radio buttons which we need to do in order to make the language selector accessible in the parent portal.

# Screenshots/GIFs:

# Testing:
I tested this in fampo with VoiceOver.

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
