### PR TITLE
adding aria-label prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.203.0",
+  "version": "2.204.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -15,7 +15,6 @@ export interface SelectValueType {
 }
 
 export interface Props {
-  labelText?: string;
   id: string;
   name: string;
   clearable?: boolean;
@@ -42,6 +41,7 @@ export interface Props {
   error?: string;
   size?: Size;
   closeMenuOnSelect?: boolean;
+  ariaLabel?: string;
 }
 
 interface State {
@@ -54,7 +54,6 @@ const selectValuePropType = PropTypes.shape({
 });
 
 const propTypes = {
-  labelText: PropTypes.string,
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   clearable: PropTypes.bool,
@@ -86,6 +85,7 @@ const propTypes = {
   error: PropTypes.string,
   size: PropTypes.oneOf(Object.values(FormElementSize)),
   closeMenuOnSelect: PropTypes.bool,
+  ariaLabel: PropTypes.string,
 };
 
 const defaultProps = {
@@ -134,7 +134,6 @@ export class Select extends React.Component<Props, State> {
 
   render() {
     const {
-      labelText,
       id,
       name,
       clearable,
@@ -161,6 +160,7 @@ export class Select extends React.Component<Props, State> {
       error,
       size,
       closeMenuOnSelect,
+      ariaLabel,
     } = this.props;
     if (!lazy) {
       if (!options) {
@@ -225,7 +225,6 @@ export class Select extends React.Component<Props, State> {
       <div className={classnames(cssClass.CONTAINER, formElementSizeClassName(size), wrapperClass)}>
         <div id={id}>
           <SelectComponent
-            aria-label={labelText}
             className={reactSelectClasses}
             clearable={clearable}
             promptTextCreator={creatablePromptFn}
@@ -246,6 +245,7 @@ export class Select extends React.Component<Props, State> {
             closeOnSelect={closeMenuOnSelect}
             value={value}
             role="listbox"
+            aria-label={ariaLabel}
             {...overrideProps}
           />
         </div>

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -15,6 +15,7 @@ export interface SelectValueType {
 }
 
 export interface Props {
+  labelText?: string;
   id: string;
   name: string;
   clearable?: boolean;
@@ -53,6 +54,7 @@ const selectValuePropType = PropTypes.shape({
 });
 
 const propTypes = {
+  labelText: PropTypes.string,
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   clearable: PropTypes.bool,
@@ -132,6 +134,7 @@ export class Select extends React.Component<Props, State> {
 
   render() {
     const {
+      labelText,
       id,
       name,
       clearable,
@@ -222,6 +225,7 @@ export class Select extends React.Component<Props, State> {
       <div className={classnames(cssClass.CONTAINER, formElementSizeClassName(size), wrapperClass)}>
         <div id={id}>
           <SelectComponent
+            aria-label={labelText}
             className={reactSelectClasses}
             clearable={clearable}
             promptTextCreator={creatablePromptFn}


### PR DESCRIPTION
# Jira: [PRTL-2597](https://clever.atlassian.net/browse/PRTL-2597)

# Overview:
adding aria-label prop to select component for accessibility

# Screenshots/GIFs:
![Screen Shot 2022-09-19 at 5 38 50 PM](https://user-images.githubusercontent.com/105459371/191124432-9e8b9ad4-6f71-40e8-acef-0e329db0a914.png)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
