### PR TITLE
Disc 2827 text input2 event handlers

### DIFF
--- a/docs/components/TextInput2View.jsx
+++ b/docs/components/TextInput2View.jsx
@@ -281,6 +281,18 @@ export default class TextInput2View extends React.PureComponent {
             description: "Called when value of input changes",
           },
           {
+            name: "onFocus",
+            type: "Function",
+            description: "Called when focus is placed on the input",
+            optional: true,
+          },
+          {
+            name: "onBlur",
+            type: "Function",
+            description: "Called when focus is removed from the input",
+            optional: true,
+          },
+          {
             name: "size",
             type: "string",
             description: (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.165.3",
+  "version": "2.165.4",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TextInput2/TextInput2.tsx
+++ b/src/TextInput2/TextInput2.tsx
@@ -25,6 +25,8 @@ export interface Props {
   errorValidation?: (value: string) => string | null;
   value: string;
   onChange: React.ChangeEventHandler<HTMLInputElement>;
+  onFocus?: React.FocusEventHandler<HTMLInputElement>;
+  onBlur?: React.FocusEventHandler<HTMLInputElement>;
   size?: Values<typeof FormElementSize>;
 }
 
@@ -64,6 +66,8 @@ const TextInput2: React.FC<Props> = ({
   obscurable,
   value,
   onChange,
+  onFocus,
+  onBlur,
   size,
 }) => {
   const id = name;
@@ -135,8 +139,14 @@ const TextInput2: React.FC<Props> = ({
           placeholder={placeholder}
           disabled={requirement === FormElementRequirement.DISABLED}
           onChange={onChange}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
+          onFocus={(e) => {
+            setIsFocused(true);
+            if (onFocus) onFocus(e);
+          }}
+          onBlur={(e) => {
+            setIsFocused(false);
+            if (onBlur) onBlur(e);
+          }}
         />
         {errorMessage != null && (
           <FontAwesome className={cssClass.ERROR_ICON} name="exclamation-circle" />

--- a/src/TextInput2/TextInput2_test.tsx
+++ b/src/TextInput2/TextInput2_test.tsx
@@ -4,6 +4,16 @@ import { shallow } from "enzyme";
 import TextInput2, { cssClass } from "./TextInput2";
 
 describe("TextInput2", () => {
+  let defaultProps;
+  beforeEach(() => {
+    defaultProps = {
+      name: "",
+      label: "",
+      value: "",
+      onChange: jest.fn(),
+    };
+  });
+
   afterEach(() => {
     jest.resetAllMocks();
   });
@@ -44,15 +54,19 @@ describe("TextInput2", () => {
     expect(myComponent.props().className).toMatch("my--custom--class");
   });
 
-  // TODO: Test any relevant state changes/event handling/prop-driven rendering.
-  /*
-  it("propagates event", () => {
-    const myComponent = shallow(
-      <TextInput2 onPerformAction={onPerformActionMock}>Test Content</TextInput2>,
-    );
+  describe("event handling", () => {
+    it("executes onFocus prop if provided", () => {
+      defaultProps.onFocus = jest.fn();
+      const wrapper = shallow(<TextInput2 {...defaultProps} />);
+      wrapper.find("input").simulate("focus");
+      expect(defaultProps.onFocus).toHaveBeenCalled();
+    });
 
-    myComponent.find(Button).simulate("click");
-    expect(onPerformActionMock).toHaveBeenCalledWith("action performed");
+    it("executes onBlur prop if provided", () => {
+      defaultProps.onBlur = jest.fn();
+      const wrapper = shallow(<TextInput2 {...defaultProps} />);
+      wrapper.find("input").simulate("blur");
+      expect(defaultProps.onBlur).toHaveBeenCalled();
+    });
   });
-  */
 });


### PR DESCRIPTION
# Jira: [DISC-2827](https://clever.atlassian.net/browse/DISC-2827)

# Overview:

Adds optional `onFocus` and `onBlur` function props to `TextInput2`.

# Screenshots/GIFs:

# Testing:

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
