### PR TITLE
Use relative imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.167.0",
+  "version": "2.168.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/DeletedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/DeletedAnnouncementBubble.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as cx from "classnames";
 import * as FontAwesome from "react-fontawesome";
 import { FlexBox } from "../";
-import { MessagingTheme } from "src/utils/messaging";
+import { MessagingTheme } from "../utils/messaging";
 
 import "./DeletedAnnouncementBubble.less";
 

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -6,7 +6,7 @@ import Linkify from "react-linkify";
 import { FlexBox, Button, Menu, Tooltip } from "../";
 import { componentDecorator, matchDecorator } from "../MessagingBubble/linkifyUtils";
 import Checkmark from "../Checkbox/CheckMark";
-import { MessagingTheme } from "..//utils/messaging";
+import { MessagingTheme } from "../utils/messaging";
 
 import "./NormalAnnouncementBubble.less";
 

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -6,7 +6,7 @@ import Linkify from "react-linkify";
 import { FlexBox, Button, Menu, Tooltip } from "../";
 import { componentDecorator, matchDecorator } from "../MessagingBubble/linkifyUtils";
 import Checkmark from "../Checkbox/CheckMark";
-import { MessagingTheme } from "src/utils/messaging";
+import { MessagingTheme } from "..//utils/messaging";
 
 import "./NormalAnnouncementBubble.less";
 

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -7,7 +7,7 @@ import * as _ from "lodash";
 import { FlexBox, Button, Tooltip } from "../";
 import { formatDateForTimestamp } from "./NormalAnnouncementBubble";
 import { componentDecorator, matchDecorator } from "../MessagingBubble/linkifyUtils";
-import { MessagingTheme } from "src/utils/messaging";
+import { MessagingTheme } from "..//utils/messaging";
 
 import "./QuotedAnnouncementBubble.less";
 

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -7,7 +7,7 @@ import * as _ from "lodash";
 import { FlexBox, Button, Tooltip } from "../";
 import { formatDateForTimestamp } from "./NormalAnnouncementBubble";
 import { componentDecorator, matchDecorator } from "../MessagingBubble/linkifyUtils";
-import { MessagingTheme } from "..//utils/messaging";
+import { MessagingTheme } from "../utils/messaging";
 
 import "./QuotedAnnouncementBubble.less";
 

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -5,7 +5,7 @@ import * as cx from "classnames";
 import { AttachmentPreview } from "../AttachmentPreview";
 import { FlexBox } from "../flex";
 import KeyCode from "../utils/KeyCode";
-import { MessagingTheme } from "..//utils/messaging";
+import { MessagingTheme } from "../utils/messaging";
 
 import "./MessagingAttachment.less";
 

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -5,7 +5,7 @@ import * as cx from "classnames";
 import { AttachmentPreview } from "../AttachmentPreview";
 import { FlexBox } from "../flex";
 import KeyCode from "../utils/KeyCode";
-import { MessagingTheme } from "src/utils/messaging";
+import { MessagingTheme } from "..//utils/messaging";
 
 import "./MessagingAttachment.less";
 

--- a/src/MessagingBubble/DeletedMessagingBubble.tsx
+++ b/src/MessagingBubble/DeletedMessagingBubble.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as cx from "classnames";
 import * as FontAwesome from "react-fontawesome";
 import { FlexBox } from "../";
-import { MessagingTheme } from "src/utils/messaging";
+import { MessagingTheme } from "..//utils/messaging";
 
 import "./DeletedMessagingBubble.less";
 

--- a/src/MessagingBubble/DeletedMessagingBubble.tsx
+++ b/src/MessagingBubble/DeletedMessagingBubble.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as cx from "classnames";
 import * as FontAwesome from "react-fontawesome";
 import { FlexBox } from "../";
-import { MessagingTheme } from "..//utils/messaging";
+import { MessagingTheme } from "../utils/messaging";
 
 import "./DeletedMessagingBubble.less";
 

--- a/src/MessagingBubble/NormalMessagingBubble.tsx
+++ b/src/MessagingBubble/NormalMessagingBubble.tsx
@@ -3,7 +3,7 @@ import * as moment from "moment";
 import Linkify from "react-linkify";
 import * as cx from "classnames";
 import { Button, FlexBox } from "..";
-import { MessagingTheme } from "..//utils/messaging";
+import { MessagingTheme } from "../utils/messaging";
 import { matchDecorator, componentDecorator } from "./linkifyUtils";
 
 import "./NormalMessagingBubble.less";

--- a/src/MessagingBubble/NormalMessagingBubble.tsx
+++ b/src/MessagingBubble/NormalMessagingBubble.tsx
@@ -3,7 +3,7 @@ import * as moment from "moment";
 import Linkify from "react-linkify";
 import * as cx from "classnames";
 import { Button, FlexBox } from "..";
-import { MessagingTheme } from "src/utils/messaging";
+import { MessagingTheme } from "..//utils/messaging";
 import { matchDecorator, componentDecorator } from "./linkifyUtils";
 
 import "./NormalMessagingBubble.less";

--- a/src/TextInput2/TextInput2.tsx
+++ b/src/TextInput2/TextInput2.tsx
@@ -24,7 +24,7 @@ export interface Props {
   // returns an error message, null for no error
   errorValidation?: (value: string) => string | null;
   value: string;
-  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
   onFocus?: React.FocusEventHandler<HTMLInputElement>;
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
   size?: Values<typeof FormElementSize>;


### PR DESCRIPTION
# Overview:
Updating imports of `src/utils/messaging` to relative imports since absolute imports in the built type declaration files aren't resolving properly. I'm not too sure how to make absolute imports work here in the type declaration files so I'm just changing these to relative imports instead

# Screenshots/GIFs:
before:
![Image 2021-10-06 at 10 56 46 AM](https://user-images.githubusercontent.com/6362897/136257718-10e95274-c8ad-4a23-b557-c17562cbac8f.jpg)

after:
![Image 2021-10-06 at 10 56 55 AM](https://user-images.githubusercontent.com/6362897/136257708-d26caf59-abc1-4a7b-980a-8d8762691acb.jpg)



# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
