### PR TITLE
PRTL-2637 Prevents screen reader users from browsing outside of the Modal dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.190.0",
+  "version": "2.191.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -89,7 +89,7 @@ export class Modal extends React.Component<Props, State> {
     const modalContent = (
       <div className={classnames("Modal", this.props.className)}>
         <div className="Modal--background" onClick={this.props.closeModal} aria-hidden="true" />
-        <div className="Modal--window" style={windowStyle}>
+        <div className="Modal--window" style={windowStyle} role="dialog" aria-modal="true">
           <header className="Modal--header">
             <button
               className="Modal--close"


### PR DESCRIPTION
# Jira: 
[PRTL-2637](https://clever.atlassian.net/browse/PRTL-2637)
will also fix [PRTL-2632](https://clever.atlassian.net/browse/PRTL-2632)

# Overview:
When the `Modal` component is open, screen readers shouldn't be able to interact with the content behind the modal dialog. Adding `role="dialog"` and `aria-modal="true"` helps us achieve this. 

[More about aria-modal](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal)

[According to this video](https://youtu.be/N_1MFcsqwTA?t=278) , as of May 2022, the aria-modal feature is compatible with all **desktop** browsers and screen readers, but NOT with mobile Android/iOS screen readers. For it to work on mobile we'll have to supplement adding`aria-hidden="true"` to ALL of the parent pages that interact with the `Modal` component in `launchpad`, `family-portal`, etc.


# Screenshots/GIFs:
Tested locally in `launchpad`:
 🔊

https://user-images.githubusercontent.com/38148568/181859114-669105c6-345c-428b-931e-ccfedb9eb272.mov

# Testing:

- [x] Unit tests (make unit-test)
- [x] make format-all
- [x] make lint
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
