### PR TITLE
Support proper screen-reader navigation in MessagingThreadHistory

### DIFF
--- a/docs/components/MessagingThreadHistoryView.jsx
+++ b/docs/components/MessagingThreadHistoryView.jsx
@@ -95,7 +95,11 @@ export default class MessagingThreadHistoryView extends React.PureComponent {
 
         <Example title="Basic Usage:">
           <ExampleCode>
-            <MessagingThreadHistory threadID="abc" messages={messages} />
+            <MessagingThreadHistory
+              threadID="abc"
+              messages={messages}
+              ariaLabel={"Thread history"}
+            />
           </ExampleCode>
           {this._renderConfig()}
         </Example>
@@ -156,6 +160,12 @@ export default class MessagingThreadHistoryView extends React.PureComponent {
             type: "() => void",
             description:
               "Optional callback that triggers on user scroll. Does not provide event information.",
+            optional: true,
+          },
+          {
+            name: "ariaLabel",
+            type: "string",
+            description: "aria-label attribute",
             optional: true,
           },
         ]}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.190.0",
+  "version": "2.191.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/AlertMessage.tsx
+++ b/src/MessagingThreadHistory/AlertMessage.tsx
@@ -16,9 +16,9 @@ interface Props {
 
 export const AlertMessage: React.FC<Props> = ({ icon, messageText }: Props) => {
   return (
-    <FlexBox className={cssClass("Container")}>
-      <FontAwesome name={icon} size="lg" />
-      <FlexItem className={cssClass("Message")} grow>
+    <FlexBox className={cssClass("Container")} role={"row"}>
+      <FontAwesome aria-hidden="true" name={icon} size="lg" />
+      <FlexItem role={"gridcell"} className={cssClass("Message")} grow>
         {messageText}
       </FlexItem>
     </FlexBox>

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -24,8 +24,10 @@ export const MessageMetadata: React.FC<
 > = React.forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) => {
   const { className, placement, readStatusText, children, errorMsg } = props;
   return (
-    <div ref={ref} className={classNames(cssClass("Message--container"), className)}>
-      <div className={cssClass(`Message--${placement}`)}>{children}</div>
+    <div ref={ref} className={classNames(cssClass("Message--container"), className)} role="row">
+      <div role="gridcell" className={cssClass(`Message--${placement}`)}>
+        {children}
+      </div>
       {readStatusText && <div className={cssClass("ReadReceipt")}>{readStatusText}</div>}
       {errorMsg && formErrorContainer(errorMsg, placement)}
     </div>

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -31,6 +31,7 @@ interface Props {
   threadID: string;
   messages: MessageData[];
   onScroll?: () => void;
+  ariaLabel?: string;
 }
 
 const SCROLL_BUFFER = 200;
@@ -50,7 +51,7 @@ function isOwnMessage(message: MessageData) {
 
 export const MessagingThreadHistory = React.forwardRef(
   (
-    { className, threadID, messages, onScroll }: Props,
+    { className, threadID, messages, onScroll, ariaLabel }: Props,
     containerRef: React.MutableRefObject<HTMLDivElement>,
   ) => {
     // ----------- Scroll position references
@@ -107,6 +108,8 @@ export const MessagingThreadHistory = React.forwardRef(
         ref={containerRef}
         onScroll={onScroll}
         tabIndex={0}
+        role="grid"
+        aria-label={ariaLabel}
       >
         {messagesWithDividers}
       </div>
@@ -128,8 +131,11 @@ function _interleaveMessagesWithDividers(
       const messageDay = _formatDateForDivider(message.timestamp);
       if (currentDay !== messageDay) {
         messagesWithDividers.push(
-          <div key={`divider-${messageDay}`} className={cssClasses.DIVIDER}>
-            {messageDay}
+          <div role="row">
+            <div role="gridcell" key={`divider-${messageDay}`} className={cssClasses.DIVIDER}>
+              {messageDay}
+            </div>
+            ,
           </div>,
         );
         currentDay = messageDay;

--- a/src/TopBar/index.tsx
+++ b/src/TopBar/index.tsx
@@ -53,6 +53,7 @@ export class TopBar extends React.PureComponent<Props> {
     return (
       <FlexBox
         alignItems="center"
+        role="banner"
         className={classnames(
           "dewey--TopBar",
           className,


### PR DESCRIPTION
# Overview:
[PRTL-2926]
Introduces `role=grid` and `role=row` and `row=gridcell` for the list of messages in thread history. This allows screen readers to navigate amongst the different messages (rows) and also the message content, timestamp and who it's from (gridcell).

With these fixes, user can navigate amongst all the content that a sighted person sees.

# Screenshots/GIFs:

https://user-images.githubusercontent.com/79538533/182241469-eee6fbcf-29a2-42b2-86a6-3de882e681ac.mov


# Testing:
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ TODO ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[PRTL-2926]: https://clever.atlassian.net/browse/PRTL-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ