### PR TITLE
[Modal] For low-vision users that zoom screens to 400%, show entire title text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.193.0",
+  "version": "2.194.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.less
+++ b/src/Modal/Modal.less
@@ -111,6 +111,7 @@
 @media only screen and (max-width: 20em) {
   .Modal--header {
     height: auto;
+
     h1 {
       white-space: normal;
     }

--- a/src/Modal/Modal.less
+++ b/src/Modal/Modal.less
@@ -103,3 +103,16 @@
     .margin--right--none;
   }
 }
+
+// For low-vision users that zoom screens to 400%, show entire title text.
+//
+// 320 CSS pixels is equivalent to a starting viewport width of 1280 CSS pixels wide at 400% zoom.
+// https://www.w3.org/WAI/WCAG21/Understanding/reflow
+@media only screen and (max-width: 20em) {
+  .Modal--header {
+    height: auto;
+    h1 {
+      white-space: normal;
+    }
+  }
+}


### PR DESCRIPTION
# Overview:
[PRTL-2668]

For low-vision users that zoom screens to 400%, show entire title text. This fix means all modals are now accessible for low-vision users. This fix helps us align with the [1.4.10 Reflow accessibility standard](https://www.w3.org/WAI/WCAG21/Understanding/reflow).

# Screenshots/GIFs:
Shows modal at 100% (not at 320px breakpoint):
![Screen Shot 2022-08-08 at 4 52 53 PM](https://user-images.githubusercontent.com/79538533/183534715-66a3a01c-0415-4e37-9d15-43499596832f.png)


Modal at 320px breakpoint:
![Screen Shot 2022-08-08 at 4 53 16 PM](https://user-images.githubusercontent.com/79538533/183534713-94dfff05-d8d4-4bd1-ae20-ef1046810b33.png)

# Testing:

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

## Testing on local install onto `launchpad`
- [ ] Display Name change modal (both normal and 320px breakpoint)
- [ ] AD Password change modal (both normal and 320px breakpoint)

## Linting
- [x] `make format-all`
- [x] `make lint`

# Roll Out:

- Before merging:
  - [ n/a ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ n/a ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ n/a ] Deployed updated docs (`make deploy-docs`)
  - [ n/a ] Posted in #eng if I made a breaking change to a beta component


[PRTL-2668]: https://clever.atlassian.net/browse/PRTL-2668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ