### PR TITLE
[PRTL-2035] removes `aria-selected` attribute from `MessagingThreadListItem`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.195.0",
+  "version": "2.196.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -148,7 +148,6 @@ export const MessagingThreadListItem: React.FC<
         )}
         onClick={onClick}
         alignItems={ItemAlign.CENTER}
-        aria-selected={selected}
       >
         <div className={cssClasses.ICON}>{icon}</div>
         <FlexItem grow className={cssClasses.DETAILS_CONTAINER}>


### PR DESCRIPTION
# Jira ticket: [PRTL-2035](https://clever.atlassian.net/browse/PRTL-2035)

# Overview:

This PR removes the `aria-selected` attribute from the `MessagingThreadListItem` because it was not an allowable aria attribute for this type of element. In order to have an `aria-selected` attribute, the element must have a `role` of `gridcell`, `option`, `row`, or `tab` ([documentation here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected)), but each of these require a parent element to have a specific containing `role` as well. Because parent elements are declared in the repos that import this `components` repo, we decided that the `role` addition required too much knowledge to live across the boundaries of several repositories and that the benefit was not worth the challenge.

# Screenshots/GIFs:

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/6520345/185497107-bdb570d6-d869-4755-8f3d-67a5909b8cb4.png">




# Testing:

To QA, pull down this branch and:

1. On the branch, run `make build` in components
2. Take the dist folder and drop it into your local fampo's node_modules/clever-components directory to replace the dist that's there
3. Run axe audit to see if [the issue](https://clever.atlassian.net/browse/PRTL-2035) has gone away ("Elements must only use allowed ARIA attributes")
4. Open both the updated local version and the current clever-dev to run a comparison test with VoiceOver to ensure that the functionality hasn't gotten worse

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
