### PR TITLE
add onSelect callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.179.0",
+  "version": "2.180.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -74,6 +74,7 @@ export interface Props {
   selectedRowsColumnName?: string;
   preselectedRowFn?: Function;
   numDisplayedActions?: number;
+  onSelect?: Function;
 
   // These must be all set together. TODO: enforce that
   lazy?: boolean;
@@ -561,6 +562,7 @@ export class Table2Beta extends React.Component<Props, State> {
       selectedRowsHeaderActions,
       disableSelectedRowsHeader,
       selectedRowsColumnName,
+      onSelect,
     } = this.props;
     const { lazy, numRows } = this.props;
     const { currentPage, sortState, pageLoading, allLoaded } = this.state;
@@ -617,6 +619,10 @@ export class Table2Beta extends React.Component<Props, State> {
                         selectedRows.clear();
                         this.setState({ allSelected: false });
                       }
+                      if (onSelect) {
+                        onSelect(selectedRows);
+                      }
+
                       this.setState({ selectedRows });
                     }}
                     disabled={displayedData.length === 0}


### PR DESCRIPTION
# Overview:
Missed one last prop, which is onSelect. Since we got rid of the selected action header, we have no way of interfacing with the selections in this component. Adding a new callback to handle this new case.

# Screenshots/GIFs:

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
