### PR TITLE
[PRTL-1689] (passion week) update react transition dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.174.0",
+  "version": "2.175.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-responsive": "^8.0.3",
     "react-select": "~1.2.1",
     "react-sticky": "^6.0.1",
-    "react-transition-group": "~1.2.0",
+    "react-transition-group": "^4.4.2",
     "short-number": "^1.0.6",
     "tether": "^1.4.0"
   },

--- a/src/LeftNav/LeftNav.tsx
+++ b/src/LeftNav/LeftNav.tsx
@@ -153,10 +153,10 @@ export class LeftNav extends React.PureComponent<Props, State> {
           >
             {openChild && (
               <div className={cssClass.SUBNAV_CONTENT}>
-                {openChild.props.children.map((child) => {
+                {React.Children.map(openChild.props.children, (child) => {
+                  // ^ cannot use normal array map, because open.props.children may be an array or a single react element
                   return (
                     <CSSTransition
-                      classNames={cssClass.SUBNAV_CONTENT_ANIM}
                       className={cssClass.SUBNAV_CONTENT_ANIM}
                       timeout={{
                         enter: WIDTH_TRANSITION_DURATION_MS,

--- a/src/LeftNav/LeftNav.tsx
+++ b/src/LeftNav/LeftNav.tsx
@@ -2,7 +2,7 @@ import * as PropTypes from "prop-types";
 import * as React from "react";
 import * as _ from "lodash";
 import * as classnames from "classnames";
-import { CSSTransitionGroup } from "react-transition-group";
+import { TransitionGroup, CSSTransition } from "react-transition-group";
 import * as RootCloseWrapper from "react-overlays/lib/RootCloseWrapper";
 
 import MorePropTypes from "../utils/MorePropTypes";
@@ -146,15 +146,30 @@ export class LeftNav extends React.PureComponent<Props, State> {
           <div className={classnames(cssClass.TOPNAV, _collapsed && cssClass.TOPNAV_COLLAPSED)}>
             {navItems}
           </div>
-          <CSSTransitionGroup
+          <TransitionGroup
             className={classnames(cssClass.SUBNAV, openChild && cssClass.SUBNAV_OPEN)}
-            transitionEnterTimeout={WIDTH_TRANSITION_DURATION_MS}
-            transitionLeaveTimeout={WIDTH_TRANSITION_DURATION_MS}
             component="div"
             transitionName={cssClass.SUBNAV_CONTENT_ANIM}
           >
-            {openChild && <div className={cssClass.SUBNAV_CONTENT}>{openChild.props.children}</div>}
-          </CSSTransitionGroup>
+            {openChild && (
+              <div className={cssClass.SUBNAV_CONTENT}>
+                {openChild.props.children.map((child) => {
+                  return (
+                    <CSSTransition
+                      classNames={cssClass.SUBNAV_CONTENT_ANIM}
+                      className={cssClass.SUBNAV_CONTENT_ANIM}
+                      timeout={{
+                        enter: WIDTH_TRANSITION_DURATION_MS,
+                        exit: WIDTH_TRANSITION_DURATION_MS,
+                      }}
+                    >
+                      {child}
+                    </CSSTransition>
+                  );
+                })}
+              </div>
+            )}
+          </TransitionGroup>
         </nav>
       </RootCloseWrapper>
     );

--- a/src/ToastStack/ToastStack.tsx
+++ b/src/ToastStack/ToastStack.tsx
@@ -1,7 +1,7 @@
 import * as classnames from "classnames";
 import * as React from "react";
 import * as _ from "lodash";
-import { CSSTransitionGroup } from "react-transition-group";
+import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { ToastNotification } from "./ToastNotification";
 
 import { ActionProps } from "./ToastNotification";
@@ -79,7 +79,15 @@ export class ToastStack extends React.PureComponent<Props> {
     const { className, clearNotification, notificationClassName, notifications } = this.props;
 
     const toasts = notifications.map((n) => (
-      <div className={cssClass.NOTIFICATION_WRAPPER} key={n.id}>
+      <CSSTransition
+        timeout={{
+          enter: 200,
+          exit: 400,
+        }}
+        classNames={cssClass.ANIMATION}
+        className={cssClass.NOTIFICATION_WRAPPER}
+        key={n.id}
+      >
         <ToastNotification
           action={n.action}
           className={notificationClassName}
@@ -90,18 +98,13 @@ export class ToastStack extends React.PureComponent<Props> {
         >
           {n.content}
         </ToastNotification>
-      </div>
+      </CSSTransition>
     ));
 
     return (
-      <CSSTransitionGroup
-        className={classnames(cssClass.CONTAINER, className)}
-        transitionName={cssClass.ANIMATION}
-        transitionEnterTimeout={200}
-        transitionLeaveTimeout={400}
-      >
+      <TransitionGroup className={classnames(cssClass.CONTAINER, className)}>
         {toasts}
-      </CSSTransitionGroup>
+      </TransitionGroup>
     );
   }
 }

--- a/test/LeftNav_test.tsx
+++ b/test/LeftNav_test.tsx
@@ -84,8 +84,8 @@ describe("LeftNav", function LeftNavTest() {
       const subnav = nav.find(`.${navCss.SUBNAV_CONTENT}`);
       assert(subnav.exists());
       assert.equal(subnav.children().length, 2);
-      assert.equal(subnav.childAt(0).prop("label"), "subLink11");
-      assert.equal(subnav.childAt(1).prop("label"), "subLink12");
+      assert.equal(subnav.childAt(0).childAt(0).prop("label"), "subLink11");
+      assert.equal(subnav.childAt(1).childAt(0).prop("label"), "subLink12");
     });
   });
 
@@ -131,8 +131,8 @@ describe("LeftNav", function LeftNavTest() {
       const subnav = this.nav.find(`.${navCss.SUBNAV_CONTENT}`);
       assert(subnav.exists());
       assert.equal(subnav.children().length, 2);
-      assert.equal(subnav.childAt(0).prop("label"), "subLink21");
-      assert.equal(subnav.childAt(1).prop("label"), "subLink22");
+      assert.equal(subnav.childAt(0).childAt(0).prop("label"), "subLink21");
+      assert.equal(subnav.childAt(1).childAt(0).prop("label"), "subLink22");
     });
   });
 
@@ -168,7 +168,7 @@ describe("LeftNav", function LeftNavTest() {
       const subnav = this.nav.find(`.${navCss.SUBNAV_CONTENT}`);
       assert(subnav.exists());
       assert.equal(subnav.children().length, 1);
-      assert.equal(subnav.childAt(0).prop("label"), "subLink11");
+      assert.equal(subnav.childAt(0).childAt(0).prop("label"), "subLink11");
     });
 
     it("renders the NavLink with the 'selected' class", () => {
@@ -184,7 +184,7 @@ describe("LeftNav", function LeftNavTest() {
       const subnav = this.nav.find(`.${navCss.SUBNAV_CONTENT}`);
       assert(subnav.exists());
       assert.equal(subnav.children().length, 1);
-      assert.equal(subnav.childAt(0).prop("label"), "subLink21");
+      assert.equal(subnav.childAt(0).childAt(0).prop("label"), "subLink21");
     });
   });
 


### PR DESCRIPTION
# Jira: [PTRL-1689](https://clever.atlassian.net/browse/PRTL-1689)

# Overview:
As a part of adding `jest` to `launchpad`, we need the `react-transition-group` dependency to be up to date. I have followed [the `react-transition-group` v1 --> v2 migration guide](https://github.com/reactjs/react-transition-group/blob/HEAD/Migration.md) to update the two components that use this transition package.

# Screenshots/GIFs:

# Testing:

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] IE11

To test manually, pull down this branch and run `make dev-server` to serve the changes up on `localhost:5010`. Open the [prod version](https://clever.github.io/components/) to compare functionality:
- [x] LeftNav behaves the same on [local](http://localhost:5010/#/components/left-nav) as in [prod](https://clever.github.io/components/#/components/left-nav)
- [x] ToastStack behaves the same on [local](http://localhost:5010/#/components/toast-stack) as in [prod](https://clever.github.io/components/#/components/toast-stack)

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
