### PR TITLE
[PRTL-3512] updates clickable rows to have tab index for focusability and a11y

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.214.0",
+  "version": "2.215.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -434,6 +434,7 @@ export class Table extends React.Component<Props, State> {
                 )}
                 key={rowIDFn(rowData)}
                 onClick={(e) => onRowClick && onRowClick(e, rowIDFn(rowData), rowData)}
+                tabIndex={onRowClick ? 0 : undefined}
                 onMouseOver={(e) => onRowMouseOver && onRowMouseOver(e, rowIDFn(rowData), rowData)}
               >
                 {columns.map(({ props: col }: { props: any }) => (


### PR DESCRIPTION
# Jira: [PRTL-3512](https://clever.atlassian.net/browse/PRTL-3512)

# Overview

This PR updates the `Table` component so that it's clickable rows have a `tabindex` value. Note that this only applies when the row is clickable! This is helpful for accessibility because it means that clickable rows are actually reachable by screen reading tools.

I'm making this change primarily because I need the rows to be able to have a `focus` state, which is only available for elements with a `tabindex` value. That's for [this design in the portal refresh project](https://www.figma.com/file/vNAz4bVF6knCw0em1GTOHD/Prefresh---Limited-Release-Design-QA?type=whiteboard&node-id=5-664&t=WrWY0CNQelouyIGi-0#428609070).

# Screenshots/GIFs:

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[PRTL-3512]: https://clever.atlassian.net/browse/PRTL-3512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ