### PR TITLE
PRTL-2701 - Remove tabIndex on MessagingThreadHistory (a11y)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.189.0",
+  "version": "2.190.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -106,7 +106,6 @@ export const MessagingThreadHistory = React.forwardRef(
         )}
         ref={containerRef}
         onScroll={onScroll}
-        tabIndex={0}
       >
         {messagesWithDividers}
       </div>


### PR DESCRIPTION
# Jira: 
[PRTL-2701](https://clever.atlassian.net/browse/PRTL-2701)

# Overview:
Removing `tabIndex="0"` on the `MessagingThreadHistory` component to prevent the whole div from being focused with keyboard navigation. If the whole div is focused, the screen reader will automatically read out all of the text inside it without scrolling to the individual elements, which is not what we want (see the 2 gifs below to see the difference)

---
[For more context about tabIndex](https://www.tpgi.com/using-the-tabindex-attribute/): Including the `tabindex` attribute to a non-focusable element (such as a `div`, as opposed to e.g. a `button`) indicates that an element can be focused/tabbed on with keyboard navigation

* `tabindex="0"` inserts the element into the tab order based on its location in the source code

* `tabindex="-1"` means that the element is not reachable via sequential keyboard navigation, but could be focused with JavaScript or visually by clicking with the mouse

I found [this video](https://www.youtube.com/watch?v=Pe0Ce1WtnUM&list=PLNYkxOF6rcICWx0C9LVWWVqvHlYJyqw7g&index=9) helpful in demonstrating these different uses

# Screenshots/GIFs:

Screen reader messages are on the bottom left:

Before removing tabIndex:

https://user-images.githubusercontent.com/38148568/181380619-7565edd6-71dd-48a3-a63e-5f5cad1bb73c.mov

After:

https://user-images.githubusercontent.com/38148568/181380628-1135f445-c4c9-4130-8bbd-2984c2ee9602.mov

Tested clever-components changes locally on `launchpad`:

https://user-images.githubusercontent.com/38148568/181832639-0f1de188-1a43-438a-853f-3ff47cff2268.mov

Tested the changes locally by manually installing dewey on `launchpad`:

https://user-images.githubusercontent.com/38148568/181832751-fe224dda-2653-496c-a34c-02844f15babf.mov


# Testing:

- [x] Unit tests (make unit-test)
- [x] make format-all
- [x] make lint
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
