### PR TITLE
Fix quoted announcement bubble overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.164.0",
+  "version": "2.164.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingBubble/NormalMessagingBubble.less
+++ b/src/MessagingBubble/NormalMessagingBubble.less
@@ -114,6 +114,7 @@
   .padding--left--s();
   flex-direction: row;
   align-items: center;
+  max-width: 100%;
 
   &:hover {
     .NormalMessagingBubble--Message--Timestamp {
@@ -130,6 +131,7 @@
   .padding--right--s();
   flex-direction: row-reverse;
   align-items: center;
+  max-width: 100%;
 
   &:hover {
     .NormalMessagingBubble--Message--Timestamp {


### PR DESCRIPTION
https://clever.atlassian.net/browse/MOC-159

# Overview:

We were seeing long quoted announcements flow off the screen because the timestamp container didn't have a width set.

# Screenshots/GIFs:

Tested in LP and FP


https://user-images.githubusercontent.com/26425483/133518379-440ea5b9-a4a5-4489-89a2-ef9df314242c.mov


https://user-images.githubusercontent.com/26425483/133518386-fabee1b3-4bc1-4641-90a7-af77b7d8a08e.mov




# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
