### PR TITLE
M5G-855 - Resolve discord between TS type and PropTypes type for titl…

### DIFF
--- a/docs/components/ModalView.jsx
+++ b/docs/components/ModalView.jsx
@@ -30,7 +30,14 @@ export default class ModalView extends Component {
             value="Open Modal"
           />
           {this.state.isModalOpen && (
-            <Modal title="Hello Modal" closeModal={() => this.setState({ isModalOpen: false })}>
+            <Modal
+              title={
+                <span id="id-for-arialabeledby-on-another-component-for-accessibility">
+                  Hello Modal
+                </span>
+              }
+              closeModal={() => this.setState({ isModalOpen: false })}
+            >
               <p>{loremIpsum({ count: 1, units: "paragraphs" })}</p>
               <p>{loremIpsum({ count: 1, units: "paragraphs" })}</p>
               <footer>
@@ -69,7 +76,7 @@ export default class ModalView extends Component {
             },
             {
               name: "title",
-              type: "String",
+              type: "Node",
               description: "The title of the modal",
             },
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.165.2",
+  "version": "2.165.3",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -9,7 +9,7 @@ import "./Modal.less";
 export interface Props {
   className?: string;
   width?: number;
-  title: React.ReactNode; // PropTypes says this can only be a string
+  title: React.ReactNode;
   closeModal: () => void;
   children: React.ReactNode;
   focusLocked?: boolean;
@@ -31,7 +31,7 @@ const closeIcon = (
 const propTypes = {
   className: PropTypes.string,
   width: PropTypes.number,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
   closeModal: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
   focusLocked: PropTypes.bool,


### PR DESCRIPTION
# Jira

[M5G-855](https://clever.atlassian.net/browse/M5G-855)

# Overview

Resolve discord between TS type and PropTypes type for title on Modal. This way, we can put an element with an id on it (for use by aria-labeled-by elsewhere) for accessibility purposes.

# Screenshots/GIFs

## Before
![Screen Shot 2021-09-27 at 3 53 10 PM](https://user-images.githubusercontent.com/57963785/134997694-83c27552-6022-4a0a-90c6-1cd7607f5025.png)

## After
![Screen Shot 2021-09-27 at 3 55 50 PM](https://user-images.githubusercontent.com/57963785/134997699-d91a5f69-9432-4d25-bc45-1aaf548388e7.png)

# Testing

- Tested with local instance of family-portal, as demonstrated in screenshots.
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out

💯  Not breaking, will pull into `family-portal` and `oauth` myself.

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
