### PR TITLE
Table2Beta onSelect fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.180.0",
+  "version": "2.182.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -697,7 +697,7 @@ export class Table2Beta extends React.Component<Props, State> {
                           if (onSelect) {
                             onSelect(selectedRows);
                           }
-                          
+
                           this.setState({ selectedRows });
                         }}
                       >

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -693,6 +693,11 @@ export class Table2Beta extends React.Component<Props, State> {
                             selectedRows.delete(rowData);
                             this.setState({ allSelected: false });
                           }
+
+                          if (onSelect) {
+                            onSelect(selectedRows);
+                          }
+                          
                           this.setState({ selectedRows });
                         }}
                       >


### PR DESCRIPTION
# Overview:
Fixing a missing invocation for the new `onSelect` prop that was causing individual row selections not firing the callback

# Screenshots/GIFs:

# Testing:
Tested locally

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
