### PR TITLE
UM-3054: Adding tooltip for next button in WizardLayout

### DIFF
--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -257,6 +257,20 @@ export default class WizardLayoutView extends React.PureComponent {
             optional: true,
           },
           {
+            name: "nextStepButtonTooltipEnabled",
+            type: "Boolean",
+            description: "Optional tooltip for the next step button",
+            defaultValue: false,
+            optional: true,
+          },
+          {
+            name: "nextStepButtonTooltipText",
+            type: "String",
+            description: "Optional next button tooltip text",
+            defaultValue: "default text",
+            optional: true,
+          },
+          {
             name: "onNextStep",
             type: "Function",
             description: "Called when user clicks on 'Next step' button.",

--- a/docs/components/WizardLayoutView.jsx
+++ b/docs/components/WizardLayoutView.jsx
@@ -257,17 +257,10 @@ export default class WizardLayoutView extends React.PureComponent {
             optional: true,
           },
           {
-            name: "nextStepButtonTooltipEnabled",
-            type: "Boolean",
-            description: "Optional tooltip for the next step button",
-            defaultValue: false,
-            optional: true,
-          },
-          {
             name: "nextStepButtonTooltipText",
             type: "String",
             description: "Optional next button tooltip text",
-            defaultValue: "default text",
+            defaultValue: "",
             optional: true,
           },
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.218.0",
+  "version": "2.219.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.219.0",
+  "version": "2.220.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.219.0",
+  "version": "2.220.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.218.0",
+  "version": "2.219.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -7,6 +7,7 @@ import { FlexBox, ItemAlign } from "../flex";
 
 import LifeFloat from "./LifeFloat";
 import "./WizardLayout.less";
+import Tooltip from "../Tooltip";
 
 export interface Props {
   className?: string;
@@ -17,6 +18,8 @@ export interface Props {
   hidePreviousStepButton?: boolean;
   nextStepButtonDisabled?: boolean;
   nextStepButtonText?: React.ReactNode;
+  nextStepButtonTooltipEnabled?: boolean;
+  nextStepButtonTooltipText?: string;
   onNextStep: () => void;
   onPrevStep: () => void;
   prevStepButtonDisabled?: boolean;
@@ -40,6 +43,8 @@ const propTypes = {
   hidePreviousStepButton: PropTypes.bool,
   nextStepButtonDisabled: PropTypes.bool,
   nextStepButtonText: PropTypes.node,
+  nextStepButtonTooltipEnabled: PropTypes.bool,
+  nextStepButtonTooltipText: PropTypes.string,
   prevStepButtonDisabled: PropTypes.bool,
   prevStepButtonText: PropTypes.node,
   onNextStep: PropTypes.func.isRequired,
@@ -89,6 +94,8 @@ export default class WizardLayout extends React.PureComponent<Props> {
       helpContent,
       nextStepButtonDisabled,
       nextStepButtonText,
+      nextStepButtonTooltipEnabled,
+      nextStepButtonTooltipText,
       hidePreviousStepButton,
       prevStepButtonDisabled,
       prevStepButtonText,
@@ -160,13 +167,20 @@ export default class WizardLayout extends React.PureComponent<Props> {
               disabled={prevStepButtonDisabled}
             />
           )}
-          <Button
-            type="primary"
-            value={nextStepButtonText || "Next step"}
-            className={cssClass.NEXT_BUTTON}
-            onClick={this._onNextStep}
-            disabled={nextStepButtonDisabled}
-          />
+          <Tooltip
+            content={nextStepButtonTooltipText || "default text"}
+            hide={!nextStepButtonTooltipEnabled}
+          >
+            <span>
+              <Button
+                type="primary"
+                value={nextStepButtonText || "Next step"}
+                className={cssClass.NEXT_BUTTON}
+                onClick={this._onNextStep}
+                disabled={nextStepButtonDisabled}
+              />
+            </span>
+          </Tooltip>
         </FlexBox>
       </FlexBox>
     );

--- a/src/WizardLayout/WizardLayout.tsx
+++ b/src/WizardLayout/WizardLayout.tsx
@@ -18,7 +18,6 @@ export interface Props {
   hidePreviousStepButton?: boolean;
   nextStepButtonDisabled?: boolean;
   nextStepButtonText?: React.ReactNode;
-  nextStepButtonTooltipEnabled?: boolean;
   nextStepButtonTooltipText?: string;
   onNextStep: () => void;
   onPrevStep: () => void;
@@ -43,7 +42,6 @@ const propTypes = {
   hidePreviousStepButton: PropTypes.bool,
   nextStepButtonDisabled: PropTypes.bool,
   nextStepButtonText: PropTypes.node,
-  nextStepButtonTooltipEnabled: PropTypes.bool,
   nextStepButtonTooltipText: PropTypes.string,
   prevStepButtonDisabled: PropTypes.bool,
   prevStepButtonText: PropTypes.node,
@@ -94,7 +92,6 @@ export default class WizardLayout extends React.PureComponent<Props> {
       helpContent,
       nextStepButtonDisabled,
       nextStepButtonText,
-      nextStepButtonTooltipEnabled,
       nextStepButtonTooltipText,
       hidePreviousStepButton,
       prevStepButtonDisabled,
@@ -104,6 +101,16 @@ export default class WizardLayout extends React.PureComponent<Props> {
       title,
       fullscreen,
     } = this.props;
+
+    const nextButton = (
+      <Button
+        type="primary"
+        value={nextStepButtonText || "Next step"}
+        className={cssClass.NEXT_BUTTON}
+        onClick={this._onNextStep}
+        disabled={nextStepButtonDisabled}
+      />
+    );
 
     return (
       <FlexBox
@@ -167,20 +174,15 @@ export default class WizardLayout extends React.PureComponent<Props> {
               disabled={prevStepButtonDisabled}
             />
           )}
-          <Tooltip
-            content={nextStepButtonTooltipText || "default text"}
-            hide={!nextStepButtonTooltipEnabled}
-          >
-            <span>
-              <Button
-                type="primary"
-                value={nextStepButtonText || "Next step"}
-                className={cssClass.NEXT_BUTTON}
-                onClick={this._onNextStep}
-                disabled={nextStepButtonDisabled}
-              />
-            </span>
-          </Tooltip>
+          {!!nextStepButtonTooltipText && (
+            <Tooltip
+              content={nextStepButtonTooltipText || "default text"}
+              hide={!nextStepButtonTooltipText}
+            >
+              <span>{nextButton}</span>
+            </Tooltip>
+          )}
+          {!nextStepButtonTooltipText && nextButton}
         </FlexBox>
       </FlexBox>
     );


### PR DESCRIPTION
# Jira: [UM-3054](https://clever.atlassian.net/browse/UM-3054)

# Overview:
We want to be able to show a tooltip for the next button (not just the next button text).

# Screenshots/GIFs:
<img width="1091" alt="Screenshot 2023-08-14 at 1 26 01 PM" src="https://github.com/Clever/components/assets/83550685/e6772a0f-4cc1-4c83-b087-651599a189ce">


# Testing:
ensured other wizards still worked. These are optional props so it shouldn't break anything. tooltip is hidden on default. 

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[UM-3054]: https://clever.atlassian.net/browse/UM-3054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ