### PR TITLE
Improve screenreader navigation by using `log` role

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.197.0",
+  "version": "2.198.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingBubble/NormalMessagingBubble.tsx
+++ b/src/MessagingBubble/NormalMessagingBubble.tsx
@@ -39,6 +39,16 @@ export interface Props {
   timestamp: Date;
 }
 
+// Collect all hardcoded strings in one place for easy replacement when
+// we eventually support i18n.
+// TODO localize these strings for various languages, once we support multi-regions.
+const i18nString = {
+  DELETE: "Delete",
+  YOUR_MESSAGE: "Your message",
+  OTHERS_MESSAGE: "Other's message",
+  QUOTED_MESSAGE: "Quoted message",
+};
+
 export const NormalMessagingBubble: React.FC<Props> = ({
   className,
   children,
@@ -53,7 +63,7 @@ export const NormalMessagingBubble: React.FC<Props> = ({
   const hideBubble = !children && !replyTo; // if message is only attachments, no body and not a reply
   const isOwnMessage = messageOwnership === "ownMessage";
   const classSuffix = isOwnMessage ? cssClasses.OWN_SUFFIX : cssClasses.OTHER_SUFFIX;
-  const aria = isOwnMessage ? "Your message" : "Other's message";
+  const whoseMessage = isOwnMessage ? i18nString.YOUR_MESSAGE : i18nString.OTHERS_MESSAGE;
   const containerClassNames = cx(
     className,
     `${cssClasses.MESSAGE_CONTAINER_BASE}${classSuffix}`,
@@ -103,9 +113,9 @@ export const NormalMessagingBubble: React.FC<Props> = ({
             metadataClassNames,
             actionButtonClassNames,
           })}
-        <div className={hideBubble ? null : bubbleClassNames} aria-label={aria}>
+        <div className={hideBubble ? null : bubbleClassNames} aria-label={whoseMessage}>
           {replyTo && (
-            <div className={replyClassNames} aria-label="Quoted message">
+            <div className={replyClassNames} aria-label={i18nString.QUOTED_MESSAGE}>
               {replyTo}
             </div>
           )}
@@ -124,7 +134,7 @@ export const NormalMessagingBubble: React.FC<Props> = ({
             actionButtonClassNames,
           })}
         {attachments?.length > 0 && (
-          <FlexBox className={attachmentClassNames} aria-label={aria}>
+          <FlexBox className={attachmentClassNames} aria-label={whoseMessage}>
             {attachments}
           </FlexBox>
         )}
@@ -135,6 +145,7 @@ export const NormalMessagingBubble: React.FC<Props> = ({
 
 // Helper function: Format a Date for our pretty timestamps.
 //  Always returns "xx:xx <AM/PM>" format.
+// TODO localize time format to be region-specific
 function _formatDateForTimestamp(date: Date): string {
   return moment(date).format("h:mm A");
 }
@@ -202,11 +213,10 @@ function _renderActionButton({
   actionButtonClassNames: string;
 }): React.ReactNode {
   const formattedTimestamp = _formatDateForTimestamp(timestamp);
-
   return (
     <div className={metadataClassNames}>
       <Button
-        ariaLabel={`Delete ${formattedTimestamp} ${messageBody || ""}`}
+        ariaLabel={`${i18nString.DELETE} ${formattedTimestamp} ${messageBody || ""}`}
         className={actionButtonClassNames}
         type="linkPlain"
         onClick={onClickDeleteButton}

--- a/src/MessagingThreadHistory/AlertMessage.tsx
+++ b/src/MessagingThreadHistory/AlertMessage.tsx
@@ -16,9 +16,9 @@ interface Props {
 
 export const AlertMessage: React.FC<Props> = ({ icon, messageText }: Props) => {
   return (
-    <FlexBox className={cssClass("Container")} role={"row"}>
+    <FlexBox className={cssClass("Container")}>
       <FontAwesome aria-hidden="true" name={icon} size="lg" />
-      <FlexItem role={"gridcell"} className={cssClass("Message")} grow>
+      <FlexItem className={cssClass("Message")} grow>
         {messageText}
       </FlexItem>
     </FlexBox>

--- a/src/MessagingThreadHistory/MessageMetadata.tsx
+++ b/src/MessagingThreadHistory/MessageMetadata.tsx
@@ -24,10 +24,8 @@ export const MessageMetadata: React.FC<
 > = React.forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) => {
   const { className, placement, readStatusText, children, errorMsg } = props;
   return (
-    <div ref={ref} className={classNames(cssClass("Message--container"), className)} role="row">
-      <div role="gridcell" className={cssClass(`Message--${placement}`)}>
-        {children}
-      </div>
+    <div ref={ref} className={classNames(cssClass("Message--container"), className)}>
+      <div className={cssClass(`Message--${placement}`)}>{children}</div>
       {readStatusText && <div className={cssClass("ReadReceipt")}>{readStatusText}</div>}
       {errorMsg && formErrorContainer(errorMsg, placement)}
     </div>

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -108,7 +108,7 @@ export const MessagingThreadHistory = React.forwardRef(
         ref={containerRef}
         onScroll={onScroll}
         tabIndex={0}
-        role="grid"
+        role="log"
         aria-label={ariaLabel}
       >
         {messagesWithDividers}
@@ -126,15 +126,13 @@ function _interleaveMessagesWithDividers(
   let currentDay = "";
   messages.forEach((message: MessageData, i) => {
     // If the message has a timestamp (i.e. is not Clever-generated) and was sent on a different
-    //  day than the previous message, we want a divider (with the date) in between.
+    // day than the previous message, we want a divider (with the date) in between.
     if (message.timestamp) {
       const messageDay = _formatDateForDivider(message.timestamp);
       if (currentDay !== messageDay) {
         messagesWithDividers.push(
-          <div role="row">
-            <div role="gridcell" key={`divider-${messageDay}`} className={cssClasses.DIVIDER}>
-              {messageDay}
-            </div>
+          <div key={`divider-${messageDay}`} className={cssClasses.DIVIDER}>
+            {messageDay}
           </div>,
         );
         currentDay = messageDay;

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -135,7 +135,6 @@ function _interleaveMessagesWithDividers(
             <div role="gridcell" key={`divider-${messageDay}`} className={cssClasses.DIVIDER}>
               {messageDay}
             </div>
-            ,
           </div>,
         );
         currentDay = messageDay;


### PR DESCRIPTION
# Jira: 
[PRTL-3048]

# Overview:
Improve screenreader navigation by using `log` role. As you can see from screencast, the user can navigate amongst the messages and hear the meta data like timestamp, "Other's message", etc.

Note that when a new message comes in, the screenreader reads it immediately.

I also bumped the version (and will update the `family-portal` version).

### Manual testing
I also copied over this build to `family-portal` and confirmed that it was working locally.

# Screenshots/GIFs:

https://user-images.githubusercontent.com/79538533/187550387-7441ce91-b77e-4248-ba59-d25ce6e571f0.mov


# Testing:
- [x] Unit tests
- [x] `make lint format`
- Manual tests:
  - [x] Chrome (by running`make dev-server`) 
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[PRTL-3048]: https://clever.atlassian.net/browse/PRTL-3048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ