### PR TITLE
TopBarButton only attempts to call onClick if truthy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.215.0",
+  "version": "2.215.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/TopBar/TopBarButton.tsx
+++ b/src/TopBar/TopBarButton.tsx
@@ -65,7 +65,7 @@ export class TopBarButton extends React.PureComponent<Props> {
             // Otherwise, button looks like it's still active, even after clicking it.
             // See PRTL-3215 for example of this bug
             this.blur();
-            onClick();
+            if (onClick) onClick();
           }}
           ref={(ref) => {
             this._containerRef = ref;


### PR DESCRIPTION
# Jira: [DO-825](https://clever.atlassian.net/browse/DO-825)

# Overview:

Since `onClick` is an optional property, we check if it's truthy before attempting to call it. **Note:** I didn't implement a short-circuiting approach (e.g. `onClick && onClick();`) because that triggered an es-lint `no-unused-expressions` error.

# Screenshots/GIFs:

# Testing:

Manually tested with `sd2` using [these instructions](https://clever.atlassian.net/wiki/spaces/ENG/pages/2471526424/Testing+Dewey+Components+Locally+in+Launchpad)

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[DO-825]: https://clever.atlassian.net/browse/DO-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ