### PR TITLE
v2.164.3 - Tidies up some CSS with MessagingAttachment styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.164.2",
+  "version": "2.164.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -23,6 +23,12 @@
   border: @size_4xs solid @neutral_silver;
   border-radius: @size_2xs;
   box-sizing: content-box;
+
+  &:focus,
+  &:active {
+    outline: none; // remove default red outline
+    border: @size_4xs solid @primary_blue_tint_2;
+  }
 }
 
 .NormalMessagingBubble--Message .MessagingAttachment--Container {
@@ -174,11 +180,17 @@
   color: @neutral_dark_gray;
 
   .MessagingAttachment--Container {
-    border: 0;
-    border-radius: 0;
+    border-radius: inherit;
+    .margin--top--none();
 
     .padding--y--s();
     .padding--x--xs();
+  }
+
+  .MessagingAttachment--Container:focus,
+  .MessagingAttachment--Container:active {
+    outline: none; // remove default red outline
+    border: @size_4xs solid @primary_blue_tint_2;
   }
 
   .MessagingAttachment--IconContainer {


### PR DESCRIPTION
# Jira
[MOC-151](https://clever.atlassian.net/browse/MOC-151)

# Overview

Tidies up some CSS with MessagingAttachment styling, including restoring the blue border upon focus (as opposed to default red outline).

# Screenshots/GIFs

## Before

### Focus
![Screen Shot 2021-09-20 at 12 05 33 PM](https://user-images.githubusercontent.com/57963785/134062951-3d417654-88d7-40ea-92d7-216785a041a1.png)
![Screen Shot 2021-09-20 at 12 06 19 PM](https://user-images.githubusercontent.com/57963785/134062956-f7e527f9-a814-43a2-835c-86648c48cc53.png)

### Hover
![Screen Shot 2021-09-20 at 12 16 59 PM](https://user-images.githubusercontent.com/57963785/134063017-9526e6ea-c87d-4cac-9b5e-68f130e1bb6f.png)

## After

### Focus
![Screen Shot 2021-09-20 at 12 05 38 PM](https://user-images.githubusercontent.com/57963785/134062955-a59ede10-9048-46d3-ace5-f0a93c3a3192.png)
![Screen Shot 2021-09-20 at 12 06 25 PM](https://user-images.githubusercontent.com/57963785/134062957-552c12e4-7aec-46ea-b54a-b39beb6308cf.png)

### Hover
![Screen Shot 2021-09-20 at 12 17 17 PM](https://user-images.githubusercontent.com/57963785/134063061-2d84a0fa-9f57-4415-8f25-0ad92ba46f80.png)

# Testing

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out

💯 

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
