### PR TITLE
PRTL-4470: Fix Menu buttons using mousedown instead of onclick

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.221.0",
+  "version": "2.221.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.221.0",
+  "version": "2.221.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Menu/MenuItem.tsx
+++ b/src/Menu/MenuItem.tsx
@@ -86,18 +86,6 @@ export default class MenuItem extends React.PureComponent<Props> {
       MenuButton = href && !disabled ? "a" : "button";
     }
 
-    // Safari fires focusout events on button mousedown events - it basically removes and returns
-    // focus between mousedown and mouseup. Yes, that is quite weird.
-    //
-    // To avoid closing the menu before the user is done clicking a button menu item, we trigger
-    // onClick on mousedown instead.
-    //
-    // This only needs to be done for buttons, not anchors.
-    let onMouseDown;
-    if (MenuButton === "button") {
-      onMouseDown = onClick;
-    }
-
     return (
       <MenuButton
         {...additionalProps}
@@ -111,7 +99,6 @@ export default class MenuItem extends React.PureComponent<Props> {
         href={href}
         onBlur={onBlur}
         onClick={onClick}
-        onMouseDown={onMouseDown}
         onMouseEnter={onMouseEnter}
         disabled={disabled}
         role="menuitem"


### PR DESCRIPTION
# Jira: [PRTL-4470](https://clever.atlassian.net/browse/PRTL-4470)

# Overview:

Mousedown button actions are not accessible. Should be onclick instead.

# Screenshots/GIFs:

Note the triggered-on-mousedown behavior previously seen (main branch, first half of video), then compare to the new triggered-on-click behavior (this branch, second half of video).

The video test was in Safari, as - per the code I nixed - that was the reason for this inaccessible behavior, that something broke in Safari with the menu focus before the modal could open. It seems that in the five years that have elapsed, Safari's behavior has changed. Also tested in Chrome.

https://www.loom.com/share/deb31bfae7274b58bd026f2e9852725e?sid=c4264847-5cb6-448c-b6d6-756f2d67db59

# Testing:

- Manual tests:
  - [x] Chrome
  - [x] Safari

# Roll Out:

💯 

- Before merging:
  - [n/a] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [n/a] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[PRTL-4470]: https://clever.atlassian.net/browse/PRTL-4470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ