### PR TITLE
Utter status of attached files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.194.0",
+  "version": "2.195.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -120,7 +120,9 @@ export const MessagingAttachment: React.FC<Props> = ({
           )}
         </FlexBox>
         <FlexBox className={cssClass("TextContainer")} column>
-          <span className={cssClass("Title")}>{errorMsg || title}</span>
+          <span role="status" className={cssClass("Title")}>
+            {errorMsg || title}
+          </span>
           {subtitle && <span className={cssClass("Subtitle")}>{subtitle}</span>}
         </FlexBox>
       </FlexBox>


### PR DESCRIPTION
# Jira: [PRTL-2032]

# Overview:
Utter status of attached files. Will utter either the error message for unsupported file types, or the name of the file for supported file types

https://user-images.githubusercontent.com/79538533/184045250-85686732-5142-4326-9dfd-fd073e50ac51.mov


# Screenshots/GIFs:
Screencast shows me testing this locally on `family-portal`:
1) Attach non-supported file-type and screen reader uttering the error message
2) Attach supported file-type, and SR uttering file name.

# Testing:
I tested locally on `family-portal` that had manually installed this version of `clever-components`.

- [x] `make format-all`, `make lint`
- [x] Tested on mobile
- [x] Tested on desktop
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ n/a ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ n/a ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ n/a ] Deployed updated docs (`make deploy-docs`)
  - [ n/a ] Posted in #eng if I made a breaking change to a beta component


[PRTL-2032]: https://clever.atlassian.net/browse/PRTL-2032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ