### PR TITLE
Pre-select rows in Table2 and announcement bubble fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.178.0",
+  "version": "2.179.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/UnavailableAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/UnavailableAnnouncementBubble.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import * as cx from "classnames";
 import { FlexBox } from "../";
-
+const darkColorThemeIcon = require("./megaphone-slash-darkColorTheme.svg");
+const lightColorThemeIcon = require("./megaphone-slash-lightColorTheme.svg");
 import "./UnavailableAnnouncementBubble.less";
 
 type ColorTheme = "white" | "light" | "dark";
@@ -35,10 +36,7 @@ export const UnavailableAnnouncementBubble: React.FC<Props> = ({
   unavailableNoticeText,
 }: Props) => {
   // The light colorTheme icon is reused for the white colorTheme as well.
-  const iconName =
-    colorTheme === "dark"
-      ? "megaphone-slash-darkColorTheme.svg"
-      : "megaphone-slash-lightColorTheme.svg";
+  const icon = colorTheme === "dark" ? darkColorThemeIcon : lightColorThemeIcon;
 
   return (
     <FlexBox
@@ -47,7 +45,7 @@ export const UnavailableAnnouncementBubble: React.FC<Props> = ({
       justify="start"
       className={cx(cssClassWithColorTheme("container", colorTheme), className)}
     >
-      <img alt="" className={cssClass("icon")} src={require(`./${iconName}`)} />
+      <img alt="" className={cssClass("icon")} src={icon} />
       <div className={cssClass("textContainer")}>
         <div className={cx(cssClassWithColorTheme("header", colorTheme))}>
           {unavailableNoticeHeader}

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -72,6 +72,7 @@ export interface Props {
   selectedRowsHeaderActions?: Array<ActionInput>;
   disableSelectedRowsHeader?: boolean;
   selectedRowsColumnName?: string;
+  preselectedRowFn?: Function;
   numDisplayedActions?: number;
 
   // These must be all set together. TODO: enforce that
@@ -175,7 +176,7 @@ export class Table2Beta extends React.Component<Props, State> {
     super(props);
 
     if (props.lazy) {
-      for (const p of ["data", "filter", "initialPage"]) {
+      for (const p of ["data", "filter", "initialPage", "preselectedRowFn"]) {
         if (props[p]) {
           console.error(`Table: prop "${p}" may not be set if "lazy"`);
         }
@@ -194,11 +195,23 @@ export class Table2Beta extends React.Component<Props, State> {
       }
     }
 
+    const selectedRows = new Set();
+    let allSelected = false;
+    if (props.selectable && props.preselectedRowFn && props.data?.length > 0) {
+      props.data.forEach((d) => {
+        if (props.preselectedRowFn(d)) {
+          selectedRows.add(d);
+        }
+      });
+
+      allSelected = selectedRows.size === props.data.length;
+    }
+
     this.state = {
       currentPage: props.initialPage || 1,
       sortState: props.initialSortState,
-      selectedRows: new Set(),
-      allSelected: false,
+      selectedRows,
+      allSelected,
       allData: new Set(),
 
       // lazy table state


### PR DESCRIPTION
# Overview:

This PR is changing two things:
- Adding a new prop that allows rendering the selectable table2 component with a pre-populated selection. Intentionally kept this only for non-lazy loading since the state management for selections would make it difficult for persisting pre-selections vs actual selections.
- Fixing an issue in `UnavailableAnnouncementBubble` that was causing it to break when importing into SD2 due to a require statement that had an inline dynamic value. Moved the image imports to the top of the file instead


# Screenshots/GIFs:

# Testing:

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
