### PR TITLE
DING-2147 - update table2beta (tooltip for cellheader)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.224.0",
+  "version": "2.225.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table2Beta/Column.tsx
+++ b/src/Table2Beta/Column.tsx
@@ -12,6 +12,7 @@ export interface Props {
   };
   noWrap?: boolean;
   sortable?: boolean;
+  tooltip?: React.ReactNode;
   sortValueFn?: Function;
   width?: string; // Not included in propTypes but appears to work and is commonly used.
 }
@@ -32,6 +33,7 @@ Column.propTypes = {
   }),
   noWrap: PropTypes.bool,
   sortable: PropTypes.bool,
+  tooltip: PropTypes.node,
   sortValueFn: PropTypes.func,
 };
 

--- a/src/Table2Beta/Header.tsx
+++ b/src/Table2Beta/Header.tsx
@@ -41,6 +41,7 @@ export default function Header({
           key={column.id}
           onSortChange={() => onSortChange(column.id)}
           sortable={column.sortable && !disableSort}
+          tooltip={column.tooltip ? column.tooltip : null}
           width={column.width}
         >
           {column.header && column.header.content}

--- a/src/Table2Beta/HeaderCell.less
+++ b/src/Table2Beta/HeaderCell.less
@@ -36,3 +36,8 @@
     fill: @neutral_black;
   }
 }
+
+.Table--header--cell--tooltip {
+  margin-left: 0.625rem;
+  cursor: pointer;
+}

--- a/src/Table2Beta/HeaderCell.tsx
+++ b/src/Table2Beta/HeaderCell.tsx
@@ -14,6 +14,7 @@ export interface Props {
   children?: React.ReactNode;
   onSortChange?: Function;
   sortable?: boolean;
+  tooltip?: React.ReactNode;
   activeSortDirection?: "asc" | "desc";
   width?: string;
 }
@@ -24,6 +25,7 @@ export const cssClass = {
   LABEL: "Table--header--cell--label",
   SORTABLE: "Table--header--cell--sortable",
   SORT: "Table--header--cell--sort_icons",
+  TOOLTIP: "Table--header--cell--tooltip",
 };
 
 export default function HeaderCell({
@@ -31,6 +33,7 @@ export default function HeaderCell({
   className,
   onSortChange,
   sortable,
+  tooltip,
   activeSortDirection,
   width,
 }: Props) {
@@ -59,6 +62,7 @@ export default function HeaderCell({
             <SortIcons direction={activeSortDirection} className={cssClass.SORT} />
           </div>
         )}
+        {tooltip && <div className={cssClass.TOOLTIP}>{tooltip}</div>}
       </FlexBox>
     </Cell>
   );


### PR DESCRIPTION
# Jira: [DING-2147](https://clever.atlassian.net/browse/DING-2147)

# Overview:

Adding a Tooltip prop for the header cell per [this](https://www.figma.com/design/7kj7xd15WhxHkyOAJUoo2n/Custom-Data-Milestones?node-id=888-28223&node-type=frame&t=ciUZXPkZqpnsP5Ci-0) design from Mancy for the CDR. 

# Screenshots/GIFs:

![Screenshot 2024-11-18 at 1 11 35 PM](https://github.com/user-attachments/assets/bc323bd0-0206-4662-b9fd-9c7a663c7afb)

# Testing:

To test I just placed the Dist Directory in my local SD2 repo, was able to reproduce the new design as shown in the screenshot. 

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[DING-2147]: https://clever.atlassian.net/browse/DING-2147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ