### PR TITLE
PRTL-2659 - descriptive button names (a11y)

### DIFF
--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -213,7 +213,12 @@ function ReplyButton({
   replyButtonText?: string;
 }): JSX.Element {
   return (
-    <Button className={cssClass("replyButton")} onClick={onReply} type={"secondary"}>
+    <Button
+      ariaLabel={"Reply"}
+      className={cssClass("replyButton")}
+      onClick={onReply}
+      type={"secondary"}
+    >
       <FlexBox alignItems="center" justify="center">
         <img
           alt=""

--- a/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/QuotedAnnouncementBubble.tsx
@@ -176,6 +176,7 @@ export const QuotedAnnouncementBubble: React.FC<Props> = ({
       )}
       <Button
         className={cssClass("button--outer")}
+        ariaLabel={buttonText}
         onClick={() => {
           if (onToggleShow) {
             onToggleShow();


### PR DESCRIPTION
# Jira: 
[PRTL-2658 ](https://clever.atlassian.net/browse/PRTL-2658)
[PRTL-2659 ](https://clever.atlassian.net/browse/PRTL-2659)

# Overview:
Added ariaLabel to the Reply and Show more/less button components that are used in the announcements in messaging

# Screenshots/GIFs:
Tested with screen reader and made sure it picked up the descriptions

<img width="500" alt="Screen Shot 2022-07-20 at 3 36 39 PM" src="https://user-images.githubusercontent.com/38148568/180108828-270abc1f-12e5-4790-b2d8-083b85904435.png">

<img width="500" alt="Screen Shot 2022-07-20 at 6 10 19 PM" src="https://user-images.githubusercontent.com/38148568/180108372-eb5fbb76-03de-442a-bcf8-c7dd458383bf.png">

<img width="500" alt="Screen Shot 2022-07-20 at 6 10 06 PM" src="https://user-images.githubusercontent.com/38148568/180108374-7814c182-2a56-4547-b07d-c84e786ff72c.png">

# Testing:

- [x] Unit tests (make unit-test)
- [x] make format-all
- [x] make lint
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] [ not needed ] Updated docs
  - [ ] [ not needed ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - [ not needed ] After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] [ not needed ] Deployed updated docs (`make deploy-docs`)
  - [ ] [ not needed ] Posted in #eng if I made a breaking change to a beta component
