### PR TITLE
v2.213.0 - PRTL-3390 - Add support for data-test-id prop to several components

### DIFF
--- a/docs/components/ButtonView.jsx
+++ b/docs/components/ButtonView.jsx
@@ -199,6 +199,12 @@ export default function ButtonView() {
             optional: true,
             defaultValue: "false",
           },
+          {
+            name: "dataTestID",
+            type: "string",
+            description: "Optional string to provide a data-testid for frontend tests to use",
+            optional: true,
+          },
         ]}
         className={cssClass.PROPS}
       />

--- a/docs/components/MessagingAttachmentView.jsx
+++ b/docs/components/MessagingAttachmentView.jsx
@@ -263,6 +263,12 @@ export default class MessagingAttachmentView extends React.PureComponent {
               defaultValue: "false",
               optional: true,
             },
+            {
+              name: "dataTestID",
+              type: "string",
+              description: "Optional string to provide a data-testid for frontend tests to use",
+              optional: true,
+            },
           ]}
           className={cssClass.PROPS}
         />

--- a/docs/components/TextAreaView.jsx
+++ b/docs/components/TextAreaView.jsx
@@ -277,6 +277,12 @@ export default class TextAreaView extends React.Component {
               optional: true,
               defaultValue: <code>FormElementSize.FULL_WIDTH</code>,
             },
+            {
+              name: "dataTestID",
+              type: "string",
+              description: "Optional string to provide a data-testid for frontend tests to use",
+              optional: true,
+            },
           ]}
         />
       </View>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.212.1",
+  "version": "2.213.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -215,6 +215,7 @@ function ReplyButton({
   return (
     <Button
       ariaLabel={"Reply"}
+      dataTestID={"replyToAnnouncementButton"}
       className={cssClass("replyButton")}
       onClick={onReply}
       type={"secondary"}

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -21,6 +21,7 @@ export interface Props {
   style?: React.CSSProperties;
   underlined?: boolean;
   ariaLabel?: string;
+  dataTestID?: string;
   [additionalProp: string]: any;
 }
 
@@ -57,6 +58,7 @@ const propTypes = {
   style: PropTypes.object,
   underlined: PropTypes.bool,
   ariaLabel: PropTypes.string,
+  dataTestID: PropTypes.string,
 };
 
 const defaultProps = {
@@ -89,6 +91,7 @@ export class Button extends React.PureComponent<Props> {
   render() {
     const {
       ariaLabel,
+      dataTestID,
       children,
       className,
       disabled,
@@ -135,6 +138,7 @@ export class Button extends React.PureComponent<Props> {
         <button
           {...additionalProps}
           aria-label={aria}
+          data-testid={dataTestID}
           className={classes}
           disabled={disabled}
           onClick={onClick}

--- a/src/FileInput/FileInput.tsx
+++ b/src/FileInput/FileInput.tsx
@@ -211,6 +211,7 @@ export class FileInput extends React.Component<Props, State> {
                   "FileInput--AttachmentIsUploading",
                 iconOnly && "FileInput--IconOnly",
               )}
+              data-testid="fileInput"
             >
               {!iconOnly && selected && renderLabel(label)}
               {!iconOnly && renderMessage(message, selected)}

--- a/src/MessagingAttachment/MessagingAttachment.tsx
+++ b/src/MessagingAttachment/MessagingAttachment.tsx
@@ -36,6 +36,7 @@ type Props = {
   title?: string;
   uploadComplete?: boolean;
   theme?: MessagingTheme;
+  dataTestID?: string;
 };
 
 // TODO: replace with a discriminated union to keep the props neat
@@ -53,6 +54,7 @@ export const MessagingAttachment: React.FC<Props> = ({
   isUpload,
   uploadComplete,
   theme,
+  dataTestID,
 }: Props) => {
   const [attachmentPreviewIsShowing, setAttachmentPreviewIsShowing] = React.useState(false);
   const isPreviewableAttachment = PreviewableFileTypes.has(fileType);
@@ -124,7 +126,7 @@ export const MessagingAttachment: React.FC<Props> = ({
             {errorMsg || title}
           </span>
           {subtitle && (
-            <span role="button" className={cssClass("Subtitle")}>
+            <span data-testid={dataTestID} role="button" className={cssClass("Subtitle")}>
               {subtitle}
             </span>
           )}

--- a/src/MessagingInput/MessagingInput.tsx
+++ b/src/MessagingInput/MessagingInput.tsx
@@ -152,6 +152,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
               hasMultiLineText && cssClass("TextField--MultiLine"),
             )}
             name={TEXT_FIELD_NAME}
+            dataTestID={"newMessageInput"}
             value={value}
             onChange={(e) => {
               onChange(e.target.value);
@@ -202,6 +203,7 @@ const MessagingInputRenderFunction: React.ForwardRefRenderFunction<MessagingInpu
           disabled={isMessageSendDisabled(disableSendButton, value, attachments)}
           onClick={() => onSubmit(value.trim())}
           ariaLabel={sendButtonText}
+          dataTestID={"sendNewMessageButton"}
         />
       </FlexBox>
       {formReturnKeyInstructionsLabel(showReturnKeyInstructions, value)}

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -19,6 +19,7 @@ export interface Props {
   minLength?: number;
   name: string;
   id?: string;
+  dataTestID?: string;
   onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
   onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
   onFocus?: React.FocusEventHandler<HTMLTextAreaElement>;
@@ -234,6 +235,7 @@ export class TextArea extends React.Component<Props, State> {
       className: "TextArea--input",
       disabled: this.props.disabled,
       id,
+      ["data-testid"]: this.props.dataTestID,
       maxLength: this.props.maxLength,
       minLength: this.props.minLength,
       name: this.props.name,

--- a/src/TopBar/index.tsx
+++ b/src/TopBar/index.tsx
@@ -66,6 +66,7 @@ export class TopBar extends React.PureComponent<Props> {
           href={this.props.logoHref}
           onClick={this.props.onLogoClick}
           className="dewey-TopBar--logoLink"
+          data-testid="topBarLogoLink"
         >
           {customLogo || (
             <Logo className="dewey--TopBar--logo" svgClassName="dewey--TopBar--logo--mobile" />


### PR DESCRIPTION
# Jira: [PRTL-3390](https://clever.atlassian.net/browse/PRTL-3390)

# Overview:

Add support for data-test-id prop to several components, to be used in Clever Messaging tests in frontend-to-end-tester.

# Screenshots/GIFs:

No visual changes to any components. From local version of Dewey, here's some screenshots of the `data-testid`s in MessagingInput working correctly:

![Screenshot 2023-02-17 at 2 33 51 PM](https://user-images.githubusercontent.com/57963785/219809058-fe8884e2-4a48-4c38-a608-32dca7b2f82f.png)
![Screenshot 2023-02-17 at 2 34 39 PM](https://user-images.githubusercontent.com/57963785/219809070-848431fa-236f-4835-a10c-89d0ddc71e41.png)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[PRTL-3390]: https://clever.atlassian.net/browse/PRTL-3390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ