### PR TITLE
Disc 2758 enhance text input2

### DIFF
--- a/docs/components/TextInput2View.jsx
+++ b/docs/components/TextInput2View.jsx
@@ -32,7 +32,7 @@ export default class TextInput2View extends React.PureComponent {
     showIcon: false,
     requirement: FormElementRequirement.REQUIRED,
     obscurable: false,
-    initialIsInError: false,
+    errorOnEmpty: false,
     size: FormElementSize.MEDIUM,
   };
 
@@ -72,7 +72,7 @@ export default class TextInput2View extends React.PureComponent {
               requirement={this.state.requirement}
               obscurable={this.state.obscurable}
               value={this.state.value}
-              initialIsInError={this.state.initialIsInError}
+              errorOnEmpty={this.state.errorOnEmpty}
               errorValidation={(value) => (value.toLowerCase() !== value ? "only lowercase" : null)}
               onChange={(e) => this.setState({ value: e.target.value })}
               size={this.state.size}
@@ -95,7 +95,7 @@ export default class TextInput2View extends React.PureComponent {
       showIcon,
       requirement,
       obscurable,
-      initialIsInError,
+      errorOnEmpty,
       size,
     } = this.state;
 
@@ -162,10 +162,10 @@ export default class TextInput2View extends React.PureComponent {
           <input
             type="checkbox"
             className={cssClass.CONFIG_TOGGLE}
-            checked={initialIsInError}
-            onChange={(e) => this.setState({ initialIsInError: e.target.checked })}
+            checked={errorOnEmpty}
+            onChange={(e) => this.setState({ errorOnEmpty: e.target.checked })}
           />{" "}
-          <span className={cssClass.CONFIG_TEXT}>Initial error</span>
+          <span className={cssClass.CONFIG_TEXT}>Error on empty</span>
         </label>
         <div className={cssClass.CONFIG}>
           <span className={cssClass.CONFIG_TEXT}>Requirement:</span>
@@ -259,9 +259,10 @@ export default class TextInput2View extends React.PureComponent {
             optional: true,
           },
           {
-            name: "initialIsInError",
+            name: "errorOnEmpty",
             type: "boolean",
-            description: "Intialize the component in an error state",
+            description:
+              "Display an error state when the input value is empty and the input is out of focus",
             optional: true,
           },
           {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.165.7",
+  "version": "2.166.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput2/TextInput2_test.tsx
+++ b/src/TextInput2/TextInput2_test.tsx
@@ -1,7 +1,14 @@
 import * as React from "react";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 
 import TextInput2, { cssClass } from "./TextInput2";
+
+// util functions
+const getInput = (wrapper) => wrapper.find("input");
+const getErrorContainer = (wrapper) => wrapper.find(`.${cssClass.INPUT_CONTAINER_ERROR}`);
+const changeInputValue = (input, value) => {
+  input.simulate("change", { target: { value } });
+};
 
 describe("TextInput2", () => {
   let defaultProps;
@@ -54,18 +61,105 @@ describe("TextInput2", () => {
     expect(myComponent.props().className).toMatch("my--custom--class");
   });
 
+  describe("error validation", () => {
+    const validValue = "valid";
+    const invalidValue = "invalid";
+    let wrapper;
+    beforeEach(() => {
+      defaultProps = {
+        ...defaultProps,
+        errorValidation: (value) => (value === invalidValue ? "test error message" : null),
+        onChange: (e) => {
+          wrapper.setProps({ value: e.target.value });
+          wrapper.update();
+        },
+      };
+    });
+
+    it("displays error on blur if provided errorValidation function returns a string", () => {
+      wrapper = mount(<TextInput2 {...defaultProps} />);
+      const input = getInput(wrapper);
+
+      input.simulate("focus");
+      changeInputValue(input, invalidValue);
+      let errorContainer = getErrorContainer(wrapper);
+      // error should not be displayed while element is still in focus
+      expect(errorContainer).not.toExist();
+
+      input.simulate("blur");
+      errorContainer = getErrorContainer(wrapper);
+      // error is displayed after focus is removed
+      expect(errorContainer).toExist();
+    });
+
+    it("removes error while focused if provided errorValidation function returns null", () => {
+      defaultProps.value = invalidValue;
+      wrapper = mount(<TextInput2 {...defaultProps} />);
+      let errorContainer = getErrorContainer(wrapper);
+      // error is already present from invalid value
+      expect(errorContainer).toExist();
+
+      const input = getInput(wrapper);
+      input.simulate("focus");
+      changeInputValue(input, validValue);
+      errorContainer = getErrorContainer(wrapper);
+      // error is removed after valid value is set
+      expect(errorContainer).not.toExist();
+    });
+
+    it("removes error if input value is empty string", () => {
+      defaultProps.value = invalidValue;
+      wrapper = mount(<TextInput2 {...defaultProps} />);
+      let errorContainer = getErrorContainer(wrapper);
+      // error is already present from invalid value
+      expect(errorContainer).toExist();
+
+      const input = getInput(wrapper);
+      input.simulate("focus");
+      changeInputValue(input, "");
+      errorContainer = getErrorContainer(wrapper);
+      // error is removed after value is set to empty string
+      expect(errorContainer).not.toExist();
+    });
+
+    it("displays error if value is empty string and errorOnEmpty is true", () => {
+      defaultProps.errorOnEmpty = true;
+      defaultProps.value = "";
+      wrapper = mount(<TextInput2 {...defaultProps} />);
+      const errorContainer = getErrorContainer(wrapper);
+      // error is displayed for empty value
+      expect(errorContainer).toExist();
+    });
+
+    it("removes error on focus if value is empty string and errorOnEmpty is true", () => {
+      defaultProps.errorOnEmpty = true;
+      defaultProps.value = "";
+      wrapper = mount(<TextInput2 {...defaultProps} />);
+      const input = getInput(wrapper);
+
+      let errorContainer = getErrorContainer(wrapper);
+      // error is displayed for empty value
+      expect(errorContainer).toExist();
+
+      input.simulate("focus");
+      errorContainer = getErrorContainer(wrapper);
+      // empty error is removed on focus
+      expect(errorContainer).not.toExist();
+    });
+  });
+
   describe("event handling", () => {
     it("executes onFocus prop if provided", () => {
       defaultProps.onFocus = jest.fn();
       const wrapper = shallow(<TextInput2 {...defaultProps} />);
-      wrapper.find("input").simulate("focus");
+      getInput(wrapper).simulate("focus");
       expect(defaultProps.onFocus).toHaveBeenCalled();
     });
 
     it("executes onBlur prop if provided", () => {
       defaultProps.onBlur = jest.fn();
       const wrapper = shallow(<TextInput2 {...defaultProps} />);
-      wrapper.find("input").simulate("blur");
+      getInput(wrapper).simulate("blur");
       expect(defaultProps.onBlur).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
# Jira: [DISC-2758](https://clever.atlassian.net/browse/DISC-2758)

# Overview:

Modifies `TextInput2` error validation behavior:

* Changes `initialIsInError` prop [(unused)](https://github.com/search?q=org%3AClever+initialIsInError&type=code) to `errorOnEmpty`
* If `errorOnEmpty`, empty error state is displayed while input is out of focus and value is empty, but is removed when input is in focus and value is empty
  * The error removal while value is empty allows normal error validation to take place 
* Only displays errorValidation error on "blur" event
  * Once the event state is set, error is removed either by correcting the error or removing the value (no error state will be set while the value is empty)

# Screenshots/GIFs:
When `errorOnEmpty` is false:
* error is not shown while value is empty
* after entering invalid value, error is not shown until focus is removed from the input
* error is removed by removing the value
* error is removed by correcting the error (i.e. entering a valid value)
![error](https://user-images.githubusercontent.com/7572022/135369726-3fee3ac6-b6b4-4f6f-967e-766063987ad7.gif)

When `errorOnEmpty` is true:
* error is displayed while input is out of focus and value is empty
* empty error is removed on focus
* entering a value allows normal error validation behavior to occur (as described above)
![errorOnEmpty](https://user-images.githubusercontent.com/7572022/135369731-37ad7233-25da-49ad-9008-72eb55f642bc.gif)


# Testing:

**Note:** Added tests use Enzyme's `mount` function instead of `shallow`, because `useEffect` calls [aren't made during shallow renders](https://github.com/enzymejs/enzyme/issues/2086).

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
