### PR TITLE
CLASSE-655 - Fix AnnouncementBubble disabled Reply button tooltip position

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.223.0",
+  "version": "2.223.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
+++ b/src/AnnouncementBubble/NormalAnnouncementBubble.tsx
@@ -252,18 +252,20 @@ function DisabledReplyButton({
         textAlign={"center"}
         tooltipClassName={cssClass("tooltip")}
       >
-        <FlexBox alignItems="center" justify="center">
-          <img
-            alt=""
-            className={cssClass("replyButton--icon")}
-            src={require("./messages-dark-gray-icon.svg")}
-          />
-          <span
-            className={cx(cssClass("replyButton--text"), cssClass("replyButton--text--disabled"))}
-          >
-            {replyButtonText || "Reply"}
-          </span>
-        </FlexBox>
+        <div>
+          <FlexBox alignItems="center" justify="center">
+            <img
+              alt=""
+              className={cssClass("replyButton--icon")}
+              src={require("./messages-dark-gray-icon.svg")}
+            />
+            <span
+              className={cx(cssClass("replyButton--text"), cssClass("replyButton--text--disabled"))}
+            >
+              {replyButtonText || "Reply"}
+            </span>
+          </FlexBox>
+        </div>
       </Tooltip>
     </Button>
   );


### PR DESCRIPTION
Wrap FlexBox inside disabled Reply button in AnnouncementBubble with a div, so that tooltip is positioned properly above it (as opposed to window top-left).

# Jira: [CLASSE-655](https://clever.atlassian.net/browse/CLASSE-655)

# Overview:

# Screenshots/GIFs:

## Before
(see: top-left)
![Screen Shot 2022-05-09 at 11 16 09 AM](https://github.com/Clever/components/assets/57963785/1b391b89-f3a0-462e-baf0-7bce5e7a8e6a)

## After
(see: right above hovered/focused button)
<img width="701" alt="Screenshot 2024-02-08 at 3 13 10 PM" src="https://github.com/Clever/components/assets/57963785/c92a2b56-8acf-4054-ae83-910537950b49">

# Testing:

Tested in local launchpad and family-portal, to view in context.

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [x] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[CLASSE-655]: https://clever.atlassian.net/browse/CLASSE-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ