### PR TITLE
change WizardLayout subtitle prop type from String to ReactNode

### DIFF
--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -293,8 +293,8 @@ export default class WizardLayoutView extends React.PureComponent {
           },
           {
             name: "subtitle",
-            type: "String",
-            description: "Subtitle string to be displayed in the header.",
+            type: "React.Node",
+            description: "Subtitle component to be displayed in the header.",
             optional: true,
           },
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.216.1",
+  "version": "2.217.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.216.1",
+  "version": "2.217.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -22,7 +22,7 @@ export interface Props {
   prevStepButtonDisabled?: boolean;
   prevStepButtonText?: React.ReactNode;
   stepper: React.ReactNode;
-  subtitle?: string;
+  subtitle?: React.ReactNode;
   title: string;
 }
 
@@ -46,7 +46,7 @@ const propTypes = {
   onPrevStep: PropTypes.func.isRequired,
   sections: PropTypes.arrayOf(SECTION_PROP_TYPE).isRequired,
   stepper: PropTypes.node.isRequired,
-  subtitle: PropTypes.string,
+  subtitle: PropTypes.node,
   title: PropTypes.string.isRequired,
 };
 
@@ -112,7 +112,7 @@ export default class WizardLayout extends React.PureComponent<Props> {
           {headerImg && <div className={cssClass.HEADER_IMG}>{headerImg}</div>}
           <div>
             <p className={cssClass.HEADER_TITLE}>{title}</p>
-            {subtitle && <p className={cssClass.HEADER_SUBTITLE}>{subtitle}</p>}
+            {subtitle && <div className={cssClass.HEADER_SUBTITLE}>{subtitle}</div>}
           </div>
         </FlexBox>
         <FlexBox className={classnames(cssClass.BODY, fullscreen && cssClass.BODY_FULLSCREEN)}>

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -112,7 +112,12 @@ export default class WizardLayout extends React.PureComponent<Props> {
           {headerImg && <div className={cssClass.HEADER_IMG}>{headerImg}</div>}
           <div>
             <p className={cssClass.HEADER_TITLE}>{title}</p>
-            {subtitle && <div className={cssClass.HEADER_SUBTITLE}>{subtitle}</div>}
+            {subtitle &&
+              (typeof subtitle === "string" ? (
+                <p className={cssClass.HEADER_SUBTITLE}>{subtitle}</p>
+              ) : (
+                <div className={cssClass.HEADER_SUBTITLE}>{subtitle}</div>
+              ))}
           </div>
         </FlexBox>
         <FlexBox className={classnames(cssClass.BODY, fullscreen && cssClass.BODY_FULLSCREEN)}>


### PR DESCRIPTION
# Overview:
As part of https://clever.atlassian.net/browse/DID-1489, we want to pass in `ReactNode` as prop to `subtitle`. By passing in `ReactNode` we can support more styling in the subtitle, and this also won't break any existing instances that pass in `String`

# Testing:
- [x] tested locally:
<img width="1001" alt="Screenshot 2023-07-10 at 2 31 26 PM" src="https://github.com/Clever/components/assets/38148568/76629087-12a5-4bd1-a56e-c105405828f2">
<br></br>

- [x] copied `dist` directory to test with local sd2 and made sure nothing breaks and that the change doesn't cause backward issues:
<img width="1352" alt="Screenshot 2023-07-10 at 3 04 01 PM" src="https://github.com/Clever/components/assets/38148568/4ae0267c-326a-49ee-a801-eb22a4c3da57">

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
