### PR TITLE
[MOC-175] fixes MessagingInput so enter key doesn't send when input should be disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.171.0",
+  "version": "2.171.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -158,9 +158,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
               //  explicitly set to have enter be a newline.
               if (e.key === KeyCode.ENTER && !e.shiftKey && !newlineOnEnter) {
                 e.preventDefault();
-                // If something other than whitespace is in the input area,
-                // or if there is at least one attachment, send the message.
-                if (value.trim() !== "" || attachmentsArePresent) {
+                if (!isMessageSendDisabled(disableSendButton, value, attachments)) {
                   onSubmit(value.trim());
                 }
               }
@@ -197,7 +195,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
               <span className={cssClass("SendText")}>{sendButtonText}</span>
             </FlexBox>
           }
-          disabled={isSendButtonDisabled(disableSendButton, value, attachments)}
+          disabled={isMessageSendDisabled(disableSendButton, value, attachments)}
           onClick={() => onSubmit(value.trim())}
           ariaLabel={sendButtonText}
         />
@@ -207,11 +205,12 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
   );
 };
 
-function isSendButtonDisabled(
+function isMessageSendDisabled(
   disableSendButton: boolean,
   value: string,
   attachments: React.ReactNode[],
 ) {
+  // disableSendButton boolean handles the case of unsendable invalid attachments
   if (disableSendButton) {
     return true;
   } else if (value.trim() === "" && (!attachments || attachments.length === 0)) {


### PR DESCRIPTION
# Jira: [MOC-175](https://clever.atlassian.net/browse/MOC-175)

# Overview:
This PR fixes an issue that was allowing teachers and guardians to send messages when there was an erroring attachment in the `MessagingInput`. While the send button was disabled, the enter key was still able to submit a message.

Now, the `onKeyDown` event listener uses the same function (now called `isMessageSendDisabled`) which checks `disableSendButton`, the prop that invalid attachments update.

Note: Ideally we'd change the name of `disableSendButton` to indicate that the boolean disables all submissions and not just the send **button**, but it seems unnecessary to push a breaking change for such a small fix.

# Screenshots/GIFs:
## Family portal before
https://user-images.githubusercontent.com/6520345/137822026-2f53420a-a224-42de-903d-e575eeb954b4.mov

## Launchpad before
https://user-images.githubusercontent.com/6520345/137822013-c02e4cce-5cea-41da-85d4-3880d82d5f1e.mov


# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
