### PR TITLE
Badges now can have no children

### DIFF
--- a/docs/components/BadgeView.jsx
+++ b/docs/components/BadgeView.jsx
@@ -46,6 +46,10 @@ export default class BadgeView extends React.PureComponent {
               I am badge superscript
               <Badge superscript>10</Badge>
             </p>
+            <h3>Empty dot</h3>
+            <Badge size="s" />
+            <Badge />
+            <Badge size="l" />
           </ExampleCode>
         </Example>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.164.3",
+  "version": "2.165.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Badge/Badge.less
+++ b/src/Badge/Badge.less
@@ -6,6 +6,10 @@
   .margin--x--2xs;
 }
 
+.Badge--empty {
+  font-size: 0.5rem;
+}
+
 .Badge--super {
   vertical-align: super;
 }

--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -6,7 +6,7 @@ import { Values } from "../utils/types";
 import "./Badge.less";
 
 export interface Props {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   className?: string;
   superscript?: boolean;
   color?: Values<typeof Color>;
@@ -15,6 +15,7 @@ export interface Props {
 
 export const cssClass = {
   CONTAINER: "Badge",
+  EMPTY: "Badge--empty",
   SUPER: "Badge--super",
   color: (c) => `Badge--${c}`,
   size: (s) => `Badge--${s}`,
@@ -47,6 +48,7 @@ export class Badge extends React.PureComponent<Props> {
     const { color, children, className, size, superscript } = this.props;
     const classes = classnames(
       cssClass.CONTAINER,
+      children === undefined && cssClass.EMPTY,
       color && cssClass.color(color),
       size && cssClass.size(size),
       superscript && cssClass.SUPER,


### PR DESCRIPTION
# Jira: [PRTL-1291](https://clever.atlassian.net/browse/PRTL-1291)

# Overview:

I need an empty badge, but badges actually must be parents and have children! Now badges can have no children. 

# Screenshots/GIFs:

<img width="686" alt="Screen Shot 2021-09-21 at 4 18 52 PM" src="https://user-images.githubusercontent.com/12452249/134260426-6ed3ab0f-f4af-4847-b636-cc867da61a1e.png">

# Testing:

Tested locally, with all the sizes too!

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
