### PR TITLE
add optional placeholder prop to Select2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.207.0",
+  "version": "2.208.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Select2/Select2.tsx
+++ b/src/Select2/Select2.tsx
@@ -29,6 +29,7 @@ export interface Props {
   value: string;
   onChange: (value: string) => void;
   size?: Values<typeof FormElementSize>;
+  placeholder?: string;
 }
 
 export const cssClass = {
@@ -71,6 +72,7 @@ const Select2: React.FC<Props> = ({
   value,
   onChange,
   size,
+  placeholder,
 }) => {
   const [createdOption, setCreatedOption] = useState<Option | null>(null);
   const options = createdOption ? [...initialOptions, createdOption] : initialOptions;
@@ -222,6 +224,7 @@ const Select2: React.FC<Props> = ({
         <input
           id={id}
           name={id}
+          placeholder={placeholder}
           className={cssClass.INPUT}
           {...getInputProps({
             ref: inputRef,


### PR DESCRIPTION
# Overview:
Adding an optional `placeholder` prop to `Select2` component. Motivated by a design change in [PRTL-3047](https://clever.atlassian.net/browse/PRTL-3047) that requires placeholders in the teacher resource dropdowns

# Screenshots/GIFs:
![Oct-19-2022 13-01-23](https://user-images.githubusercontent.com/38148568/196815462-baa8e061-c7fa-4c75-8fd5-05951725655a.gif)

**Tested locally in launchpad:**

![Oct-19-2022 13-09-10](https://user-images.githubusercontent.com/38148568/196815493-8938874b-1ff7-4c62-8dba-0c5508e433a7.gif)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
