### PR TITLE
PRTL-2609-2611 sortable table a11y

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.203.0",
+  "version": "2.204.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table/Cell.tsx
+++ b/src/Table/Cell.tsx
@@ -9,6 +9,7 @@ export interface Props {
   className?: string;
   noWrap?: boolean;
   width?: string;
+  isHeader?: boolean;
   [additionalProp: string]: any;
 }
 
@@ -17,15 +18,34 @@ export const cssClass = {
   NO_WRAP: "Table--cell--no_wrap",
 };
 
-export default function Cell({ children, className, noWrap, width, ...additionalProps }: Props) {
+export default function Cell({
+  children,
+  className,
+  noWrap,
+  width,
+  isHeader,
+  ...additionalProps
+}: Props) {
   return (
-    <td
-      className={classnames(cssClass.CELL, noWrap && cssClass.NO_WRAP, className)}
-      style={{ width }}
-      {...additionalProps}
-    >
-      {children}
-    </td>
+    <>
+      {isHeader ? (
+        <th
+          className={classnames(cssClass.CELL, noWrap && cssClass.NO_WRAP, className)}
+          style={{ width }}
+          {...additionalProps}
+        >
+          {children}
+        </th>
+      ) : (
+        <td
+          className={classnames(cssClass.CELL, noWrap && cssClass.NO_WRAP, className)}
+          style={{ width }}
+          {...additionalProps}
+        >
+          {children}
+        </td>
+      )}
+    </>
   );
 }
 
@@ -34,4 +54,5 @@ Cell.propTypes = {
   children: PropTypes.node,
   noWrap: PropTypes.bool,
   width: PropTypes.string,
+  isHeader: PropTypes.bool,
 };

--- a/src/Table/HeaderCell.tsx
+++ b/src/Table/HeaderCell.tsx
@@ -34,16 +34,28 @@ export default function HeaderCell({
   activeSortDirection,
   width,
 }: Props) {
+  const Enter = "Enter";
+  const Space = " ";
+
   return (
     <Cell
+      isHeader
+      aria-sort={sortable && activeSortDirection ? `${activeSortDirection}ending` : null}
       className={classnames(cssClass.HEADER_CELL, sortable && cssClass.SORTABLE, className)}
       onClick={() => sortable && onSortChange()}
+      onKeyUp={(e) => (e.key === Enter || e.key === Space) && sortable && onSortChange()}
       width={width}
     >
       <FlexBox alignItems={ItemAlign.CENTER}>
-        <div className={cssClass.LABEL}>{children}</div>
+        <div
+          className={cssClass.LABEL}
+          tabIndex={sortable ? 0 : null}
+          role={sortable ? "button" : null}
+        >
+          {children}
+        </div>
         {sortable && (
-          <div>
+          <div aria-hidden="true">
             <SortIcons direction={activeSortDirection} className={cssClass.SORT} />
           </div>
         )}

--- a/src/Table2Beta/Cell.tsx
+++ b/src/Table2Beta/Cell.tsx
@@ -9,6 +9,7 @@ export interface Props {
   className?: string;
   noWrap?: boolean;
   width?: string;
+  isHeader?: boolean;
   [additionalProp: string]: any;
 }
 
@@ -17,15 +18,34 @@ export const cssClass = {
   NO_WRAP: "Table--cell--no_wrap",
 };
 
-export default function Cell({ children, className, noWrap, width, ...additionalProps }: Props) {
+export default function Cell({
+  children,
+  className,
+  noWrap,
+  width,
+  isHeader,
+  ...additionalProps
+}: Props) {
   return (
-    <td
-      className={classnames(cssClass.CELL, noWrap && cssClass.NO_WRAP, className)}
-      style={{ width }}
-      {...additionalProps}
-    >
-      {children}
-    </td>
+    <>
+      {isHeader ? (
+        <th
+          className={classnames(cssClass.CELL, noWrap && cssClass.NO_WRAP, className)}
+          style={{ width }}
+          {...additionalProps}
+        >
+          {children}
+        </th>
+      ) : (
+        <td
+          className={classnames(cssClass.CELL, noWrap && cssClass.NO_WRAP, className)}
+          style={{ width }}
+          {...additionalProps}
+        >
+          {children}
+        </td>
+      )}
+    </>
   );
 }
 
@@ -34,4 +54,5 @@ Cell.propTypes = {
   children: PropTypes.node,
   noWrap: PropTypes.bool,
   width: PropTypes.string,
+  isHeader: PropTypes.bool,
 };

--- a/src/Table2Beta/HeaderCell.tsx
+++ b/src/Table2Beta/HeaderCell.tsx
@@ -34,18 +34,28 @@ export default function HeaderCell({
   activeSortDirection,
   width,
 }: Props) {
+  const Enter = "Enter";
+  const Space = " ";
+
   return (
     <Cell
+      isHeader
+      aria-sort={sortable && activeSortDirection ? `${activeSortDirection}ending` : null}
       className={classnames(cssClass.HEADER_CELL, sortable && cssClass.SORTABLE, className)}
       onClick={() => sortable && onSortChange()}
+      onKeyUp={(e) => (e.key === Enter || e.key === Space) && sortable && onSortChange()}
       width={width}
     >
       <FlexBox alignItems={ItemAlign.CENTER}>
-        <div className={cssClass.LABEL} role={sortable ? "button" : null}>
+        <div
+          className={cssClass.LABEL}
+          tabIndex={sortable ? 0 : null}
+          role={sortable ? "button" : null}
+        >
           {children}
         </div>
         {sortable && (
-          <div>
+          <div aria-hidden="true">
             <SortIcons direction={activeSortDirection} className={cssClass.SORT} />
           </div>
         )}


### PR DESCRIPTION
# Jira: 
[PRTL-2609](https://clever.atlassian.net/browse/PRTL-2609) and [PRTL-2611](https://clever.atlassian.net/browse/PRTL-2611)

# Overview:
This PR makes changes to both `Table` and `Table2Beta` components, following the [accessible table design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/table/) for a table with sortable rows

* Distinguishing the use of `th` for header cells vs `td` for data cells
* Adding `aria-sort` so VO can announce "sort up/sort down"

# Screenshots/GIFs:
## Before
### using the Tab key

https://user-images.githubusercontent.com/38148568/191340125-d84e8ad5-99ce-4f45-ba14-8b72d6c67eba.mov



### using VoiceOver

https://user-images.githubusercontent.com/38148568/191339669-c5dff4fc-7f94-4c76-aa2d-011d7d0e342f.mov


## After
### using the Tab key

https://user-images.githubusercontent.com/38148568/191340242-afe5dc63-12b8-46fa-a023-8e1953d0b145.mov



### using VoiceOver

https://user-images.githubusercontent.com/38148568/191339854-569bf8da-d659-420b-807c-705290f1e0d6.mov



# Testing:

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
