### PR TITLE
fix: remove improper aria-hidden usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.185.0",
+  "version": "2.186.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/FloatingButton/FloatingButton.tsx
+++ b/src/FloatingButton/FloatingButton.tsx
@@ -257,7 +257,7 @@ export default class FloatingButton extends React.PureComponent<Props, State> {
                   onClick={() => this.additionalButtonHandler(button)}
                   value={button.label}
                   size={size || Button.Size.M}
-                  aria-hidden={!active}
+                  display={!active ? "none" : "block"}
                 />
               </div>
             ))}


### PR DESCRIPTION
# Jira: [PRTL-2618]

# Overview:
Fix [improper usage of `aria-hidden`](https://www.w3.org/TR/wai-aria-1.1/#aria-hidden).

Reading through CSS guidance, seems like `display` is the [right attribute to fuss with](https://developer.mozilla.org/en-US/docs/Web/CSS/display).

# Screenshots/GIFs:
https://user-images.githubusercontent.com/79538533/179845139-b6410c08-0ad4-4999-afca-b3d48ef40f14.mov

# Testing:
- [x] Ran component dev-server locally and confirmed floating button closes/opens with mouse
- [x] Ran component dev-server locally and confirmed floating button closes/opens with VoiceOver and keyboard commands (see video)
- [x] `make lint` and `make format`
- [x] Unit tests `make test`
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [n/a] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [n/a] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [n/a] Deployed updated docs (`make deploy-docs`)
  - [n/a] Posted in #eng if I made a breaking change to a beta component


[PRTL-2618]: https://clever.atlassian.net/browse/PRTL-2618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ