### PR TITLE
[PRTL-2790] add semantic header to NormalAnnouncementBubble

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.192.0",
+  "version": "2.193.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -31,6 +31,8 @@
 }
 
 .NormalAnnouncementBubble--senderName {
+  font-size: 1rem;
+  margin: 0;
   color: @neutral_dark_gray;
   .text--line-height-4();
   .text--semi-bold();

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.less
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.less
@@ -33,6 +33,7 @@
 .NormalAnnouncementBubble--senderName {
   font-size: 1rem;
   margin: 0;
+  padding: 0;
   color: @neutral_dark_gray;
   .text--line-height-4();
   .text--semi-bold();

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -72,7 +72,7 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
       <FlexBox>
         <div className={cssClass("senderIcon")}>{senderIcon}</div>
         <FlexBox column alignItems="start" justify="center">
-          <h3 className={cssClass("senderName")}>{senderName}</h3>
+          <h4 className={cssClass("senderName")}>{senderName}</h4>
           <div className={cssClass("timestamp")}>{formatDateForTimestamp(sentAtTimestamp)}</div>
         </FlexBox>
         {deleteMenu}

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -72,7 +72,7 @@ export const NormalAnnouncementBubble: React.FC<Props> = ({
       <FlexBox>
         <div className={cssClass("senderIcon")}>{senderIcon}</div>
         <FlexBox column alignItems="start" justify="center">
-          <div className={cssClass("senderName")}>{senderName}</div>
+          <h3 className={cssClass("senderName")}>{senderName}</h3>
           <div className={cssClass("timestamp")}>{formatDateForTimestamp(sentAtTimestamp)}</div>
         </FlexBox>
         {deleteMenu}


### PR DESCRIPTION
# Jira: [PRTL-2790](https://clever.atlassian.net/browse/PRTL-2790)

# Overview:

Without adjusting the styling, this PR replaces a `div` element with a more semantically-appropriate `h4` element. This allows a screen reader to distinguish that the element is worth highlighting among the elements on the page. This means that each announcement will appear in the "Headings menu" when navigating the page by screen reader.

# Screenshots
### Before:

https://user-images.githubusercontent.com/6520345/182496588-ba4d8858-ea13-487b-9c34-8fb1db2b4fde.mov

### After:

https://user-images.githubusercontent.com/6520345/182496443-11740aae-5fb6-44cb-a71a-5822b4f1c53f.mov


# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
