### PR TITLE
[PRTL-2563] fix disallowed aria attrs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.202.0",
+  "version": "2.203.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -116,6 +116,7 @@ export const MessagingThreadListItem: React.FC<
     } else if (!isRead) {
       indicatorIcon = (
         <div
+          role="status"
           aria-label={`Unread messages in thread ${title}`}
           className={classNames(
             cssClasses.UNREAD_ORB,


### PR DESCRIPTION
# Jira: [PRTL-2563](https://clever.atlassian.net/browse/PRTL-2563)

# Overview:
This PR addresses an issue where the unread badge had an `aria-label`, but no `role`. [Here's the documentation for the `status` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role) that I picked, which seemed appropriate for a badge like this one.

# Screenshots/GIFs:
## Before
<img width="1791" alt="image" src="https://user-images.githubusercontent.com/6520345/190806056-23ea5e52-3bd0-4863-b046-70d4383bdadd.png">
## After
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/6520345/190807091-35537c6b-bdb0-4550-b931-d658e644b94d.png">


# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
