### PR TITLE
PRTL-2643 make tooltip dismissible with Esc key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.200.0",
+  "version": "2.201.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -126,6 +126,12 @@ export default class Tooltip extends React.Component<Props, State> {
         handleShowTooltip();
       }
     };
+    const handleEscape = (event) => {
+      if (event.keyCode === 27 && this.state.showTooltip) {
+        handleHideTooltip();
+        event.stopPropagation();
+      }
+    };
 
     const tooltip = (
       <BootstrapTooltip
@@ -154,6 +160,7 @@ export default class Tooltip extends React.Component<Props, State> {
             onMouseEnter: handleMouseEnter,
             onMouseLeave: handleMouseLeave,
             onMouseDown: handleOnClick,
+            onKeyUp: (event) => handleEscape(event),
             ...child.props,
           })}
           <Overlay


### PR DESCRIPTION
# Jira: [PRTL-2643](https://clever.atlassian.net/browse/PRTL-2643)

# Overview:
If a `Tooltip` is within a `Modal`, pressing Esc while it's being focused will close the entire modal and not just the tooltip itself. Adding `onKeyUp` callback to support closing the tooltip on Escape.

# Screenshots
### Before
![Sep-14-2022 15-30-45](https://user-images.githubusercontent.com/38148568/190274388-05f56dd7-ad5c-4832-8e31-1d1b9ac083ad.gif)

### After
![Sep-14-2022 15-31-56](https://user-images.githubusercontent.com/38148568/190274541-4b145b37-c448-4b16-a548-a97e34687013.gif)

# Testing:

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
