### PR TITLE
POC-536 - Add optional prop to Menu that restores MenuItem Safari compatibility at cost of accessibility

### DIFF
--- a/docs/components/MenuView.jsx
+++ b/docs/components/MenuView.jsx
@@ -350,6 +350,13 @@ export default class MenuView extends React.PureComponent {
               "Optional ref override for the triggering element, for accessibility purposes (e.g. returning focus after modal close).",
             optional: true,
           },
+          {
+            name: "useSafariCompatibilityMode",
+            type: "boolean",
+            description:
+              "Optional prop for improved Safari compatibility at the cost of accessibility. Use in conjunction with frontend useragent detection.",
+            optional: true,
+          },
         ]}
         className={cssClass.PROPS}
       />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.222.0",
+  "version": "2.223.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.222.0",
+  "version": "2.223.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -23,6 +23,7 @@ export interface Props {
   trigger: React.ReactElement;
   triggerRefOverride?: React.RefObject<HTMLElement>;
   wrapItems?: boolean;
+  useSafariCompatibilityMode?: boolean;
   [additionalProp: string]: any;
 }
 
@@ -43,6 +44,7 @@ const propTypes = {
   stayOpenOnSelect: PropTypes.bool,
   trigger: PropTypes.node.isRequired,
   wrapItems: PropTypes.bool,
+  useSafariCompatibilityMode: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -118,6 +120,7 @@ export default class Menu extends React.PureComponent<Props> {
       trigger,
       triggerRefOverride,
       wrapItems,
+      useSafariCompatibilityMode,
     } = this.props;
     const { open } = this.state;
 
@@ -163,6 +166,7 @@ export default class Menu extends React.PureComponent<Props> {
                     focused: this._isFocused(menuItem, i),
                     onClick: (e) => this._handleItemClick(menuItem, e),
                     onMouseEnter: (e) => this._handleItemMouseEnter(menuItem, i, e),
+                    useSafariCompatibilityMode,
                   })}
                 </li>
               ))}

--- a/src/Menu/MenuItem.tsx
+++ b/src/Menu/MenuItem.tsx
@@ -19,6 +19,7 @@ export interface Props {
   onMouseEnter?: Function;
   selected?: boolean;
   target?: string;
+  useSafariCompatibilityMode?: boolean;
   [additionalProp: string]: any;
 }
 
@@ -35,6 +36,7 @@ const propTypes = {
   onMouseEnter: PropTypes.func,
   selected: PropTypes.bool,
   target: PropTypes.string,
+  useSafariCompatibilityMode: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -77,6 +79,7 @@ export default class MenuItem extends React.PureComponent<Props> {
       selected,
       target,
       disabled,
+      useSafariCompatibilityMode,
     } = this.props;
     const additionalProps = _.omit(this.props, Object.keys(propTypes));
 
@@ -84,6 +87,18 @@ export default class MenuItem extends React.PureComponent<Props> {
     if (!MenuButton) {
       // Render disabled href elements as buttons so that they can be disabled
       MenuButton = href && !disabled ? "a" : "button";
+    }
+
+    // Safari fires focusout events on button mousedown events - it basically removes and returns
+    // focus between mousedown and mouseup. Yes, that is quite weird.
+    //
+    // To avoid closing the menu before the user is done clicking a button menu item, we trigger
+    // onClick on mousedown instead.
+    //
+    // This only needs to be done for buttons, not anchors.
+    let onMouseDown: Function;
+    if (useSafariCompatibilityMode && MenuButton === "button") {
+      onMouseDown = onClick;
     }
 
     return (
@@ -99,6 +114,7 @@ export default class MenuItem extends React.PureComponent<Props> {
         href={href}
         onBlur={onBlur}
         onClick={onClick}
+        onMouseDown={onMouseDown}
         onMouseEnter={onMouseEnter}
         disabled={disabled}
         role="menuitem"


### PR DESCRIPTION
# Jira: [POC-536](https://clever.atlassian.net/browse/POC-536)

# Overview:

Add optional prop to Menu that restores MenuItem Safari compatibility (onMouseDown trigger instead of onClick) at the cost of overall accessibility.

# Testing:

Tested in local launchpad, and it indeed functions exactly as it should: clicks trigger on mouse-down in Safari (instead of not at all).

No changes in behavior if the prop value is false or undefined.

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[POC-536]: https://clever.atlassian.net/browse/POC-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ