### PR TITLE
[M5G-773] RadioGroup additional text under selected option

### DIFF
--- a/docs/components/RadioGroupView.jsx
+++ b/docs/components/RadioGroupView.jsx
@@ -23,6 +23,7 @@ const OPTION_TYPE = `{
   label: string,
   lang?: string,
   value?: any,
+  additionalText?: string,
 }`;
 
 export default class RadioGroupView extends React.PureComponent {
@@ -30,6 +31,7 @@ export default class RadioGroupView extends React.PureComponent {
 
   state = {
     disableAll: false,
+    selectedAdditionalText: null,
     selectedCity: null,
     selectedEmoji: null,
     selectedFood: null,
@@ -41,6 +43,7 @@ export default class RadioGroupView extends React.PureComponent {
     const {
       disableAll,
       requireSelection,
+      selectedAdditionalText,
       selectedCity,
       selectedEmoji,
       selectedFood,
@@ -95,8 +98,13 @@ export default class RadioGroupView extends React.PureComponent {
               onChange={(id) => this.setState({ selectedCity: id })}
               options={[
                 { id: "london", label: "London", disabled: disableAll },
-                { id: "paris", label: "Paris", disabled: disableAll },
-                { id: "sanFrancisco", label: "San Francisco", disabled: disableAll },
+                { id: "paris", label: "Paris", disabled: disableAll, additionalText: "Baguette" },
+                {
+                  id: "sanFrancisco",
+                  label: "San Francisco",
+                  disabled: disableAll,
+                  additionalText: "Clever HQ is here!",
+                },
                 {
                   id: "none",
                   label: "None of the above",
@@ -104,6 +112,16 @@ export default class RadioGroupView extends React.PureComponent {
                 },
               ]}
               selectedID={selectedCity}
+            />
+
+            <RadioGroup
+              label="Do you want to try the additionalText option?"
+              onChange={(id) => this.setState({ selectedAdditionalText: id })}
+              options={[
+                { id: "yes", label: "Yes", disabled: disableAll, additionalText: "Huzzah!" },
+                { id: "no", label: "No", disabled: disableAll },
+              ]}
+              selectedID={selectedAdditionalText}
             />
 
             <RadioGroup
@@ -244,6 +262,9 @@ export default class RadioGroupView extends React.PureComponent {
                 The <code>value</code> field provides the convenience of receiving a custom value in
                 the RadioGroup onChange event in addition to the selected ID to avoid having to do a
                 value lookup.
+                <br />
+                The <code>additionalText</code> field's value will be displayed under its associated
+                radio button option if provided and if that option is currently selected.
               </p>
             ),
           },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.162.0",
+  "version": "2.163.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/RadioGroup/RadioGroup.less
+++ b/src/RadioGroup/RadioGroup.less
@@ -17,3 +17,11 @@
   .text--medium;
   .text--semi-bold;
 }
+
+.RadioGroup--additionalText {
+  .margin--top--xs;
+  .margin--left--l;
+  .text--smallMedium;
+  line-height: @size_m;
+  color: @neutral_dark_gray;
+}

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -15,6 +15,7 @@ interface Option<IDType extends string = string, ValueType = any> {
   /** A BCP47 language tag. */
   lang?: string;
   value?: ValueType;
+  additionalText?: string;
 }
 
 export interface Props<OptionIDType extends string, OptionValueType> {
@@ -32,6 +33,7 @@ const cssClass = {
   CONTAINER: "RadioGroup",
   LABEL: "RadioGroup--label",
   RADIO: "RadioGroup--radio",
+  ADDITIONAL_TEXT: "RadioGroup--additionalText",
 };
 
 const LABEL_ID_PREFIX = "RadioGroup--label";
@@ -87,20 +89,25 @@ export default class RadioGroup<
           )}
           {error && <FormError>{error}</FormError>}
           {_.map(options, (o) => (
-            <Radio<OptionIDType, OptionValueType>
-              checked={o.id === selectedID}
-              className={cssClass.RADIO}
-              disabled={!!disabled || !!o.disabled}
-              id={o.id}
-              key={o.id}
-              onSelect={onChange}
-              ref={(ref) => this._handleRadioRef(ref)}
-              tabIndex={o.id === focusableOptionID ? 0 : -1}
-              value={o.value}
-              lang={o.lang}
-            >
-              {o.label}
-            </Radio>
+            <>
+              <Radio<OptionIDType, OptionValueType>
+                checked={o.id === selectedID}
+                className={cssClass.RADIO}
+                disabled={!!disabled || !!o.disabled}
+                id={o.id}
+                key={o.id}
+                onSelect={onChange}
+                ref={(ref) => this._handleRadioRef(ref)}
+                tabIndex={o.id === focusableOptionID ? 0 : -1}
+                value={o.value}
+                lang={o.lang}
+              >
+                {o.label}
+              </Radio>
+              {o.id === selectedID && o.additionalText && (
+                <div className={cssClass.ADDITIONAL_TEXT}>{o.additionalText}</div>
+              )}
+            </>
           ))}
         </div>
       </WithKeyboardNav>


### PR DESCRIPTION
# Jira:
https://clever.atlassian.net/browse/M5G-773
https://www.figma.com/file/X5yHaqtEAyCAtjBFeXRb2s/Messages-v2-(Translations)?node-id=617%3A15312

# Overview:
We want to be able to display some copy underneath the selected radio button in some cases, so adding a new field in the `options` prop in the `RadioGroup` component that takes a string of text that will be displayed under the radio button option if it is provided and if that option is actually selected. Since this new field is optional, this change should be backward-compatible.

# Screenshots/GIFs:


https://user-images.githubusercontent.com/35714960/132770106-c6b8b192-05eb-49b1-8072-739a3434f5e5.mov



# Testing:
- [x] Checked it still works with a11y tabbing
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
