### PR TITLE
Prtl 4849 allow custom ref for menu trigger element

### DIFF
--- a/docs/components/MenuView.jsx
+++ b/docs/components/MenuView.jsx
@@ -343,6 +343,13 @@ export default class MenuView extends React.PureComponent {
             ),
             default: false,
           },
+          {
+            name: "triggerRefOverride",
+            type: "React.RefObject<HTMLElement>",
+            description:
+              "Optional ref override for the triggering element, for accessibility purposes (e.g. returning focus after modal close).",
+            optional: true,
+          },
         ]}
         className={cssClass.PROPS}
       />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.221.1",
+  "version": "2.222.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.221.1",
+  "version": "2.222.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -21,6 +21,7 @@ export interface Props {
   placement?: Values<typeof Placement>;
   stayOpenOnSelect?: boolean;
   trigger: React.ReactElement;
+  triggerRefOverride?: React.RefObject<HTMLElement>;
   wrapItems?: boolean;
   [additionalProp: string]: any;
 }
@@ -108,7 +109,16 @@ export default class Menu extends React.PureComponent<Props> {
   };
 
   render() {
-    const { className, maxHeight, maxWidth, minWidth, placement, trigger, wrapItems } = this.props;
+    const {
+      className,
+      maxHeight,
+      maxWidth,
+      minWidth,
+      placement,
+      trigger,
+      triggerRefOverride,
+      wrapItems,
+    } = this.props;
     const { open } = this.state;
 
     const additionalProps = _.omit(
@@ -132,7 +142,7 @@ export default class Menu extends React.PureComponent<Props> {
             className: classnames(cssClass.TRIGGER, trigger.props.className),
             id: this.IDs.TRIGGER,
             onClick: this._handleTriggerClick,
-            ref: this._handleTriggerRef,
+            ref: triggerRefOverride || this._handleTriggerRef,
             role: "button",
           })}
           {open && (


### PR DESCRIPTION
# Jira: [PRTL-4849](https://clever.atlassian.net/browse/PRTL-4849)

# Overview:

Currently, passing a `ref` to the Menu puts it on the Menu element rather than the trigger, and passing a `ref` to the trigger element leads to it being ignored in favor of the in-component use of the trigger ref.

For the use case of needing to return focus for accessibility reasons (e.g. when a modal is closed, you must return focus to the element which opened it), we need the option to override the default ref behavior. As the menu is closed when the modal opens, we need to return focus to the trigger element of the menu.

# Screenshots/GIFs:

# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Firefox

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[PRTL-4849]: https://clever.atlassian.net/browse/PRTL-4849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ