### PR TITLE
Improve unselected state to 3:1 color contrast

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.183.0",
+  "version": "2.184.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FloatingButton/FloatingButton.less
+++ b/src/FloatingButton/FloatingButton.less
@@ -63,8 +63,8 @@
 }
 
 .Button.FloatingButton--green {
-  background-color: @alert_green_tint_1;
-  border-color: @alert_green_tint_1;
+  background-color: @alert_green;
+  border-color: @alert_green;
   color: @neutral_white;
 
   &:hover,


### PR DESCRIPTION
# Jira: [PRTL-2695]

# Overview:
Improved color contrast of the `ColorGroup.GREEN` to be a11y-compliant (3:1).

# Screenshots/GIFs:
![Screen Shot 2022-07-06 at 9 18 54 AM](https://user-images.githubusercontent.com/79538533/177597988-cd4a9d1e-c1b0-483f-acde-b676042c5174.png)


# Testing:
- [x] Unit tests (ran `make test`)
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11
- [x] Confirmed only `launchpad` using this button with the `GREEN`

# Roll Out:

- Before merging:
  - [Not needed] Updated docs 
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - [x] New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [Not needed] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[PRTL-2695]: https://clever.atlassian.net/browse/PRTL-2695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ