### PR TITLE
PRTL-2770 toast notification a11y

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.205.0",
+  "version": "2.206.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ToastStack/ToastNotification.tsx
+++ b/src/ToastStack/ToastNotification.tsx
@@ -70,7 +70,7 @@ export class ToastNotification extends React.PureComponent<Props> {
         alignItems={ItemAlign.CENTER}
       >
         <FontAwesome name={iconMap[type]} size="lg" spin={type === ToastType.PROCESSING} />
-        <FlexBox className={cssClass.CONTENT} grow aria-live="polite">
+        <FlexBox className={cssClass.CONTENT} grow role="alert">
           {children}
         </FlexBox>
         {action && (


### PR DESCRIPTION
# Jira: [PRTL-2770](https://clever.atlassian.net/browse/PRTL-2770)

# Overview:
Currently, `ToastNotification` has a `aria-live="polite"` tag, which announces the notification in a less-disruptive manner. Because of this, I've found that whenever a notification is dispatched AND the focus returns to a button, screen reader will announce the button and omit the toast message altogether. Adding `role="alert"` to ensure screen reader will announce the messages right away

Tested in all places that send out notifications

# Screenshots/GIFs:
 ### 🎧 🔊

## Before
### Launch an app button
https://user-images.githubusercontent.com/38148568/192397306-f793a623-e0e2-4b29-968a-cd815d710da4.mov

### Share feedback button
https://user-images.githubusercontent.com/38148568/192397336-f9a29663-2209-4bfa-9747-f34db0471272.mov

## After
### Launch an app button
https://user-images.githubusercontent.com/38148568/192397319-95997b4b-ebf5-4a15-a1a7-504061ccbe82.mov

### Share feedback button
https://user-images.githubusercontent.com/38148568/192397357-9e9c6266-8506-42a2-9107-c5fa2d04b998.mov

# Testing:

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
