### PR TITLE
PRTL-2661 - Make NormalMessagingBubble screen-reader accessible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.188.1",
+  "version": "2.189.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -82,6 +82,7 @@ export const MessagingAttachment: React.FC<Props> = ({
           isUpload && !uploadComplete && cssClass("IsUploading"),
           !!errorMsg && cssClass("Error"),
         )}
+        aria-label={"Attachment"}
         tabIndex={0}
         onClick={(e) =>
           handleClickAttachment(

--- a/src/MessagingBubble/NormalMessagingBubble.tsx
+++ b/src/MessagingBubble/NormalMessagingBubble.tsx
@@ -28,7 +28,6 @@ const cssClasses = {
 
 export interface Props {
   bubbleType: "normal";
-
   attachments?: React.ReactNode[];
   children: React.ReactNode;
   className?: string;
@@ -54,6 +53,7 @@ export const NormalMessagingBubble: React.FC<Props> = ({
   const hideBubble = !children && !replyTo; // if message is only attachments, no body and not a reply
   const isOwnMessage = messageOwnership === "ownMessage";
   const classSuffix = isOwnMessage ? cssClasses.OWN_SUFFIX : cssClasses.OTHER_SUFFIX;
+  const aria = isOwnMessage ? "Your message" : "Other's message";
   const containerClassNames = cx(
     className,
     `${cssClasses.MESSAGE_CONTAINER_BASE}${classSuffix}`,
@@ -103,8 +103,12 @@ export const NormalMessagingBubble: React.FC<Props> = ({
             metadataClassNames,
             actionButtonClassNames,
           })}
-        <div className={hideBubble ? null : bubbleClassNames}>
-          {replyTo && <div className={replyClassNames}>{replyTo}</div>}
+        <div className={hideBubble ? null : bubbleClassNames} aria-label={aria}>
+          {replyTo && (
+            <div className={replyClassNames} aria-label="Quoted message">
+              {replyTo}
+            </div>
+          )}
           <Linkify componentDecorator={componentDecorator} matchDecorator={matchDecorator}>
             {children}
           </Linkify>
@@ -120,7 +124,9 @@ export const NormalMessagingBubble: React.FC<Props> = ({
             actionButtonClassNames,
           })}
         {attachments?.length > 0 && (
-          <FlexBox className={attachmentClassNames}>{attachments}</FlexBox>
+          <FlexBox className={attachmentClassNames} aria-label={aria}>
+            {attachments}
+          </FlexBox>
         )}
       </FlexBox>
     </FlexBox>


### PR DESCRIPTION
# Jira: 
[PRTL-2661](https://clever.atlassian.net/browse/PRTL-2661)

# Overview:
Added ariaLabel to NormalMessagingBubble component to make it screen-reader accessible:

1. `"Your message"`: when messageOwnership === "ownMessage"
2. `"Other's message"`: when messageOwnership === "otherMessage"
3. `"Quoted message"` to group the `QuotedAnnouncementBubble` portion of the reply

# Screenshots/GIFs:

 Sound on 🔊

Reading your own messages:

https://user-images.githubusercontent.com/38148568/181127537-c2316f1e-05b6-432b-96a2-e33e0657e4ba.mov

Reading someone else's messages:

https://user-images.githubusercontent.com/38148568/181127565-2d4a4fc7-cf76-4033-bc13-e38b50f98fc6.mov


# Testing:

- [x] Unit tests (make unit-test)
- [x] make format-all
- [x] make lint
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
