### PR TITLE
Don't read additional floating buttons from screenreader unless the button group is active

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.165.4",
+  "version": "2.165.5",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FloatingButton/FloatingButton.tsx
+++ b/src/FloatingButton/FloatingButton.tsx
@@ -1,16 +1,16 @@
-import * as _ from "lodash";
-import * as classnames from "classnames";
+import "./FloatingButton.less";
+
 import * as PropTypes from "prop-types";
 import * as React from "react";
 import * as RootCloseWrapper from "react-overlays/lib/RootCloseWrapper";
+import * as _ from "lodash";
+import * as classnames from "classnames";
 
 import { Button } from "../Button/Button";
 import FlexBox from "../flex/FlexBox";
 import { Icon } from "../Icon/Icon";
-import { breakpointS } from "../utils/Constants";
 import { Values } from "../utils/types";
-
-import "./FloatingButton.less";
+import { breakpointS } from "../utils/Constants";
 
 export interface Props {
   additionalButtons?: any[];
@@ -257,6 +257,7 @@ export default class FloatingButton extends React.PureComponent<Props, State> {
                   onClick={() => this.additionalButtonHandler(button)}
                   value={button.label}
                   size={size || Button.Size.M}
+                  aria-hidden={!active}
                 />
               </div>
             ))}


### PR DESCRIPTION
# Jira: [PRTL-1072](https://clever.atlassian.net/browse/PRTL-1072)
# Jira: [PRTL-1073](https://clever.atlassian.net/browse/PRTL-1073)

# Overview:
Previously, if a user navigated to a floating button but did not click to open it, it would still read out all its additional buttons on the screen reader. With this fix, the additional button options are only read when the floating button is active.

# Screenshots/GIFs:

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
