### PR TITLE
Toasts now announce their messages when appearing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.171.1",
+  "version": "2.171.2",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ToastStack/ToastNotification.tsx
+++ b/src/ToastStack/ToastNotification.tsx
@@ -70,7 +70,7 @@ export class ToastNotification extends React.PureComponent<Props> {
         alignItems={ItemAlign.CENTER}
       >
         <FontAwesome name={iconMap[type]} size="lg" spin={type === ToastType.PROCESSING} />
-        <FlexBox className={cssClass.CONTENT} grow>
+        <FlexBox className={cssClass.CONTENT} grow aria-live="polite">
           {children}
         </FlexBox>
         {action && (


### PR DESCRIPTION
# Jira: [PRTL-1135](https://clever.atlassian.net/browse/PRTL-1135)

# Overview:

With this nifty little change, toast announcements are read out by screen readers! 

# Screenshots/GIFs:

# Testing:

Tested locally with screen reader. 

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
