### PR TITLE
ASOC-417 - Add button and tootlip props to EditableInfoPanel

### DIFF
--- a/docs/components/EditableInfoPanelView.jsx
+++ b/docs/components/EditableInfoPanelView.jsx
@@ -22,7 +22,8 @@ export default class EditableInfoPanelView extends React.PureComponent {
   static cssClass = cssClass;
 
   state = {
-    modalOpen: false,
+    exampleOneModalOpen: false,
+    exampleTwoModalOpen: false,
     column1Content: "column 1 content",
     column2Content: "column 2 content",
     normalContent: "normal content",
@@ -61,14 +62,17 @@ export default class EditableInfoPanelView extends React.PureComponent {
                   </FlexItem>
                 </FlexBox>
               }
-              onClick={() => this.setState({ modalOpen: true })}
+              onClick={() => this.setState({ exampleOneModalOpen: true })}
             >
               <div className="EditableInfoPanel--column">{this.state.column1Content}</div>
               <div className="EditableInfoPanel--column">{this.state.column2Content}</div>
               <div>{this.state.normalContent}</div>
             </EditableInfoPanel>
-            {this.state.modalOpen && (
-              <Modal title="Edit Content" closeModal={() => this.setState({ modalOpen: false })}>
+            {this.state.exampleOneModalOpen && (
+              <Modal
+                title="Edit Content"
+                closeModal={() => this.setState({ exampleOneModalOpen: false })}
+              >
                 <TextInput
                   label="Column 1 Content"
                   placeholder={this.state.column1Content}
@@ -86,6 +90,44 @@ export default class EditableInfoPanelView extends React.PureComponent {
                   placeholder={this.state.normalContent}
                   onChange={(e) => this.setState({ normalContent: e.target.value })}
                   value={this.state.normalContent}
+                />
+              </Modal>
+            )}
+          </ExampleCode>
+        </Example>
+
+        <Example title="With buttonProps and tooltipProps:">
+          <ExampleCode>
+            <EditableInfoPanel
+              className="my--custom--class"
+              title={
+                <FlexBox alignItems={ItemAlign.CENTER}>
+                  <Icon size={Icon.sizes.MEDIUM} name={Icon.names.CHAT} />
+                  <FlexItem className={cssClass.TITLE_TEXT}>
+                    <p>Editable Info Panel Title</p>
+                  </FlexItem>
+                </FlexBox>
+              }
+              onClick={() => this.setState({ exampleTwoModalOpen: true })}
+              tooltipProps={{
+                content: "You don't have permission to edit this content.",
+                placement: "right",
+              }}
+              buttonProps={{ disabled: true, value: "Modify" }}
+            >
+              <div className="EditableInfoPanel--column">{this.state.column1Content}</div>
+              <div>{this.state.normalContent}</div>
+            </EditableInfoPanel>
+            {this.state.exampleTwoModalOpen && (
+              <Modal
+                title="Edit Content"
+                closeModal={() => this.setState({ exampleTwoModalOpen: false })}
+              >
+                <TextInput
+                  label="Column 1 Content"
+                  placeholder={this.state.column1Content}
+                  onChange={(e) => this.setState({ column1Content: e.target.value })}
+                  value={this.state.column1Content}
                 />
               </Modal>
             )}
@@ -111,6 +153,18 @@ export default class EditableInfoPanelView extends React.PureComponent {
             name: "className",
             type: "string",
             description: "Optional additional CSS class name to apply to the container.",
+            optional: true,
+          },
+          {
+            name: "buttonProps",
+            type: "Button.Props",
+            description: "Optional overrides for the button on the right.",
+            optional: true,
+          },
+          {
+            name: "tooltipProps",
+            type: "Tooltip.Props",
+            description: "Optional tooltip that wraps around the button on the right.",
             optional: true,
           },
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.223.2",
+  "version": "2.224.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.223.2",
+  "version": "2.224.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/EditableInfoPanel/EditableInfoPanel.tsx
+++ b/src/EditableInfoPanel/EditableInfoPanel.tsx
@@ -35,7 +35,6 @@ const cssClass = {
   CONTAINER: "EditableInfoPanel",
   HEADER: "EditableInfoPanel--header",
   CONTENT: "EditableInfoPanel--content",
-  BUTTON: "EditableInfoPanel--button",
 };
 
 export default class EditableInfoPanel extends React.PureComponent<Props> {

--- a/src/EditableInfoPanel/EditableInfoPanel.tsx
+++ b/src/EditableInfoPanel/EditableInfoPanel.tsx
@@ -1,9 +1,11 @@
 import * as classnames from "classnames";
 import * as PropTypes from "prop-types";
 import * as React from "react";
-import { Button } from "../Button/Button";
+import { Button, Props as ButtonProps } from "../Button/Button";
 import FlexBox from "../flex/FlexBox";
 import FlexItem from "../flex/FlexItem";
+import { Props as TooltipProps } from "../Tooltip/Tooltip";
+import Tooltip from "../Tooltip/Tooltip";
 
 import "./EditableInfoPanel.less";
 
@@ -12,6 +14,12 @@ export interface Props {
   className?: string;
   title?: React.ReactNode;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
+  buttonProps?: ButtonProps;
+  tooltipProps?: EditableInfoPanelTooltipProps;
+}
+
+export interface EditableInfoPanelTooltipProps extends Omit<TooltipProps, "children"> {
+  children?: React.ReactNode | null;
 }
 
 const propTypes = {
@@ -19,26 +27,45 @@ const propTypes = {
   className: PropTypes.string,
   title: PropTypes.node,
   onClick: PropTypes.func.isRequired,
+  buttonProps: PropTypes.object,
+  tooltipProps: PropTypes.object,
 };
 
 const cssClass = {
   CONTAINER: "EditableInfoPanel",
   HEADER: "EditableInfoPanel--header",
   CONTENT: "EditableInfoPanel--content",
+  BUTTON: "EditableInfoPanel--button",
 };
 
 export default class EditableInfoPanel extends React.PureComponent<Props> {
   static propTypes = propTypes;
 
   render() {
-    const { title, children, className, onClick } = this.props;
+    const { title, className, children, onClick, buttonProps, tooltipProps } = this.props;
+
+    const btn = (
+      <Button
+        {...{
+          value: "Edit",
+          size: "small",
+          onClick,
+          ...buttonProps,
+        }}
+      />
+    );
     return (
       <div className={classnames(cssClass.CONTAINER, className)}>
         <FlexBox className={cssClass.HEADER}>
           {title}
           <FlexItem grow />
           <FlexItem>
-            <Button value="Edit" size="small" onClick={onClick} />
+            {tooltipProps && (
+              <Tooltip {...tooltipProps}>
+                <span>{btn}</span>
+              </Tooltip>
+            )}
+            {!tooltipProps && btn}
           </FlexItem>
         </FlexBox>
         <div className={cssClass.CONTENT}>{children}</div>

--- a/test/EditableInfoPanel_test.tsx
+++ b/test/EditableInfoPanel_test.tsx
@@ -5,41 +5,41 @@ import { shallow } from "enzyme";
 import EditableInfoPanel from "../src/EditableInfoPanel";
 
 describe("EditableInfoPanel", () => {
-    it("uses default buttonProps and does not render tooltip when buttonProps and tooltipProps are not provided", () => {
-        const wrapper = shallow(
-            <EditableInfoPanel title="Title" onClick={() => null}>
-                Content
-            </EditableInfoPanel>,
-        );
-        assert.strictEqual(wrapper.find("Button").props().size, "small");
-        assert.strictEqual(wrapper.find("Button").props().value, "Edit");
-        assert.strictEqual(wrapper.find("Tooltip").length, 0);
-    });
-    
-    it("uses buttonProps when provided", () => {
-        const wrapper = shallow(
-            <EditableInfoPanel
-                title="Title"
-                onClick={() => null}
-                buttonProps={{size: "large", value: "New value!"}}
-            >
-                Content
-            </EditableInfoPanel>,
-        );
-        assert.strictEqual(wrapper.find("Button").props().size, "large");
-        assert.strictEqual(wrapper.find("Button").props().value, "New value!");
-    });
+  it("uses default buttonProps and does not render tooltip when buttonProps and tooltipProps are not provided", () => {
+    const wrapper = shallow(
+      <EditableInfoPanel title="Title" onClick={() => null}>
+        Content
+      </EditableInfoPanel>,
+    );
+    assert.strictEqual(wrapper.find("Button").props().size, "small");
+    assert.strictEqual(wrapper.find("Button").props().value, "Edit");
+    assert.strictEqual(wrapper.find("Tooltip").length, 0);
+  });
 
-    it("renders a tooltip when tooltipProps are provided", () => {
-        const wrapper = shallow(
-            <EditableInfoPanel
-                title="Title"
-                onClick={() => null}
-                tooltipProps={{ content: "Tooltip content"}}
-            >
-                Content
-            </EditableInfoPanel>,
-        );
-        assert.strictEqual(wrapper.find("Tooltip").length, 1);
-    });
+  it("uses buttonProps when provided", () => {
+    const wrapper = shallow(
+      <EditableInfoPanel
+        title="Title"
+        onClick={() => null}
+        buttonProps={{ size: "large", value: "New value!" }}
+      >
+        Content
+      </EditableInfoPanel>,
+    );
+    assert.strictEqual(wrapper.find("Button").props().size, "large");
+    assert.strictEqual(wrapper.find("Button").props().value, "New value!");
+  });
+
+  it("renders a tooltip when tooltipProps are provided", () => {
+    const wrapper = shallow(
+      <EditableInfoPanel
+        title="Title"
+        onClick={() => null}
+        tooltipProps={{ content: "Tooltip content" }}
+      >
+        Content
+      </EditableInfoPanel>,
+    );
+    assert.strictEqual(wrapper.find("Tooltip").length, 1);
+  });
 });

--- a/test/EditableInfoPanel_test.tsx
+++ b/test/EditableInfoPanel_test.tsx
@@ -1,0 +1,45 @@
+import * as assert from "assert";
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import EditableInfoPanel from "../src/EditableInfoPanel";
+
+describe("EditableInfoPanel", () => {
+    it("uses default buttonProps and does not render tooltip when buttonProps and tooltipProps are not provided", () => {
+        const wrapper = shallow(
+            <EditableInfoPanel title="Title" onClick={() => null}>
+                Content
+            </EditableInfoPanel>,
+        );
+        assert.strictEqual(wrapper.find("Button").props().size, "small");
+        assert.strictEqual(wrapper.find("Button").props().value, "Edit");
+        assert.strictEqual(wrapper.find("Tooltip").length, 0);
+    });
+    
+    it("uses buttonProps when provided", () => {
+        const wrapper = shallow(
+            <EditableInfoPanel
+                title="Title"
+                onClick={() => null}
+                buttonProps={{size: "large", value: "New value!"}}
+            >
+                Content
+            </EditableInfoPanel>,
+        );
+        assert.strictEqual(wrapper.find("Button").props().size, "large");
+        assert.strictEqual(wrapper.find("Button").props().value, "New value!");
+    });
+
+    it("renders a tooltip when tooltipProps are provided", () => {
+        const wrapper = shallow(
+            <EditableInfoPanel
+                title="Title"
+                onClick={() => null}
+                tooltipProps={{ content: "Tooltip content"}}
+            >
+                Content
+            </EditableInfoPanel>,
+        );
+        assert.strictEqual(wrapper.find("Tooltip").length, 1);
+    });
+});


### PR DESCRIPTION
# Jira:
https://clever.atlassian.net/browse/ASOC-417

# Overview:
Currently, we can't modify the button on this panel component. This PR adds buttonProps and tooltipProps that allow us to customize it further. 


# Screenshots/GIFs:
![Screen Recording 2024-09-04 at 11 48 10 AM](https://github.com/user-attachments/assets/da09497f-9b06-4dd9-a3a3-71ec29b0dd24)

# Testing:
Added tests
- [x] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:
This change is backwards compatible so it will only be updated where neeeded.

- Before merging:
  - [x] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
