### PR TITLE
fix: TopBarButton remains in focus after it's been clicked

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.209.0",
+  "version": "2.210.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TopBar/TopBarButton.tsx
+++ b/src/TopBar/TopBarButton.tsx
@@ -38,6 +38,12 @@ export class TopBarButton extends React.PureComponent<Props> {
     }
   }
 
+  blur() {
+    if (this._containerRef && this._containerRef.blur) {
+      this._containerRef.blur();
+    }
+  }
+
   render() {
     const { active, children, className, href, onClick } = this.props;
     const additionalProps = _.omit(this.props, Object.keys(propTypes));
@@ -54,7 +60,13 @@ export class TopBarButton extends React.PureComponent<Props> {
             this.props.round ? "TopBarButton--rounded" : null,
           )}
           href={href}
-          onClick={onClick}
+          onClick={() => {
+            // Button should not stay in active/focused state after it has been invoked.
+            // Otherwise, button looks like it's still active, even after clicking it.
+            // See PRTL-3215 for example of this bug
+            this.blur();
+            onClick();
+          }}
           ref={(ref) => {
             this._containerRef = ref;
           }}


### PR DESCRIPTION
# Jira: [PRTL-3215]

# Overview:
Before this fix, TopBarButton will remain visually in the selected/focused state after the button has been clicked. This behavior has been hidden in the past b/c TopBarButton didn't usually invoke a Modal. You can see this bug in this video:

## On click bug
https://user-images.githubusercontent.com/79538533/202751217-fec42fef-14fb-4dc0-b24c-48bc92057663.mov

## After fix
On click of the question-mark icon and on closing the modal, notice that the question-mark TopBarButton is no longer active/selected/focused looking.

https://user-images.githubusercontent.com/79538533/202751104-8a0f940d-7a2b-44ca-ac36-7c65297c00b7.mov

# Testing:
- [x] Passes `make format lint`
- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[PRTL-3215]: https://clever.atlassian.net/browse/PRTL-3215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ