### PR TITLE
fix: deprecate messaging components in favor of dew3y versions

### DIFF
--- a/src/MessagingAvatar/MessagingAvatar.tsx
+++ b/src/MessagingAvatar/MessagingAvatar.tsx
@@ -23,6 +23,9 @@ type Props = {
   imageSrc?: string;
 };
 
+/**
+ * @deprecated Do not use. Instead, use [@clever/msg-avatar](https://github.com/Clever/clever-ui/tree/master/packages/msg-avatar)
+ */
 export const MessagingAvatar: React.FC<Props> = ({ className, text, color, imageSrc }: Props) => {
   // If an imageSrc is provided, it takes precedent over displaying text
   if (imageSrc) {

--- a/src/MessagingBubble/DeletedMessagingBubble.tsx
+++ b/src/MessagingBubble/DeletedMessagingBubble.tsx
@@ -21,6 +21,9 @@ export interface Props {
   deletionNoticeText: string;
 }
 
+/**
+ * @deprecated Do not use. Instead, use [@clever/msg-bubble DeletedBubble](https://github.com/Clever/clever-ui/blob/master/packages/msg-bubble/src/lib/deleted/DeletedBubble.tsx)
+ */
 export const DeletedMessagingBubble: React.FC<Props> = ({
   className,
   messageOwnership,

--- a/src/MessagingBubble/MessagingBubble.tsx
+++ b/src/MessagingBubble/MessagingBubble.tsx
@@ -11,6 +11,9 @@ import {
 
 type MessagingBubbleProps = DeletedMessagingBubbleProps | NormalMessagingBubbleProps;
 
+/**
+ * @deprecated Do not use. Instead, use [@clever/msg-bubble Bubble](https://github.com/Clever/clever-ui/blob/master/packages/msg-bubble/src/lib/bubble/Bubble.tsx)
+ */
 export const MessagingBubble: React.FC<MessagingBubbleProps> = (props: MessagingBubbleProps) => {
   switch (props.bubbleType) {
     case "deleted": {

--- a/src/MessagingThreadListItem/MessagingThreadListItem.tsx
+++ b/src/MessagingThreadListItem/MessagingThreadListItem.tsx
@@ -56,6 +56,9 @@ type Props = {
   showNewLabel?: boolean;
 };
 
+/**
+ * @deprecated Do not use. Instead, use [@clever/msg-thread-list-item](https://github.com/Clever/clever-ui/tree/master/packages/msg-thread-list-item)
+ */
 export const MessagingThreadListItem: React.FC<
   Props & { ref?: React.Ref<HTMLDivElement> }
 > = React.forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) => {


### PR DESCRIPTION
# Jira: [PRTL-3143]

# Overview:
- fix: deprecate messaging components in favor of dew3y versions found in `@clever/msg-..`

# Screenshots/GIFs:
![Screen Shot 2023-01-27 at 7 40 45 AM](https://user-images.githubusercontent.com/79538533/215126655-a1a25b19-e99b-4f49-9b40-d2c12a9ac221.png)

# Testing:
N/A
- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step. ✅ 
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[PRTL-3143]: https://clever.atlassian.net/browse/PRTL-3143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ