### PR TITLE
PRTL-2654 Add button pressed state to messages list 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.199.0",
+  "version": "2.200.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/List/Item.tsx
+++ b/src/List/Item.tsx
@@ -8,6 +8,7 @@ export interface Props {
   children: React.ReactNode;
   className?: string;
   onClick?: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>;
+  selected?: boolean;
 }
 
 const cssClass = {
@@ -23,10 +24,11 @@ export default class Item extends React.PureComponent<Props> {
     children: PropTypes.node.isRequired,
     className: PropTypes.string,
     onClick: PropTypes.func,
+    selected: PropTypes.bool,
   };
 
   render() {
-    const { children, className, onClick } = this.props;
+    const { children, className, onClick, selected } = this.props;
 
     let Wrapper: Extract<keyof JSX.IntrinsicElements, "div" | "button"> = "div";
     if (onClick) {
@@ -34,14 +36,16 @@ export default class Item extends React.PureComponent<Props> {
     }
 
     return (
-      <li className={classnames(cssClass.CONTAINER, className)}>
+      <div className={classnames(cssClass.CONTAINER, className)}>
         <Wrapper
+          role="tab"
+          aria-selected={selected}
           className={classnames(cssClass.CONTENT_WRAPPER, !!onClick && cssClass.CONTENT_ONCLICK)}
           onClick={onClick}
         >
           {children}
         </Wrapper>
-      </li>
+      </div>
     );
   }
 }

--- a/src/List/List.tsx
+++ b/src/List/List.tsx
@@ -80,9 +80,12 @@ export default class List extends React.PureComponent<Props> {
             {title}
           </header>
         )}
-        <ul className={classnames(cssClass.ITEMS, cssClass.rowType(rowType), itemsClassName)}>
+        <div
+          role="tablist"
+          className={classnames(cssClass.ITEMS, cssClass.rowType(rowType), itemsClassName)}
+        >
           {items}
-        </ul>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
# Jira: [PRTL-2654](https://clever.atlassian.net/browse/PRTL-2654)

# Overview:
Currently VO doesn’t pick up the pressed state of the message thread on the thread list:

![img](https://axeauditor.dequecloud.com/api/v1/file/7e755f50-d0e3-11ec-a49c-6f4e32e8de50)

We want the VO to say something like "Thread 1, selected, tab..." when a user clicks on a thread to improve accessibility

The fix is to include the `aria-selected` tag on the button, which also [requires](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) specifying `role="tab"`, as well as `role="tablist"` on its parent element

I'm also getting rid of the `ul` and `li` structure and changing the wrappers to `<div>` since it causes the axe tool to complain about some nesting issues (lmk if you're curious and want a walk through, kinda hard to explain it here 😕)

# Screenshots/GIFs:
👂 🔉 

Before:

https://user-images.githubusercontent.com/38148568/189222751-c88e7673-b4d3-46d8-9af1-226fe3bfab90.mov

After:

https://user-images.githubusercontent.com/38148568/189222760-1770acb2-92b1-451f-93f6-dcfbc1425b9d.mov

No new axe issues:
<img width="964" alt="Screen Shot 2022-09-08 at 1 35 53 PM" src="https://user-images.githubusercontent.com/38148568/189226345-d5c9686b-1045-4997-abcc-fd59d8dc28d1.png">


# Testing:

- [x] Unit tests (make unit-test)
- [x] make format-all
- [x] make lint
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
