### PR TITLE
Changing WizardLayout title prop type from String to ReactNode

### DIFF
--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -227,7 +227,7 @@ export default class WizardLayoutView extends React.PureComponent {
             name: "sections",
             type: "Object",
             description:
-              "Array of objects with a title, subtitle, and content (React.Node to be displayed).",
+              "Array of objects with a title (React.node), subtitle (string), and content (React.Node to be displayed).",
           },
           {
             name: "headerImg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.219.0",
+  "version": "2.218.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.217.0",
+  "version": "2.219.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.218.0",
+  "version": "2.219.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.219.0",
+  "version": "2.217.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.217.0",
+  "version": "2.218.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/WizardLayout/WizardLayout.less
+++ b/src/WizardLayout/WizardLayout.less
@@ -89,6 +89,7 @@
   .text--large();
   .text--semi-bold();
   .margin--bottom--none();
+  .padding--y--xs();
   width: 100%;
   color: @neutral_dark_gray;
 }

--- a/src/WizardLayout/WizardLayout.less
+++ b/src/WizardLayout/WizardLayout.less
@@ -89,7 +89,7 @@
   .text--large();
   .text--semi-bold();
   .margin--bottom--none();
-  .padding--y--xs();
+  line-height: 1.5;
   width: 100%;
   color: @neutral_dark_gray;
 }

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -27,7 +27,7 @@ export interface Props {
 }
 
 const SECTION_PROP_TYPE = PropTypes.shape({
-  title: PropTypes.string,
+  title: PropTypes.node,
   subtitle: PropTypes.string,
   content: PropTypes.node.isRequired,
 });
@@ -134,7 +134,12 @@ export default class WizardLayout extends React.PureComponent<Props> {
           <FlexBox column grow className={cssClass.SECTION_CONTAINER}>
             {sections.map((elem, i) => (
               <div className={cssClass.SECTION} key={i}>
-                {elem.title && <p className={cssClass.SECTION_TITLE}>{elem.title}</p>}
+                {elem.title && typeof elem.title === "string" && (
+                  <p className={cssClass.SECTION_TITLE}>{elem.title}</p>
+                )}
+                {elem.title && typeof elem.title !== "string" && (
+                  <div className={cssClass.SECTION_TITLE}>{elem.title}</div>
+                )}
                 {elem.subtitle && <p className={cssClass.SECTION_SUBTITLE}>{elem.subtitle}</p>}
                 {(elem.subtitle || elem.title) && <div className={cssClass.SECTION_DIVIDER} />}
                 {elem.content}

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -134,8 +134,12 @@ export default class WizardLayout extends React.PureComponent<Props> {
           <FlexBox column grow className={cssClass.SECTION_CONTAINER}>
             {sections.map((elem, i) => (
               <div className={cssClass.SECTION} key={i}>
-                {elem.title && typeof elem.title === "string" && <p className={cssClass.SECTION_TITLE}>{elem.title}</p>}
-                {elem.title && typeof elem.title !== "string" && <div className={cssClass.SECTION_TITLE}>{elem.title}</div>}
+                {elem.title && typeof elem.title === "string" && (
+                  <p className={cssClass.SECTION_TITLE}>{elem.title}</p>
+                )}
+                {elem.title && typeof elem.title !== "string" && (
+                  <div className={cssClass.SECTION_TITLE}>{elem.title}</div>
+                )}
                 {elem.subtitle && <p className={cssClass.SECTION_SUBTITLE}>{elem.subtitle}</p>}
                 {(elem.subtitle || elem.title) && <div className={cssClass.SECTION_DIVIDER} />}
                 {elem.content}

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -134,12 +134,7 @@ export default class WizardLayout extends React.PureComponent<Props> {
           <FlexBox column grow className={cssClass.SECTION_CONTAINER}>
             {sections.map((elem, i) => (
               <div className={cssClass.SECTION} key={i}>
-                {elem.title && typeof elem.title === "string" && (
-                  <p className={cssClass.SECTION_TITLE}>{elem.title}</p>
-                )}
-                {elem.title && typeof elem.title !== "string" && (
-                  <div className={cssClass.SECTION_TITLE}>{elem.title}</div>
-                )}
+                {elem.title && <div className={cssClass.SECTION_TITLE}>{elem.title}</div>}
                 {elem.subtitle && <p className={cssClass.SECTION_SUBTITLE}>{elem.subtitle}</p>}
                 {(elem.subtitle || elem.title) && <div className={cssClass.SECTION_DIVIDER} />}
                 {elem.content}

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -134,7 +134,8 @@ export default class WizardLayout extends React.PureComponent<Props> {
           <FlexBox column grow className={cssClass.SECTION_CONTAINER}>
             {sections.map((elem, i) => (
               <div className={cssClass.SECTION} key={i}>
-                {elem.title && <div className={cssClass.SECTION_TITLE}>{elem.title}</div>}
+                {elem.title && typeof elem.title === "string" && <p className={cssClass.SECTION_TITLE}>{elem.title}</p>}
+                {elem.title && typeof elem.title !== "string" && <div className={cssClass.SECTION_TITLE}>{elem.title}</div>}
                 {elem.subtitle && <p className={cssClass.SECTION_SUBTITLE}>{elem.subtitle}</p>}
                 {(elem.subtitle || elem.title) && <div className={cssClass.SECTION_DIVIDER} />}
                 {elem.content}


### PR DESCRIPTION
# Jira: [UM-3030](https://clever.atlassian.net/browse/UM-3030)
Making step titles type be react nodes instead of strings so that GCRi wizard can have an "Optional" pill in the name. This meant changing the tag in which it was displayed in from `<p>` to `<div>`.

<img width="1027" alt="Screenshot 2023-08-03 at 1 56 44 PM" src="https://github.com/Clever/components/assets/83550685/eaa039d7-69fd-4c6c-8533-b51f7b14f243">

# testing:
manual testing:
Making sure styling is still correct for steps with subtitles and ones without. 

Step with subtitle (before):
<img width="1027" alt="Screenshot 2023-08-03 at 2 01 58 PM" src="https://github.com/Clever/components/assets/83550685/c96cf6f8-95f1-465f-9157-277803572a3f">

step with subtitle (after)
<img width="1027" alt="Screenshot 2023-08-03 at 2 01 50 PM" src="https://github.com/Clever/components/assets/83550685/9130bd10-fa35-4a22-b1cb-b62df438ba08">


Step without subtitle (before):
<img width="1027" alt="Screenshot 2023-08-03 at 2 02 42 PM" src="https://github.com/Clever/components/assets/83550685/156df9fc-f344-4681-a861-daf13939e67c">

step without subtitle (after):
<img width="1027" alt="Screenshot 2023-08-03 at 2 02 38 PM" src="https://github.com/Clever/components/assets/83550685/b4f74e6c-a1d7-46d8-a3fe-1e526e1cd3e3">

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component

[UM-3030]: https://clever.atlassian.net/browse/UM-3030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ