### PR TITLE
POC-388: Pass event as prop in onClick handler to ExpandableContainer component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.213.0",
+  "version": "2.214.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ExpandableContainer/ExpandableContainer.tsx
+++ b/src/ExpandableContainer/ExpandableContainer.tsx
@@ -13,7 +13,7 @@ export interface Props {
   children: React.ReactNode;
   className?: string;
   isExpanded?: boolean;
-  onClick?: () => void;
+  onClick?: (e : React.MouseEvent) => void;
   title: React.ReactNode;
 }
 


### PR DESCRIPTION
# Jira: [TKT-000](https://clever.atlassian.net/browse/TKT-000)

# Overview:
Exposing the event for the onClick handler, since we're needing to conditionally expand/collapse this component depending on which element within the title was clicked. https://clever.atlassian.net/browse/POC-388

# Screenshots/GIFs:

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
