### PR TITLE
[PRTL-2505] add aria-label to multi-select toggle carat button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.198.0",
+  "version": "2.199.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MultiSelect/MultiSelect.tsx
+++ b/src/MultiSelect/MultiSelect.tsx
@@ -87,6 +87,12 @@ export function getSelectableOptions(
   return [...creatableOption, ...selectableOptions];
 }
 
+// pulling out English string literals to eventually be i18n friendly
+// when i18n is prioritized for these components
+const i18nStrings = {
+  TOGGLE_BUTTON_LABEL: "toggle dropdown options",
+};
+
 /*
   Multi-item select drop down component
 */
@@ -261,7 +267,7 @@ const MultiSelect: React.FC<Props> = ({
           />
         </div>
         <button
-          aria-label="toggle dropdown options"
+          aria-label={i18nStrings.TOGGLE_BUTTON_LABEL}
           className={cssClass.CARET_BUTTON}
           {...getToggleButtonProps()}
         >

--- a/src/MultiSelect/MultiSelect.tsx
+++ b/src/MultiSelect/MultiSelect.tsx
@@ -260,7 +260,11 @@ const MultiSelect: React.FC<Props> = ({
             )}
           />
         </div>
-        <button className={cssClass.CARET_BUTTON} {...getToggleButtonProps()}>
+        <button
+          aria-label="toggle dropdown options"
+          className={cssClass.CARET_BUTTON}
+          {...getToggleButtonProps()}
+        >
           <FontAwesome name={isOpen ? "caret-up" : "caret-down"} />
         </button>
       </div>


### PR DESCRIPTION
# Jira ticket: [PRTL-2505](https://clever.atlassian.net/browse/PRTL-2505)

# Overview:
This PR adds an `aria-label` to the carat button ( 🔼 / 🔽 ) on the multiselect component (it toggles if the dropdown options are showing on the multiselect). This allows assistive technologies like screen readers to read the button and indicate what it's for.

# Screenshots/GIFs:

## Before

https://user-images.githubusercontent.com/6520345/188757547-7453afaf-ac52-492d-80ed-0a82dfcfd4f9.mov

## After

https://user-images.githubusercontent.com/6520345/188757558-aff2be73-f84b-43da-9a71-4d7d4cc3ef58.mov


# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
