### PR TITLE
[a11y] Fix FileInput aria-label

### DIFF
--- a/docs/components/FileInputView.jsx
+++ b/docs/components/FileInputView.jsx
@@ -142,8 +142,7 @@ export default class FileInputView extends React.PureComponent {
             {
               name: "store",
               type: "Function",
-              description:
-                "Function to be called when the user has seleceted a file to be uploaded",
+              description: "Function to be called when the user has selected a file to be uploaded",
               defaultValue: "False",
             },
             {

--- a/docs/components/FileInputView.jsx
+++ b/docs/components/FileInputView.jsx
@@ -135,7 +135,8 @@ export default class FileInputView extends React.PureComponent {
             {
               name: "label",
               type: "String",
-              description: "Sets the label of the file input",
+              description:
+                "Sets the label of the file input. This prop is also used as part of the aria-label for accessibility",
               optional: true,
             },
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.165.5",
+  "version": "2.165.6",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FileInput/FileInput.tsx
+++ b/src/FileInput/FileInput.tsx
@@ -174,7 +174,7 @@ export class FileInput extends React.Component<Props, State> {
         multiple={false}
         onDropAccepted={this.onDropAccepted}
         onDropRejected={this.onDropRejected}
-        inputProps={{ "aria-label": `Upload ${this.props.label}` }}
+        inputProps={{ "aria-label": label ? `Upload ${label}` : "Upload" }}
       >
         {({ isDragActive, isDragReject }) => {
           let message = `Upload ${this.props.label}`;


### PR DESCRIPTION
# Jira: [TKT-000](https://clever.atlassian.net/browse/TKT-000)

# Overview:
In #750 we started setting `aria-label` on the internal `input` within `<FileInput>` using the `label` prop. This change better handles the case where `label` is not passed in to avoid setting the `aria-label` to be "Upload undefined". 

# Screenshots/GIFs:

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
