### PR TITLE
[M5G-851] Hovercrafts can now land on tooltips

### DIFF
--- a/docs/components/TooltipView.jsx
+++ b/docs/components/TooltipView.jsx
@@ -43,6 +43,19 @@ export default class TooltipView extends Component {
                 </Tooltip>
               </div>
               <div className={cssClass.EXAMPLE}>
+                500ms delay in and out{" "}
+                <Tooltip
+                  content="Here is a simple tooltip with transitions in and out delayed by 500ms."
+                  placement={placement}
+                  textAlign={textAlign}
+                  hide={disabled}
+                  delayMs={500}
+                  delayHideMs={500}
+                >
+                  <FontAwesome className={cssClass.TRIGGER} name="question-circle" />
+                </Tooltip>
+              </div>
+              <div className={cssClass.EXAMPLE}>
                 HTML + long text{" "}
                 <Tooltip
                   content={

--- a/docs/components/TooltipView.jsx
+++ b/docs/components/TooltipView.jsx
@@ -7,7 +7,7 @@ import FontAwesome from "react-fontawesome";
 import Example, { ExampleCode } from "./Example";
 import PropDocumentation from "./PropDocumentation";
 import View from "./View";
-import { Button, SegmentedControl, Tooltip } from "src";
+import { SegmentedControl, Tooltip } from "src";
 
 import "./TooltipView.less";
 
@@ -18,12 +18,13 @@ export default class TooltipView extends Component {
     this.state = {
       placement: Tooltip.Placement.RIGHT,
       textAlign: Tooltip.Align.LEFT,
+      disabled: false,
     };
   }
 
   render() {
     const { cssClass } = TooltipView;
-    const { placement, textAlign } = this.state;
+    const { placement, textAlign, disabled } = this.state;
 
     return (
       <View className={cssClass.CONTAINER} title="Tooltip" sourcePath="src/Tooltip/Tooltip.tsx">
@@ -36,6 +37,7 @@ export default class TooltipView extends Component {
                   content="Here is a simple tooltip."
                   placement={placement}
                   textAlign={textAlign}
+                  hide={disabled}
                 >
                   <FontAwesome className={cssClass.TRIGGER} name="question-circle" />
                 </Tooltip>
@@ -53,6 +55,7 @@ export default class TooltipView extends Component {
                   }
                   placement={placement}
                   textAlign={textAlign}
+                  hide={disabled}
                 >
                   <FontAwesome className={cssClass.TRIGGER} name="question-circle" />
                 </Tooltip>
@@ -63,6 +66,7 @@ export default class TooltipView extends Component {
                   content="Tooltips triggered by clicks stay open."
                   placement={placement}
                   textAlign={textAlign}
+                  hide={disabled}
                   clickTrigger
                 >
                   <FontAwesome className={cssClass.TRIGGER} name="question-circle" />
@@ -88,6 +92,15 @@ export default class TooltipView extends Component {
               options={_.map(Tooltip.Align, (p) => ({ content: p, value: p }))}
             />
           </div>
+          <label className={cssClass.CONFIG}>
+            <input
+              type="checkbox"
+              checked={disabled}
+              className={cssClass.CONFIG_TOGGLE}
+              onChange={(e) => this.setState({ disabled: e.target.checked })}
+            />{" "}
+            Disabled
+          </label>
           <div className={cssClass.ACCESSIBILITY_NOTICE}>
             For accessibility reasons, all tooltips are also triggered by focus. Press the tab key
             to move focus throughout the page.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.172.3",
+  "version": "2.173.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -209,7 +209,6 @@ button.NormalAnnouncementBubble--deleteMenuItem {
 }
 
 .NormalAnnouncementBubble--readReceipts--tooltip {
-  cursor: pointer;
   .text--semi-bold();
   padding-right: @size_2xs;
   padding-left: @size_2xs;

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -1,9 +1,10 @@
 import * as _ from "lodash";
 
-import * as classnames from "classnames";
+import * as React from "react";
 import * as BootstrapTooltip from "react-bootstrap/lib/Tooltip";
 import * as Overlay from "react-bootstrap/lib/Overlay";
-import * as React from "react";
+import * as RootCloseWrapper from "react-overlays/lib/RootCloseWrapper";
+import * as classnames from "classnames";
 import * as PropTypes from "prop-types";
 
 import { Values } from "../utils/types";
@@ -133,27 +134,29 @@ export default class Tooltip extends React.Component<Props, State> {
     const child = React.Children.only(children);
 
     return (
-      <>
-        {React.cloneElement(child, {
-          ref: this.tooltipTarget,
-          tabIndex: 0,
-          "aria-describedby": this.id,
-          className: cssClass.FOCUSABLE_TRIGGER,
-          onFocus: handleShowTooltip,
-          onBlur: handleHideTooltip,
-          onMouseEnter: handleMouseEnter,
-          onMouseLeave: handleMouseLeave,
-          onMouseDown: !clickTrigger || hide ? undefined : handleOnClick,
-          ...child.props,
-        })}
-        <Overlay
-          target={this.tooltipTarget.current}
-          show={this.state.showTooltip}
-          placement={placement}
-        >
-          {tooltip}
-        </Overlay>
-      </>
+      <RootCloseWrapper onRootClose={handleHideTooltip}>
+        <>
+          {React.cloneElement(child, {
+            ref: this.tooltipTarget,
+            tabIndex: 0,
+            "aria-describedby": this.id,
+            className: cssClass.FOCUSABLE_TRIGGER,
+            onFocus: handleShowTooltip,
+            onBlur: handleHideTooltip,
+            onMouseEnter: handleMouseEnter,
+            onMouseLeave: handleMouseLeave,
+            onMouseDown: !clickTrigger || hide ? undefined : handleOnClick,
+            ...child.props,
+          })}
+          <Overlay
+            target={this.tooltipTarget.current}
+            show={this.state.showTooltip}
+            placement={placement}
+          >
+            {tooltip}
+          </Overlay>
+        </>
+      </RootCloseWrapper>
     );
   }
 }

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -64,7 +64,6 @@ const defaultProps = {
 
 export const cssClass = {
   CONTENT: "Tooltip--content",
-  FOCUSABLE_TRIGGER: "Tooltip--focusable-trigger",
   align: (textAlign) => `Tooltip--content--${textAlign}`,
 };
 
@@ -140,7 +139,6 @@ export default class Tooltip extends React.Component<Props, State> {
             ref: this.tooltipTarget,
             tabIndex: 0,
             "aria-describedby": this.id,
-            className: cssClass.FOCUSABLE_TRIGGER,
             onFocus: handleShowTooltip,
             onBlur: handleHideTooltip,
             onMouseEnter: handleMouseEnter,

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -115,7 +115,17 @@ export default class Tooltip extends React.Component<Props, State> {
     };
     const handleMouseEnter = clickTrigger ? undefined : handleShowTooltip;
     const handleMouseLeave = clickTrigger ? undefined : handleHideTooltip;
-    const handleOnClick = this.state.showTooltip ? handleHideTooltip : handleShowTooltip;
+    const handleOnClick = () => {
+      if (!clickTrigger || hide) {
+        // Nothing should happen on click if clickTrigger is not set or if the tooltip is disabled
+        return;
+      }
+      if (this.state.showTooltip) {
+        handleHideTooltip();
+      } else {
+        handleShowTooltip();
+      }
+    };
 
     const tooltip = (
       <BootstrapTooltip
@@ -143,7 +153,7 @@ export default class Tooltip extends React.Component<Props, State> {
             onBlur: handleHideTooltip,
             onMouseEnter: handleMouseEnter,
             onMouseLeave: handleMouseLeave,
-            onMouseDown: !clickTrigger || hide ? undefined : handleOnClick,
+            onMouseDown: handleOnClick,
             ...child.props,
           })}
           <Overlay

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -113,14 +113,16 @@ export default class Tooltip extends React.Component<Props, State> {
       if (hide) return;
       setTimeout(() => this.setState({ showTooltip: false }), delayHideMs);
     };
+    const handleMouseEnter = clickTrigger ? undefined : handleShowTooltip;
+    const handleMouseLeave = clickTrigger ? undefined : handleHideTooltip;
     const handleOnClick = this.state.showTooltip ? handleHideTooltip : handleShowTooltip;
 
     const tooltip = (
       <BootstrapTooltip
         id={this.id}
         className={tooltipClassName}
-        onMouseEnter={handleShowTooltip}
-        onMouseLeave={handleHideTooltip}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
         <div className={classnames(cssClass.CONTENT, cssClass.align(textAlign), className)}>
           {content}
@@ -139,17 +141,15 @@ export default class Tooltip extends React.Component<Props, State> {
           className: cssClass.FOCUSABLE_TRIGGER,
           onFocus: handleShowTooltip,
           onBlur: handleHideTooltip,
-          onMouseEnter: clickTrigger ? undefined : handleShowTooltip,
-          onMouseLeave: clickTrigger ? undefined : handleHideTooltip,
+          onMouseEnter: handleMouseEnter,
+          onMouseLeave: handleMouseLeave,
           onMouseDown: !clickTrigger || hide ? undefined : handleOnClick,
           ...child.props,
         })}
         <Overlay
           target={this.tooltipTarget.current}
-          onHide={handleHideTooltip}
           show={this.state.showTooltip}
           placement={placement}
-          rootClose
         >
           {tooltip}
         </Overlay>


### PR DESCRIPTION
# Jira: 
https://clever.atlassian.net/browse/M5G-851

# Overview:
In order to be accessible, tooltips should be hoverable and escape-able. Tooltips were previously not hoverable since the tooltip would disappear before the mouse can be moved to it. This PR fixes that which required some changes internally (mainly, we can't use OverlayTrigger anymore since we need to more manually control `show` of the tooltip).

# Screenshots/GIFs:

Before: 


https://user-images.githubusercontent.com/35714960/142266346-6e7166cf-98e3-4a09-9bec-cda3a1f38f60.mov


After:


https://user-images.githubusercontent.com/35714960/142266390-375b390e-6638-43f7-9c97-2ea2d45fa46f.mov



# Testing:

- Checked other places that Tooltip is used in components
- Checked new Tooltip in launchpad use case on actual a11y ticket
- Checked Tooltip in a few other use cases in launchpad
- Tested on 3 browsers
- Tested keyboard a11y
- Tested disabled state

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
