### PR TITLE
fix: hide decorative element from screen reader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.189.0",
+  "version": "2.190.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -133,7 +133,11 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
                     onClick={onReplyCancel}
                     aria-label="Cancel reply"
                   >
-                    <FontAwesome aria-hidden="true" name="times" className={cssClass("Reply--CloseIcon")} />
+                    <FontAwesome
+                      aria-hidden="true"
+                      name="times"
+                      className={cssClass("Reply--CloseIcon")}
+                    />
                   </button>
                 )}
               </div>

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -133,7 +133,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
                     onClick={onReplyCancel}
                     aria-label="Cancel reply"
                   >
-                    <FontAwesome name="times" className={cssClass("Reply--CloseIcon")} />
+                    <FontAwesome aria-hidden="true" name="times" className={cssClass("Reply--CloseIcon")} />
                   </button>
                 )}
               </div>
@@ -191,7 +191,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
           type="primary"
           value={
             <FlexBox alignItems="center">
-              <FontAwesome name="paper-plane" />
+              <FontAwesome aria-hidden="true" name="paper-plane" />
               <span className={cssClass("SendText")}>{sendButtonText}</span>
             </FlexBox>
           }


### PR DESCRIPTION
# Overview:
[PRTL-2723]
So Deque's incorrect when it says that the "Cancel" icon is a non-decorative element that can't be inserted using `:before`.  In fact, there is a `Button` wrapping the `FontAwesome` Cancel icon that has an `aria-label` set and is properly uttered by the screen reader.

The approach I took here is to explicitly hide this `Fontawesome` element from the screen reader with `aria-hidden=true`. This aligns with the guidance I found here:
* [Font awesome guidance](https://fontawesome.com/docs/web/dig-deeper/accessibility#manually-make-your-icons-accessible)
* [How to hide content guidance](https://www.a11yproject.com/posts/how-to-hide-content/)

This fix will mean that a properly behaving screen reader (And hopefully an accessibility auditing tools) will ignore this decorative element.  

Note that the `:before` insertion behavior is in the `react-fontawesome` codebase and actually can't be changed. There are some workarounds though as described in the very good [Font awesome accessibility guide](https://fontawesome.com/docs/web/dig-deeper/accessibility)

# Screenshots/GIFs:
Video shows user, with a screen reader, navigating to the "Cancel" button and the reader uttering "Cancel button". User can then navigate to next element (and ignores the Cancel icon)

https://user-images.githubusercontent.com/79538533/181392566-957b42d4-5bda-43af-9e93-5a43083de1a7.mov


# Testing:

- [x] Unit tests (`make test`)
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Linting and Polish
- [x] `npm version minor` (bumped version)
- [x] `make lint`
- [x] `make format-all`
- [x] `make build`
 
# Roll Out:

- Before merging:
  - [ n/a ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ n/a ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [  n/a ] Deployed updated docs (`make deploy-docs`)
  - [ n/a ] Posted in #eng if I made a breaking change to a beta component


[PRTL-2723]: https://clever.atlassian.net/browse/PRTL-2723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ