### PR TITLE
Use aria-expanded prop for FloatingButton to indicate when menu is expanded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.165.1",
+  "version": "2.165.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FloatingButton/FloatingButton.tsx
+++ b/src/FloatingButton/FloatingButton.tsx
@@ -234,6 +234,7 @@ export default class FloatingButton extends React.PureComponent<Props, State> {
                     )
                   : label
               }
+              aria-expanded={additionalButtons ? active : null}
               size={size || Button.Size.M}
             />
           </div>


### PR DESCRIPTION
# Jira:
https://clever.atlassian.net/browse/PRTL-1068 and https://clever.atlassian.net/browse/PRTL-1128

# Overview:
This PR sets the aria-expanded prop for the `FloatingButton` component to indicate when it is expanded vs collapsed. Since the FloatingButton also supports not expanding to a menu, we only use this prop when `additionalButtons` are passed.

# Screenshots/GIFs:
N/A

# Testing:
Verified the prop shows up and changes.

- [ ] Unit tests
- Manual tests:
  - [X] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:
🚀 

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
