### PR TITLE
[M5G-867] fixes guardians sending attachment launch-blocking styling bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.165.6",
+  "version": "2.165.7",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AttachmentPreview/AttachmentPreview.less
+++ b/src/AttachmentPreview/AttachmentPreview.less
@@ -38,6 +38,7 @@
   padding: @size_ml @size_s @size_ml @size_l;
   .padding--left--l();
   filter: brightness(0) invert(1); /* makes the file icon white without needing a different <img> src attr */
+  box-sizing: content-box;
 }
 
 .AttachmentPreview--PreviewWindow {

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -300,6 +300,12 @@
   }
 
   // ⬇️ For family portal attachments we don't want the margins defined above ⬇️
+  .QuotedAnnouncementBubble--attachmentContainer
+    .MessagingAttachment--FamilyPortal
+    .MessagingAttachment--Container {
+    width: 100%;
+  }
+
   .NormalMessagingBubble--Message--Container--Own
     .MessagingAttachment--ParentContainer.MessagingAttachment--FamilyPortal
     .MessagingAttachment--Container {
@@ -311,12 +317,6 @@
     .MessagingAttachment--ParentContainer.MessagingAttachment--FamilyPortal
     .MessagingAttachment--Container {
     margin-right: 0;
-    width: 100%;
-  }
-
-  .QuotedAnnouncementBubble--attachmentContainer
-    .MessagingAttachment--FamilyPortal
-    .MessagingAttachment--Container {
     width: 100%;
   }
 

--- a/src/MessagingAttachment/MessagingAttachment.less
+++ b/src/MessagingAttachment/MessagingAttachment.less
@@ -299,6 +299,27 @@
     overflow: hidden;
   }
 
+  // ⬇️ For family portal attachments we don't want the margins defined above ⬇️
+  .NormalMessagingBubble--Message--Container--Own
+    .MessagingAttachment--ParentContainer.MessagingAttachment--FamilyPortal
+    .MessagingAttachment--Container {
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .NormalMessagingBubble--Message--Container--Other
+    .MessagingAttachment--ParentContainer.MessagingAttachment--FamilyPortal
+    .MessagingAttachment--Container {
+    margin-right: 0;
+    width: 100%;
+  }
+
+  .QuotedAnnouncementBubble--attachmentContainer
+    .MessagingAttachment--FamilyPortal
+    .MessagingAttachment--Container {
+    width: 100%;
+  }
+
   // ⬇️ In attachment-only messages, we don't want the margins defined above either ⬇️
   .NormalMessagingBubble--Message--Timestamp--Own
     + .NormalMessagingBubble--Message--Attachment--Own


### PR DESCRIPTION
# Jira: [M5G-867](https://clever.atlassian.net/browse/M5G-867)

# Overview:
This PR fixes two problems that need to be addressed prior to releasing the guardians sending attachments feature.

1. On mobile, the family portal attachments had an odd looking white gap at the edge of the attachment (on the left for sent attachments and the right for sent attachments)
2. In the attachment image preview overlay, the top bar was missing the image icon.


# Screenshots/GIFs:
## Attachment bug before

![image](https://user-images.githubusercontent.com/6520345/135369325-ab63c9d0-f307-4d4b-b7fc-3f7c7dec0f44.png)

![image](https://user-images.githubusercontent.com/6520345/135369502-8158ad8b-827a-4888-b72d-6ab5149b76e9.png)

![image](https://user-images.githubusercontent.com/6520345/135369334-ac91ac60-4d37-4dd9-bbca-3e0fd4eb26a8.png)

## Attachment bug after
![image](https://user-images.githubusercontent.com/6520345/135370067-ea30afa5-ce0e-4136-a0c7-d9ced68d576b.png)

![image](https://user-images.githubusercontent.com/6520345/135370107-f93fdc49-b018-4b1f-9f2f-2f5909fd9a13.png)

![image](https://user-images.githubusercontent.com/6520345/135370317-45ba9afd-e100-4d6c-b135-924b20929153.png)

## Missing topbar icon before
![image](https://user-images.githubusercontent.com/6520345/135370471-64c3d70d-150c-4b6f-af24-59063a06478a.png)

![image](https://user-images.githubusercontent.com/6520345/135370486-386c0546-bca5-46aa-ab2e-d56d7732e32a.png)

## Missing topbar icon after
![image](https://user-images.githubusercontent.com/6520345/135370564-2baf22ff-5b82-4e7d-b739-2bf293d500e5.png)

![image](https://user-images.githubusercontent.com/6520345/135370511-fe39144f-4989-44b6-8140-0651ac2d2210.png)




# Testing:
- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Chrome mobile emulator at a variety of screen sizes
  - [ ] Safari
  - [ ] IE11

# Roll Out:
- Before merging:
  - [x] Bumped version in `package.json`
