### PR TITLE
[Select2] Support custom options

### DIFF
--- a/docs/components/Select2View.jsx
+++ b/docs/components/Select2View.jsx
@@ -28,6 +28,7 @@ export default class Select2View extends React.PureComponent {
     label: "Select an option",
     hideLabel: false,
     clearable: true,
+    creatable: false,
     requirement: FormElementRequirement.REQUIRED,
     initialIsInError: false,
     value: null,
@@ -74,6 +75,7 @@ export default class Select2View extends React.PureComponent {
                 value: `option_${i + 1}_value`,
               }))}
               clearable={this.state.clearable}
+              creatable={this.state.creatable}
               requirement={this.state.requirement}
               initialIsInError={this.state.initialIsInError}
               onChange={(v) => {
@@ -93,7 +95,16 @@ export default class Select2View extends React.PureComponent {
   }
 
   _renderConfig() {
-    const { label, value, hideLabel, clearable, requirement, initialIsInError, size } = this.state;
+    const {
+      label,
+      value,
+      hideLabel,
+      clearable,
+      creatable,
+      requirement,
+      initialIsInError,
+      size,
+    } = this.state;
 
     return (
       <FlexBox alignItems={ItemAlign.CENTER} className={cssClass.CONFIG_CONTAINER} wrap>
@@ -138,6 +149,15 @@ export default class Select2View extends React.PureComponent {
             onChange={(e) => this.setState({ clearable: e.target.checked })}
           />{" "}
           <span className={cssClass.CONFIG_LABEL_TEXT}>Clearable</span>
+        </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            checked={creatable}
+            className={cssClass.CONFIG_TOGGLE}
+            onChange={(e) => this.setState({ creatable: e.target.checked })}
+          />{" "}
+          <span className={cssClass.CONFIG_LABEL_TEXT}>Creatable</span>
         </label>
         <div className={cssClass.CONFIG}>
           <span className={cssClass.CONFIG_TEXT}>Requirement:</span>
@@ -237,6 +257,13 @@ export default class Select2View extends React.PureComponent {
             optional: true,
           },
           {
+            name: "creatable",
+            type: "boolean",
+            description:
+              "If new options are allowed to be created (if input text does not match any existing options)",
+            optional: true,
+          },
+          {
             name: "requirement",
             type: '"required", "optional", or "disabled"',
             description: "Indicator to note if the input is required",
@@ -245,7 +272,7 @@ export default class Select2View extends React.PureComponent {
           {
             name: "initialIsInError",
             type: "boolean",
-            description: "Intialize the component in an error state",
+            description: "Initialize the component in an error state",
             optional: true,
           },
           {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.169.0",
+  "version": "2.170.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select2/Select2.tsx
+++ b/src/Select2/Select2.tsx
@@ -71,7 +71,7 @@ const Select2: React.FC<Props> = ({
 }) => {
   const [selectableOptions, setSelectableOptions] = useState(options);
 
-  // handle inital error state via focus state since
+  // handle initial error state via focus state since
   // hooks can't combine the downshift state well with component hook state
   const [hasBeenFocused, setHasBeenFocused] = useState(false);
   useEffect(() => {


### PR DESCRIPTION
# Jira:
https://clever.atlassian.net/browse/prtl-997
https://clever.atlassian.net/browse/prtl-998

# Overview:
There are several open accessibility issues with the old `Select` component. I tried fixing one of the labeling issues but I had some trouble getting the screen reader to recognize the attached label. As an alternative, I want to try swapping those instances of `Select` with `Select2` since the latter does not have the same labeling issue, and is where we want to go design-wise anyway. The `Select` instances that I want to upgrade to `Select2` are using the `creatable` prop which allows users to specify a custom option. This pull request implements the` creatable` mode for `Select2`. I discussed this with the design team, and they're on board.

# Screenshots/GIFs:
https://www.loom.com/share/b1446c99e8174780b0589d49c7f23c1e

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
