### PR TITLE
Bump version to 2.164.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.163.0",
+  "version": "2.164.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Overview:

Oops I forgot to rebase to master before merging https://github.com/Clever/components/pull/742 and now 2.163.0 includes both my changes and Chloe's changes from here https://github.com/Clever/components/pull/741

Bumping the version here so that it's clear that the next version (2.165.0) will also be pulling my changes. 

# Screenshots/GIFs:

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
