### PR TITLE
PRTL-4452 - MessagingThreadHistory accessibility fix for message ownership

### DIFF
--- a/docs/components/MessagingThreadHistoryView.jsx
+++ b/docs/components/MessagingThreadHistoryView.jsx
@@ -31,16 +31,18 @@ function randomElement(items) {
 function newMessage(displayAlertMessageAfter = false) {
   const message = randomElement(["Hello!", "Hi!", "How are you doing?"]);
   const placement = randomElement(["left", "right"]);
+  const senderName = placement === "right" ? "My Name" : "Other User";
   const errorMsg = randomElement(["Message failed to send", ""]);
   newestTime.add(6, "hours");
   currentMessageIndex++;
   return {
     content: (
-      <MessagingBubble theme={placement === "left" ? "otherMessage" : "ownMessage"}>
+      <MessagingBubble messageOwnership={placement === "left" ? "otherMessage" : "ownMessage"}>
         {message}
       </MessagingBubble>
     ),
     placement,
+    senderName,
     timestamp: new Date(newestTime),
     index: currentMessageIndex,
     readStatusText: errorMsg ? "" : "Read",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.219.0",
+  "version": "2.220.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/MessagingThreadHistory.less
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.less
@@ -13,12 +13,31 @@
   }
 }
 
-.ThreadHistory--Divider {
+.ThreadHistory--Divider--Date {
   .margin--y--m();
   font-size: 0.875rem;
+  .text--semi-bold();
   .text--line-height-1();
   color: @neutral_medium_gray;
   .text--center();
+}
+
+.ThreadHistory--Divider--Name--right {
+  .margin--right--xs();
+  .text--medium();
+  .text--semi-bold();
+  .text--line-height-1();
+  color: @neutral_medium_gray;
+  .text--right();
+}
+
+.ThreadHistory--Divider--Name--left {
+  .margin--left--xs();
+  .text--medium();
+  .text--semi-bold();
+  .text--line-height-1();
+  color: @neutral_medium_gray;
+  .text--left();
 }
 
 .ThreadHistory--FirstMessage {

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -11,7 +11,9 @@ import "./MessagingThreadHistory.less";
 
 const cssClasses = {
   CONTAINER: "ThreadHistory--Container",
-  DIVIDER: "ThreadHistory--Divider",
+  DIVIDER_DATE: "ThreadHistory--Divider--Date",
+  DIVIDER_NAME_RIGHT: "ThreadHistory--Divider--Name--right",
+  DIVIDER_NAME_LEFT: "ThreadHistory--Divider--Name--left",
   FIRST_MESSAGE: "ThreadHistory--FirstMessage",
 };
 
@@ -24,6 +26,7 @@ export interface MessageData {
   readStatusText?: string;
   displayAlertMessageAfter?: { icon: string; messageText: string };
   errorMsg?: string;
+  senderName?: string;
 }
 
 interface Props {
@@ -121,9 +124,10 @@ function _interleaveMessagesWithDividers(
   messages: MessageData[],
   lastMessageRef: React.MutableRefObject<HTMLDivElement>,
 ) {
-  // Interleave dividers (e.g. "Today," "Yesterday", "May 20") with messages.
+  // Interleave dividers (e.g. dates, user names) with messages.
   const messagesWithDividers: React.ReactNode[] = [];
   let currentDay = "";
+  let currentSenderName = "";
   messages.forEach((message: MessageData, i) => {
     // If the message has a timestamp (i.e. is not Clever-generated) and was sent on a different
     // day than the previous message, we want a divider (with the date) in between.
@@ -131,12 +135,26 @@ function _interleaveMessagesWithDividers(
       const messageDay = _formatDateForDivider(message.timestamp);
       if (currentDay !== messageDay) {
         messagesWithDividers.push(
-          <div key={`divider-${messageDay}`} className={cssClasses.DIVIDER}>
+          <div key={`divider-${messageDay}`} className={cssClasses.DIVIDER_DATE}>
             {messageDay}
           </div>,
         );
         currentDay = messageDay;
       }
+    }
+    if (message.senderName && ["right", "left"].includes(message.placement)) {
+      if (currentSenderName !== message.senderName) {
+        const dividerClass =
+          message.placement === "left"
+            ? cssClasses.DIVIDER_NAME_LEFT
+            : cssClasses.DIVIDER_NAME_RIGHT;
+        messagesWithDividers.push(
+          <div key={`divider-${message.senderName}-message${i}`} className={dividerClass}>
+            {message.senderName}
+          </div>,
+        );
+      }
+      currentSenderName = message.senderName;
     }
     // All content is wrapped in MessageMetadata, which handles placement and timestamps.
     messagesWithDividers.push(


### PR DESCRIPTION
# JIRA
[PRTL-4452](https://clever.atlassian.net/browse/PRTL-4452)

# Overview
MessagingThreadHistory should make it clear in a non-visual manner which message was sent by whom. The new name dividers above each string of messages sent by a given user will accomplish that, for both sighted users and screen-reader reliant users.

I thought about taking this chance to move this big ol' component to Dew3y, but I think we may want more time to re-think it in the move, rather than a quick-and-dirty port. 🤔 

# Screenshots/GIFs

![Screenshot 2023-10-10 at 12 03 10 PM](https://github.com/Clever/components/assets/57963785/4f313df3-cbd9-4df8-83b7-9ba934be767d)
![Screenshot 2023-10-10 at 12 03 20 PM](https://github.com/Clever/components/assets/57963785/0e613990-0011-4a44-a55d-550aed92e721)
![Screenshot 2023-10-10 at 12 19 20 PM](https://github.com/Clever/components/assets/57963785/9676b725-99ca-4d12-90ee-5dea70e30e67)

# Testing

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [x] Firefox

# Roll Out

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component

[PRTL-4452]: https://clever.atlassian.net/browse/PRTL-4452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ