### PR TITLE
removed input focus as conditional from errorValidation

### DIFF
--- a/docs/components/TextInput2View.jsx
+++ b/docs/components/TextInput2View.jsx
@@ -33,6 +33,7 @@ export default class TextInput2View extends React.PureComponent {
     requirement: FormElementRequirement.REQUIRED,
     obscurable: false,
     errorOnEmpty: false,
+    errorOnFocus: false,
     size: FormElementSize.MEDIUM,
   };
 
@@ -73,6 +74,7 @@ export default class TextInput2View extends React.PureComponent {
               obscurable={this.state.obscurable}
               value={this.state.value}
               errorOnEmpty={this.state.errorOnEmpty}
+              errorOnFocus={this.state.errorOnFocus}
               errorValidation={(value) => (value.toLowerCase() !== value ? "only lowercase" : null)}
               onChange={(e) => this.setState({ value: e.target.value })}
               size={this.state.size}
@@ -96,6 +98,7 @@ export default class TextInput2View extends React.PureComponent {
       requirement,
       obscurable,
       errorOnEmpty,
+      errorOnFocus,
       size,
     } = this.state;
 
@@ -166,6 +169,15 @@ export default class TextInput2View extends React.PureComponent {
             onChange={(e) => this.setState({ errorOnEmpty: e.target.checked })}
           />{" "}
           <span className={cssClass.CONFIG_TEXT}>Error on empty</span>
+        </label>
+        <label className={cssClass.CONFIG}>
+          <input
+            type="checkbox"
+            className={cssClass.CONFIG_TOGGLE}
+            checked={errorOnFocus}
+            onChange={(e) => this.setState({ errorOnFocus: e.target.checked })}
+          />{" "}
+          <span className={cssClass.CONFIG_TEXT}>Error on focus</span>
         </label>
         <div className={cssClass.CONFIG}>
           <span className={cssClass.CONFIG_TEXT}>Requirement:</span>
@@ -263,6 +275,13 @@ export default class TextInput2View extends React.PureComponent {
             type: "boolean",
             description:
               "Display an error state when the input value is empty and the input is out of focus",
+            optional: true,
+          },
+          {
+            name: "errorOnFocus",
+            type: "boolean",
+            description:
+              "Display an error state when the input value does not meet validation criteria and the input is in focus",
             optional: true,
           },
           {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.210.1",
+  "version": "2.211.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",
@@ -106,7 +106,7 @@
     "typescript": "3.x",
     "url-loader": "^0.5.7",
     "webpack": "^5.24.2",
-    "webpack-cli": "^4.5.0",
+    "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^3.11.2"
   },
   "peer-dependencies": {

--- a/src/TextInput2/TextInput2.tsx
+++ b/src/TextInput2/TextInput2.tsx
@@ -90,7 +90,7 @@ const TextInput2: React.FC<Props> = ({
 
     const newErrorMessage = errorValidation(value);
     // only show error when input isn't in focus
-    if (newErrorMessage && !isFocused) {
+    if (newErrorMessage) {
       setErrorMessage(newErrorMessage);
       return;
     }

--- a/src/TextInput2/TextInput2.tsx
+++ b/src/TextInput2/TextInput2.tsx
@@ -89,7 +89,6 @@ const TextInput2: React.FC<Props> = ({
     }
 
     const newErrorMessage = errorValidation(value);
-    // only show error when input isn't in focus
     if (newErrorMessage) {
       setErrorMessage(newErrorMessage);
       return;

--- a/src/TextInput2/TextInput2.tsx
+++ b/src/TextInput2/TextInput2.tsx
@@ -93,11 +93,11 @@ const TextInput2: React.FC<Props> = ({
 
     const newErrorMessage = errorValidation(value);
     // show error if input is out of focus
-    if (newErrorMessage && !isFocused && !errorOnFocus) {
+    if (newErrorMessage && !isFocused) {
       setErrorMessage(newErrorMessage);
     }
     // show error if input is in focus
-    else if (newErrorMessage && errorOnFocus) {
+    else if (newErrorMessage && isFocused && errorOnFocus) {
       setErrorMessage(newErrorMessage);
       return;
     }

--- a/src/TextInput2/TextInput2.tsx
+++ b/src/TextInput2/TextInput2.tsx
@@ -21,6 +21,8 @@ export interface Props {
   requirement?: Values<typeof FormElementRequirement>;
   obscurable?: boolean;
   errorOnEmpty?: boolean;
+  // option to return an error message while input is in focus
+  errorOnFocus?: boolean;
   // returns an error message, null for no error
   errorValidation?: (value: string) => string | null;
   value: string;
@@ -63,6 +65,7 @@ const TextInput2: React.FC<Props> = ({
   icon,
   requirement,
   errorOnEmpty,
+  errorOnFocus,
   errorValidation,
   obscurable,
   value,
@@ -89,7 +92,12 @@ const TextInput2: React.FC<Props> = ({
     }
 
     const newErrorMessage = errorValidation(value);
-    if (newErrorMessage) {
+    // show error if input is out of focus
+    if (newErrorMessage && !isFocused && !errorOnFocus) {
+      setErrorMessage(newErrorMessage);
+    }
+    // show error if input is in focus
+    else if (newErrorMessage && errorOnFocus) {
       setErrorMessage(newErrorMessage);
       return;
     }

--- a/src/TextInput2/TextInput2_test.tsx
+++ b/src/TextInput2/TextInput2_test.tsx
@@ -84,7 +84,7 @@ describe("TextInput2", () => {
       input.simulate("focus");
       changeInputValue(input, invalidValue);
       const errorContainer = getErrorContainer(wrapper);
-      // error should be dsiplayed while element is still in focus
+      // error should be displayed while element is still in focus
       expect(errorContainer).toExist();
     });
 

--- a/src/TextInput2/TextInput2_test.tsx
+++ b/src/TextInput2/TextInput2_test.tsx
@@ -76,6 +76,18 @@ describe("TextInput2", () => {
       };
     });
 
+    it("displays error while focused and errorOnFocus is true", () => {
+      defaultProps.errorOnFocus = true;
+      wrapper = mount(<TextInput2 {...defaultProps} />);
+      const input = getInput(wrapper);
+
+      input.simulate("focus");
+      changeInputValue(input, invalidValue);
+      const errorContainer = getErrorContainer(wrapper);
+      // error should be dsiplayed while element is still in focus
+      expect(errorContainer).toExist();
+    });
+
     it("displays error on blur if provided errorValidation function returns a string", () => {
       wrapper = mount(<TextInput2 {...defaultProps} />);
       const input = getInput(wrapper);
@@ -84,7 +96,7 @@ describe("TextInput2", () => {
       changeInputValue(input, invalidValue);
       let errorContainer = getErrorContainer(wrapper);
       // error should not be displayed while element is still in focus
-      expect(errorContainer).toExist();
+      expect(errorContainer).not.toExist();
 
       input.simulate("blur");
       errorContainer = getErrorContainer(wrapper);

--- a/src/TextInput2/TextInput2_test.tsx
+++ b/src/TextInput2/TextInput2_test.tsx
@@ -84,7 +84,7 @@ describe("TextInput2", () => {
       changeInputValue(input, invalidValue);
       let errorContainer = getErrorContainer(wrapper);
       // error should not be displayed while element is still in focus
-      expect(errorContainer).not.toExist();
+      expect(errorContainer).toExist();
 
       input.simulate("blur");
       errorContainer = getErrorContainer(wrapper);


### PR DESCRIPTION
# Jira: [PRTL-3206](https://clever.atlassian.net/browse/PRTL-3206)

# Overview:
There is a validation error bug on the `EditLinkPanel` custom component in `launchpad`. An `errorOnFocus` prop was created to allow the option to display error messages while the input is still in focus

# Screenshots/GIFs:
https://user-images.githubusercontent.com/105511993/206551289-852ce7d7-717e-4700-b7fd-c49c7eeec63d.mov


# Testing:
- [x] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
