### PR TITLE
M5G-774 - Adjust RadioGroup implementation so that consumers can override st

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.164.1",
+  "version": "2.164.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/RadioGroup/RadioGroup.less
+++ b/src/RadioGroup/RadioGroup.less
@@ -5,7 +5,9 @@
     .margin--top--l;
   }
 
-  .RadioGroup--radio {
+  // The latter class (selectedWithAdditionalText) exists purely to be overriden by the consumer.
+  .RadioGroup--radio,
+  .RadioGroup--radio--selectedWithAdditionalText {
     &:not(:first-child) {
       .margin--top--s;
     }

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -33,6 +33,7 @@ const cssClass = {
   CONTAINER: "RadioGroup",
   LABEL: "RadioGroup--label",
   RADIO: "RadioGroup--radio",
+  RADIO_SELECTED_WITH_ADDITIONAL_TEXT: "RadioGroup--radio--selectedWithAdditionalText",
   ADDITIONAL_TEXT: "RadioGroup--additionalText",
 };
 
@@ -88,27 +89,33 @@ export default class RadioGroup<
             </div>
           )}
           {error && <FormError>{error}</FormError>}
-          {_.map(options, (o) => (
-            <>
-              <Radio<OptionIDType, OptionValueType>
-                checked={o.id === selectedID}
-                className={cssClass.RADIO}
-                disabled={!!disabled || !!o.disabled}
-                id={o.id}
-                key={o.id}
-                onSelect={onChange}
-                ref={(ref) => this._handleRadioRef(ref)}
-                tabIndex={o.id === focusableOptionID ? 0 : -1}
-                value={o.value}
-                lang={o.lang}
-              >
-                {o.label}
-              </Radio>
-              {o.id === selectedID && o.additionalText && (
-                <div className={cssClass.ADDITIONAL_TEXT}>{o.additionalText}</div>
-              )}
-            </>
-          ))}
+          {_.map(options, (o) => {
+            const isSelectedAndHasAdditionalText = o.id === selectedID && o.additionalText;
+            return (
+              <>
+                <Radio<OptionIDType, OptionValueType>
+                  checked={o.id === selectedID}
+                  className={classnames(
+                    cssClass.RADIO,
+                    isSelectedAndHasAdditionalText && cssClass.RADIO_SELECTED_WITH_ADDITIONAL_TEXT,
+                  )}
+                  disabled={!!disabled || !!o.disabled}
+                  id={o.id}
+                  key={o.id}
+                  onSelect={onChange}
+                  ref={(ref) => this._handleRadioRef(ref)}
+                  tabIndex={o.id === focusableOptionID ? 0 : -1}
+                  value={o.value}
+                  lang={o.lang}
+                >
+                  {o.label}
+                </Radio>
+                {isSelectedAndHasAdditionalText && (
+                  <div className={cssClass.ADDITIONAL_TEXT}>{o.additionalText}</div>
+                )}
+              </>
+            );
+          })}
         </div>
       </WithKeyboardNav>
     );


### PR DESCRIPTION
# Jira

[M5G-774](https://clever.atlassian.net/browse/M5G-774)

# Overview

Adjust RadioGroup implementation so that consumers can override styling to adjust margins and padding in a way that allows treating the selected-with-additional-text group differently, as currently there is no way to do so.

# Testing

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out

💯 

- Before merging
  - [n/a] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component

# Screenshots/GIFs

## clever-components: unchanged

![Kapture 2021-09-15 at 16 33 32](https://user-images.githubusercontent.com/57963785/133526498-a53ed7fe-2b95-4cc7-8355-9847309d6233.gif)

## family-portal, desktop modal: can override styling

![Screen Shot 2021-09-15 at 4 25 40 PM](https://user-images.githubusercontent.com/57963785/133526541-6325ed26-50af-4fb5-9ffd-4cf405e2293c.png)
![Screen Shot 2021-09-15 at 4 25 47 PM](https://user-images.githubusercontent.com/57963785/133526543-66326e92-7465-43be-b013-a01661159fbc.png)
![Screen Shot 2021-09-15 at 4 25 56 PM](https://user-images.githubusercontent.com/57963785/133526545-02a66351-e3e4-4f77-bfef-04aa119b2540.png)

## family-portal, mobile fullscreen: can override styling
![Screen Shot 2021-09-15 at 4 27 18 PM](https://user-images.githubusercontent.com/57963785/133526580-bdeeb42f-8866-463a-934e-5f3d128b067d.png)
![Screen Shot 2021-09-15 at 4 27 30 PM](https://user-images.githubusercontent.com/57963785/133526581-df76ca02-6545-48e4-8411-94616a818e62.png)
![Screen Shot 2021-09-15 at 4 27 52 PM](https://user-images.githubusercontent.com/57963785/133526583-b9aaddf7-28d3-4ef6-b357-76dc565dee0a.png)