### PR TITLE
Shapi 1293 fix visual bug in left nav component when collapsed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.223.0",
+  "version": "2.223.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/LeftNav/LeftNav.tsx
+++ b/src/LeftNav/LeftNav.tsx
@@ -84,7 +84,6 @@ export class LeftNav extends React.PureComponent<Props, State> {
   _getNonEmptyChildren(children: LeftNavChildren) {
     return _.compact(React.Children.toArray(children)) as React.ReactElement[];
   }
-
   render() {
     const {
       children,
@@ -93,13 +92,19 @@ export class LeftNav extends React.PureComponent<Props, State> {
       collapsed,
       narrow,
       withActiveNavGroups,
-      withTooltips,
     } = this.props;
+    let { withTooltips } = this.props;
     const { openNavGroup } = this.state;
     const _collapsed = collapsed || (collapseOnSubNavOpen && !!openNavGroup);
 
     // Clone all of the children so that we can attach our own click handlers
     const navItems = this._getNonEmptyChildren(children).map((child) => {
+      // Disable ToolTips when LeftNav is not collapsed
+      if (_collapsed) {
+        withTooltips = true;
+      } else {
+        withTooltips = false;
+      }
       // Configure top level NavLinks to close any open NavGroup on click
       if (child.type === NavLink) {
         return React.cloneElement(child, {


### PR DESCRIPTION
# Jira: 
[SHAPI-1293](https://clever.atlassian.net/jira/software/projects/SHAPI/boards/257?selectedIssue=SHAPI-1293)

# Overview:

There is an existing bug in the LeftNav component which makes the tooltip that shows up when we hover over an icon with the nav collapse stay, even if the nav has be uncollapsed. (Which is affecting at least Apps-dashboard LeftNav)

# Screenshots/GIFs:

Before:

https://github.com/user-attachments/assets/4c197be2-2362-4ef5-8bb2-02e7e8b986f5

After:


https://github.com/user-attachments/assets/a58a64c9-8048-4a82-be4b-fa00154109ff



# Testing:

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:
100%
- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[SHAPI-1293]: https://clever.atlassian.net/browse/SHAPI-1293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ