### PR TITLE
POC-344 - fix bug with x button in message attachment while previewing an attachment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.211.1",
+  "version": "2.212.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AttachmentPreview/AttachmentPreview.less
+++ b/src/AttachmentPreview/AttachmentPreview.less
@@ -178,7 +178,6 @@
 
   .AttachmentPreview--FooterBar {
     .zIndex--6;
-    display: flex;
     .justify--end();
     background-color: @neutral_black;
     position: fixed;

--- a/src/AttachmentPreview/AttachmentPreview.less
+++ b/src/AttachmentPreview/AttachmentPreview.less
@@ -178,14 +178,12 @@
 
   .AttachmentPreview--FooterBar {
     .zIndex--6;
-    .justify--end();
     background-color: @neutral_black;
     position: fixed;
     bottom: 0;
     left: 0;
     width: 100%;
     height: @HEADER_BAR_HEIGHT;
-    .alignItems(center);
     color: @neutral_white;
   }
 
@@ -194,7 +192,6 @@
   }
 
   .AttachmentPreview--FooterBar .AttachmentPreview--DownloadContainer {
-    .flexbox();
     text-align: right;
     .margin--right--m();
     .margin--left--m();

--- a/src/AttachmentPreview/AttachmentPreview.tsx
+++ b/src/AttachmentPreview/AttachmentPreview.tsx
@@ -115,12 +115,12 @@ export const AttachmentPreview: React.FC<Props> = ({
           )}
         </FlexBox>
       </FlexBox>
-      <FlexBox className={cssClass.FOOTER_BAR}>
+      <div className={cssClass.FOOTER_BAR}>
         <Button type="linkPlain" className={cssClass.DOWNLOAD_CONTAINER} onClick={onClickDownload}>
           <FontAwesome className={cssClass.DOWNLOAD_BUTTON} name="download" />{" "}
           <span>{downloadButtonTextMobile}</span>
         </Button>
-      </FlexBox>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# Jira: [POC-344](https://clever.atlassian.net/browse/PRTL-344)

# Overview:

When previewing an attachment in the message field that you are about to send, the "x" button shifted to the right.
<img width="464" alt="257 PM here's an attachment message" src="https://user-images.githubusercontent.com/14099028/212171488-1b6fa584-ae75-4046-b494-95c06f4896f0.png">

The fix was getting rid of the unnecessary flexbox in the attachment footerbar container.

- Launchpad post-fix:
<img width="582" alt="Click to view" src="https://user-images.githubusercontent.com/14099028/212171606-28bf8e2e-8cfd-457c-967f-69e7af47a10a.png">

- Fampo post-fix
<img width="765" alt="Send en melding" src="https://user-images.githubusercontent.com/14099028/212171653-e76b49c5-24ba-41d2-bdd2-807fddc1a9fd.png">

# Testing:

- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
