### PR TITLE
Add Aria Role to Select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.168.1",
+  "version": "2.168.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -219,7 +219,10 @@ export class Select extends React.Component<Props, State> {
     // The label container must be returned after the ReactSelect otherwise it does not get displayed
     // in the browser.
     return (
-      <div className={classnames(cssClass.CONTAINER, formElementSizeClassName(size), wrapperClass)}>
+      <div
+        className={classnames(cssClass.CONTAINER, formElementSizeClassName(size), wrapperClass)}
+        role="listbox"
+      >
         <div id={id}>
           <SelectComponent
             className={reactSelectClasses}

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -219,10 +219,7 @@ export class Select extends React.Component<Props, State> {
     // The label container must be returned after the ReactSelect otherwise it does not get displayed
     // in the browser.
     return (
-      <div
-        className={classnames(cssClass.CONTAINER, formElementSizeClassName(size), wrapperClass)}
-        role="listbox"
-      >
+      <div className={classnames(cssClass.CONTAINER, formElementSizeClassName(size), wrapperClass)}>
         <div id={id}>
           <SelectComponent
             className={reactSelectClasses}
@@ -244,6 +241,7 @@ export class Select extends React.Component<Props, State> {
             noResultsText={noResultsText}
             closeOnSelect={closeMenuOnSelect}
             value={value}
+            role="listbox"
             {...overrideProps}
           />
         </div>


### PR DESCRIPTION
# Jira: 

[PRTL-951](https://clever.atlassian.net/browse/PRTL-951)

# Overview:

The Select component gets an aria role!

# Screenshots/GIFs:

# Testing:

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
