### PR TITLE
[PRTL-2025] add button role to attachment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.196.0",
+  "version": "2.197.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -123,7 +123,11 @@ export const MessagingAttachment: React.FC<Props> = ({
           <span role="status" className={cssClass("Title")}>
             {errorMsg || title}
           </span>
-          {subtitle && <span className={cssClass("Subtitle")}>{subtitle}</span>}
+          {subtitle && (
+            <span role="button" className={cssClass("Subtitle")}>
+              {subtitle}
+            </span>
+          )}
         </FlexBox>
       </FlexBox>
       {attachmentPreviewIsShowing && isPreviewableAttachment && (


### PR DESCRIPTION
# Jira: [PRTL-2025](https://clever.atlassian.net/browse/PRTL-2025)

# Overview:

In order to allow screen readers to indicate that the attachment is clickable, this PR adds a `button` role to the descriptor text. That text is the best place for the `button` role because it allows the screen reader to announce the effect that clicking will have.

# Screenshots/GIFs:

### Before
https://user-images.githubusercontent.com/6520345/186543149-1c5e933e-e51d-401a-838a-833134b2e129.mov

### After
https://user-images.githubusercontent.com/6520345/186543159-de660550-4cb2-4ddf-8841-046243c1be30.mov



# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
