### PR TITLE
add selectable header customization props

### DIFF
--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -199,6 +199,7 @@ export default class Table2BetaView extends React.PureComponent {
                     plural: !!this.state.tableFilter ? `${this.state.tableFilter}s` : "",
                   }}
                   selectedRowsHeaderActions={sampleActionInputs}
+                  selectedRowsColumnName="Select all"
                 >
                   <Table2Beta.Column
                     id="details"

--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -524,16 +524,14 @@ export default class Table2BetaView extends React.PureComponent {
             {
               name: "disableSelectedRowsHeader",
               type: "boolean",
-              description:
-                "Allows for disabling the selected row action header",
+              description: "Allows for disabling the selected row action header",
               optional: true,
               defaultValue: "false",
             },
             {
               name: "selectedRowsColumnName",
               type: "string",
-              description:
-                "Allows for a custom column name for the selection column",
+              description: "Allows for a custom column name for the selection column",
               optional: true,
               defaultValue: "",
             },

--- a/docs/components/Table2BetaView.jsx
+++ b/docs/components/Table2BetaView.jsx
@@ -522,6 +522,22 @@ export default class Table2BetaView extends React.PureComponent {
               defaultValue: "None",
             },
             {
+              name: "disableSelectedRowsHeader",
+              type: "boolean",
+              description:
+                "Allows for disabling the selected row action header",
+              optional: true,
+              defaultValue: "false",
+            },
+            {
+              name: "selectedRowsColumnName",
+              type: "string",
+              description:
+                "Allows for a custom column name for the selection column",
+              optional: true,
+              defaultValue: "",
+            },
+            {
               name: "numDisplayedActions",
               type: "number",
               description:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.177.0",
+  "version": "2.178.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table2Beta/Table.less
+++ b/src/Table2Beta/Table.less
@@ -132,3 +132,7 @@
 .Table2Beta--action--menu--item--title {
   line-height: 1.5rem;
 }
+
+.Table2Beta--Checkbox--Header {
+  white-space: nowrap;
+}

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -70,6 +70,8 @@ export interface Props {
   selectedRowsHeaderContentType?: { singular: string; plural?: string };
   selectedRowsHeaderContentTypeNoSelection?: string;
   selectedRowsHeaderActions?: Array<ActionInput>;
+  disableSelectedRowsHeader?: boolean;
+  selectedRowsColumnName?: string;
   numDisplayedActions?: number;
 
   // These must be all set together. TODO: enforce that
@@ -159,6 +161,7 @@ export const cssClass = {
   ACTION_MENU_ITEM: "Table2Beta--actions--menu--item",
   ACTION_MENU_ITEM_TITLE: "Table2Beta--actions--menu--item--title",
   TABLE: "Table2Beta",
+  CHECKBOX_HEADER: "Table2Beta--Checkbox--Header",
 };
 
 export class Table2Beta extends React.Component<Props, State> {
@@ -543,6 +546,8 @@ export class Table2Beta extends React.Component<Props, State> {
       selectedRowsHeaderContentType,
       selectedRowsHeaderContentTypeNoSelection,
       selectedRowsHeaderActions,
+      disableSelectedRowsHeader,
+      selectedRowsColumnName,
     } = this.props;
     const { lazy, numRows } = this.props;
     const { currentPage, sortState, pageLoading, allLoaded } = this.state;
@@ -572,7 +577,7 @@ export class Table2Beta extends React.Component<Props, State> {
 
     return (
       <>
-        {selectable && (
+        {selectable && !disableSelectedRowsHeader && (
           <SelectedRowsHeader
             className={className}
             selectedRows={selectedRows}
@@ -602,8 +607,9 @@ export class Table2Beta extends React.Component<Props, State> {
                       this.setState({ selectedRows });
                     }}
                     disabled={displayedData.length === 0}
+                    className={cssClass.CHECKBOX_HEADER}
                   >
-                    {""}
+                    {selectedRowsColumnName}
                   </Checkbox>
                 </HeaderCell>
               )}


### PR DESCRIPTION
# Jira: [SHAPI-211](https://clever.atlassian.net/browse/SHAPI-211)

# Overview:
Adding two new props that allow for explicitly disabling the selectable row action header and making the column header text for the checkboxes customizable (so we can include text like `Select all`). Both changes are backwards compatible, so not expecting any major impact.

# Screenshots/GIFs:
![Screen Shot 2022-04-28 at 11 45 41 AM](https://user-images.githubusercontent.com/29630673/165826370-d69840d3-cc39-4adf-b005-6ceb8b88b426.png)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
