### PR TITLE
PRTL-2601: add alt text to table2beta actions and Checkboxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.201.0",
+  "version": "2.202.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -86,7 +86,7 @@ export default class Checkbox extends React.PureComponent<Props> {
     return (
       <button
         aria-checked={ariaCheckedState}
-        aria-labelledby={hasLabel && this._labelID}
+        aria-labelledby={hasLabel ? this._labelID : undefined}
         // TODO: aria-label needs to be translated
         aria-label={!hasLabel ? "select/unselect" : undefined}
         className={classnames(

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -81,11 +81,14 @@ export default class Checkbox extends React.PureComponent<Props> {
     if (ariaCheckedState && partial) {
       ariaCheckedState = "mixed";
     }
+    const hasLabel = !!children;
 
     return (
       <button
         aria-checked={ariaCheckedState}
-        aria-labelledby={this._labelID}
+        aria-labelledby={hasLabel && this._labelID}
+        // TODO: aria-label needs to be translated
+        aria-label={!hasLabel ? "select/unselect" : undefined}
         className={classnames(
           cssClass.CONTAINER,
           checked && cssClass.CHECKED,

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -528,7 +528,7 @@ export class Table2Beta extends React.Component<Props, State> {
                 <img
                   className={cssClass.SINGLE_ACTION_TRIGGER}
                   src={require("./ellipsis.svg")}
-                  // TODO: is this a good alt text for the ellipsis icon?
+                  // TODO: alt-texts need to be translated
                   alt="more actions"
                 />
               </Button>

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -462,6 +462,27 @@ export class Table2Beta extends React.Component<Props, State> {
     return this._getLazyData();
   }
 
+  actionIconAndHoverIcon = (action: ActionInput) => {
+    return (
+      <>
+        {action.icon && (
+          <img
+            className={cssClass.ACTION_ICON}
+            src={action.icon}
+            alt={action.title.singular.toString()}
+          />
+        )}
+        {action.hoverIcon && (
+          <img
+            className={cssClass.ACTION_HOVER_ICON}
+            src={action.hoverIcon}
+            alt={action.title.singular.toString()}
+          />
+        )}
+      </>
+    );
+  };
+
   _singleActionsRender(rowData) {
     const { singleActions } = this.props;
     if (singleActions.length === 1) {
@@ -471,20 +492,7 @@ export class Table2Beta extends React.Component<Props, State> {
           type="link"
           value={
             <>
-              {singleActions[0].icon && (
-                <img
-                  className={cssClass.ACTION_ICON}
-                  src={singleActions[0].icon}
-                  alt={singleActions[0].title.singular.toString()}
-                />
-              )}
-              {singleActions[0].hoverIcon && (
-                <img
-                  className={cssClass.ACTION_HOVER_ICON}
-                  src={singleActions[0].hoverIcon}
-                  alt={singleActions[0].title.singular.toString()}
-                />
-              )}
+              {this.actionIconAndHoverIcon(singleActions[0])}
               <div className={cssClass.ACTION_TITLE}>{singleActions[0].title.singular}</div>
             </>
           }
@@ -501,20 +509,7 @@ export class Table2Beta extends React.Component<Props, State> {
             value={
               <>
                 <span className={singleActions[0].hoverIcon && cssClass.ACTION_ICON_CONTAINER}>
-                  {singleActions[0].icon && (
-                    <img
-                      className={cssClass.ACTION_ICON}
-                      src={singleActions[0].icon}
-                      alt={singleActions[0].title.singular.toString()}
-                    />
-                  )}
-                  {singleActions[0].hoverIcon && (
-                    <img
-                      className={cssClass.ACTION_HOVER_ICON}
-                      src={singleActions[0].hoverIcon}
-                      alt={singleActions[0].title.singular.toString()}
-                    />
-                  )}
+                  {this.actionIconAndHoverIcon(singleActions[0])}
                 </span>
                 <div className={cssClass.ACTION_TITLE}>{singleActions[0].title.singular}</div>
               </>
@@ -545,20 +540,7 @@ export class Table2Beta extends React.Component<Props, State> {
                 key="action.title.singular"
               >
                 <div className={cssClass.ACTION_MENU_ITEM_TITLE}>
-                  {action.icon && (
-                    <img
-                      className={cssClass.ACTION_ICON}
-                      src={action.icon}
-                      alt={action.title.singular.toString()}
-                    />
-                  )}
-                  {action.hoverIcon && (
-                    <img
-                      className={cssClass.ACTION_HOVER_ICON}
-                      src={action.hoverIcon}
-                      alt={action.title.singular.toString()}
-                    />
-                  )}
+                  {this.actionIconAndHoverIcon(action)}
                   <div className={cssClass.ACTION_TITLE}>{action.title.singular}</div>
                 </div>
               </Menu.Item>

--- a/src/Table2Beta/Table.tsx
+++ b/src/Table2Beta/Table.tsx
@@ -472,10 +472,18 @@ export class Table2Beta extends React.Component<Props, State> {
           value={
             <>
               {singleActions[0].icon && (
-                <img className={cssClass.ACTION_ICON} src={singleActions[0].icon} />
+                <img
+                  className={cssClass.ACTION_ICON}
+                  src={singleActions[0].icon}
+                  alt={singleActions[0].title.singular.toString()}
+                />
               )}
               {singleActions[0].hoverIcon && (
-                <img className={cssClass.ACTION_HOVER_ICON} src={singleActions[0].hoverIcon} />
+                <img
+                  className={cssClass.ACTION_HOVER_ICON}
+                  src={singleActions[0].hoverIcon}
+                  alt={singleActions[0].title.singular.toString()}
+                />
               )}
               <div className={cssClass.ACTION_TITLE}>{singleActions[0].title.singular}</div>
             </>
@@ -494,10 +502,18 @@ export class Table2Beta extends React.Component<Props, State> {
               <>
                 <span className={singleActions[0].hoverIcon && cssClass.ACTION_ICON_CONTAINER}>
                   {singleActions[0].icon && (
-                    <img className={cssClass.ACTION_ICON} src={singleActions[0].icon} />
+                    <img
+                      className={cssClass.ACTION_ICON}
+                      src={singleActions[0].icon}
+                      alt={singleActions[0].title.singular.toString()}
+                    />
                   )}
                   {singleActions[0].hoverIcon && (
-                    <img className={cssClass.ACTION_HOVER_ICON} src={singleActions[0].hoverIcon} />
+                    <img
+                      className={cssClass.ACTION_HOVER_ICON}
+                      src={singleActions[0].hoverIcon}
+                      alt={singleActions[0].title.singular.toString()}
+                    />
                   )}
                 </span>
                 <div className={cssClass.ACTION_TITLE}>{singleActions[0].title.singular}</div>
@@ -509,7 +525,12 @@ export class Table2Beta extends React.Component<Props, State> {
           <Menu
             trigger={
               <Button size="small" className={cssClass.ACTION_MENU} type="link">
-                <img className={cssClass.SINGLE_ACTION_TRIGGER} src={require("./ellipsis.svg")} />
+                <img
+                  className={cssClass.SINGLE_ACTION_TRIGGER}
+                  src={require("./ellipsis.svg")}
+                  // TODO: is this a good alt text for the ellipsis icon?
+                  alt="more actions"
+                />
               </Button>
             }
             placement={Menu.Placement.RIGHT}
@@ -524,9 +545,19 @@ export class Table2Beta extends React.Component<Props, State> {
                 key="action.title.singular"
               >
                 <div className={cssClass.ACTION_MENU_ITEM_TITLE}>
-                  {action.icon && <img className={cssClass.ACTION_ICON} src={action.icon} />}
+                  {action.icon && (
+                    <img
+                      className={cssClass.ACTION_ICON}
+                      src={action.icon}
+                      alt={action.title.singular.toString()}
+                    />
+                  )}
                   {action.hoverIcon && (
-                    <img className={cssClass.ACTION_HOVER_ICON} src={action.hoverIcon} />
+                    <img
+                      className={cssClass.ACTION_HOVER_ICON}
+                      src={action.hoverIcon}
+                      alt={action.title.singular.toString()}
+                    />
                   )}
                   <div className={cssClass.ACTION_TITLE}>{action.title.singular}</div>
                 </div>


### PR DESCRIPTION
# Jira: [PRTL-2601](https://clever.atlassian.net/browse/PRTL-2601)

# Overview:

A11y project, need to add alt text to action icons on Student Analytics page. This is handled in the Table2Beta component, by adding alt text to icon images using the title of the action

Checkboxes used in T2B were also missing alt-text, except those which had a label. For the checkboxes without a label, I added a generic aria-label "select/unselect" as this component could be used elsewhere. 

# Screenshots/GIFs:

# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - **New component or backward-compatible component feature change? Run `npm version minor`**
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
