### PR TITLE
Fix TopBar color contrast

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.186.0",
+  "version": "2.187.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TopBar/common.less
+++ b/src/TopBar/common.less
@@ -1,3 +1,7 @@
 @import (reference) "../less/utilities";
 
 @topBarHeight: 3.75rem;
+@topBarHeightMargin: 1.25rem;
+@activeIndicatorSize: 11px;
+// Hover that is at 3:1 color contrast with @primary_blue
+@primary_blue_hover: #002B6A;

--- a/src/TopBar/common.less
+++ b/src/TopBar/common.less
@@ -2,4 +2,4 @@
 
 @topBarHeight: 3.75rem;
 // Hover that is at 3:1 color contrast with @primary_blue
-@primary_blue_hover: #002B6A;
+@primary_blue_hover: #002b6a;

--- a/src/TopBar/common.less
+++ b/src/TopBar/common.less
@@ -1,7 +1,5 @@
 @import (reference) "../less/utilities";
 
 @topBarHeight: 3.75rem;
-@topBarHeightMargin: 1.25rem;
-@activeIndicatorSize: 11px;
 // Hover that is at 3:1 color contrast with @primary_blue
 @primary_blue_hover: #002B6A;

--- a/src/TopBar/index.less
+++ b/src/TopBar/index.less
@@ -79,30 +79,11 @@
 // a11y theme: meets all accessibility color contrast requirements
 // https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast
 .dewey--TopBar.dewey--TopBar--theme--a11y {
-
   .TopBarButton {
-    height: @topBarHeight;
     &:hover,
     &:focus,
     &:active {
       background-color:fade(@primary_blue_hover, 100%);
     }
-  }
-  .TopBarButton--rounded {
-    height: @topBarHeight - @topBarHeightMargin;
-  }
-  .TopBarButton--activeIndicator {
-    background-color: transparent;
-    opacity: 1.0;
-    border-bottom: @activeIndicatorSize solid @neutral_white;
-    border-left: @activeIndicatorSize solid transparent;
-    border-right: @activeIndicatorSize solid transparent;
-    bottom: 0;
-    display: block;
-    height: 0;
-    left: 50%;
-    margin-left: -@activeIndicatorSize;
-    position: absolute;
-    width: 0;
   }
 }

--- a/src/TopBar/index.less
+++ b/src/TopBar/index.less
@@ -75,3 +75,34 @@
     }
   }
 }
+
+// a11y theme: meets all accessibility color contrast requirements
+// https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast
+.dewey--TopBar.dewey--TopBar--theme--a11y {
+
+  .TopBarButton {
+    height: @topBarHeight;
+    &:hover,
+    &:focus,
+    &:active {
+      background-color:fade(@primary_blue_hover, 100%);
+    }
+  }
+  .TopBarButton--rounded {
+    height: @topBarHeight - @topBarHeightMargin;
+  }
+  .TopBarButton--activeIndicator {
+    background-color: transparent;
+    opacity: 1.0;
+    border-bottom: @activeIndicatorSize solid @neutral_white;
+    border-left: @activeIndicatorSize solid transparent;
+    border-right: @activeIndicatorSize solid transparent;
+    bottom: 0;
+    display: block;
+    height: 0;
+    left: 50%;
+    margin-left: -@activeIndicatorSize;
+    position: absolute;
+    width: 0;
+  }
+}

--- a/src/TopBar/index.less
+++ b/src/TopBar/index.less
@@ -83,7 +83,7 @@
     &:hover,
     &:focus,
     &:active {
-      background-color:fade(@primary_blue_hover, 100%);
+      background-color: fade(@primary_blue_hover, 100%);
     }
   }
 }

--- a/src/TopBar/index.less
+++ b/src/TopBar/index.less
@@ -77,8 +77,8 @@
 }
 
 // a11y theme: meets all accessibility color contrast requirements
-// https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast
 .dewey--TopBar.dewey--TopBar--theme--a11y {
+  /* stylelint-disable-next-line no-descending-specificity */
   .TopBarButton {
     &:hover,
     &:focus,

--- a/src/TopBar/index.tsx
+++ b/src/TopBar/index.tsx
@@ -10,7 +10,7 @@ import Menu from "../Menu";
 
 // Defined as an array first as a convenience to make automatic enumeration of all themes easier in
 // the demo code.
-export const TopBarThemes = ["default", "plain"] as const;
+export const TopBarThemes = ["default", "plain", "a11y"] as const;
 type TopBarTheme = typeof TopBarThemes[number];
 
 export interface Props {


### PR DESCRIPTION
# Jira: [PRTL-2755]

# Overview:
Fix [accessibility issue](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast) with active and hover state of the TopBar. This change will be propagated to both teacher/student TopBrs once `launchpad` picks up the latest `component@latest` package.

# Screenshots/GIFs:

https://user-images.githubusercontent.com/79538533/180044426-559eccac-94b3-42be-856b-f22ecc7d47e1.mov


# Testing:
- [x] Ran component dev-server locally and confirmed fixes
- [x] `make lint` and `make format`
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ n/a ] Updated docs (New theme `a11y` will automatically be updated as one of the valid parameter values).
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ n/a ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ n/a ] Deployed updated docs (`make deploy-docs`)
  - [ n/a ] Posted in #eng if I made a breaking change to a beta component


[PRTL-2755]: https://clever.atlassian.net/browse/PRTL-2755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ