### PR TITLE
Add prop for aria-level for the date dividers in MessagingThreadHistory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.224.0",
+  "version": "2.225.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.225.0",
+  "version": "2.226.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/MessagingThreadHistory/MessagingThreadHistory.tsx
+++ b/src/MessagingThreadHistory/MessagingThreadHistory.tsx
@@ -35,6 +35,7 @@ interface Props {
   messages: MessageData[];
   onScroll?: () => void;
   ariaLabel?: string;
+  dividerAriaLevel?: number;
 }
 
 const SCROLL_BUFFER = 200;
@@ -54,7 +55,7 @@ function isOwnMessage(message: MessageData) {
 
 export const MessagingThreadHistory = React.forwardRef(
   (
-    { className, threadID, messages, onScroll, ariaLabel }: Props,
+    { className, threadID, messages, onScroll, ariaLabel, dividerAriaLevel }: Props,
     containerRef: React.MutableRefObject<HTMLDivElement>,
   ) => {
     // ----------- Scroll position references
@@ -97,7 +98,11 @@ export const MessagingThreadHistory = React.forwardRef(
 
     // ----------- Render
 
-    const messagesWithDividers = _interleaveMessagesWithDividers(messages, lastMessageRef);
+    const messagesWithDividers = _interleaveMessagesWithDividers(
+      messages,
+      lastMessageRef,
+      dividerAriaLevel,
+    );
 
     return (
       <div
@@ -123,6 +128,7 @@ export const MessagingThreadHistory = React.forwardRef(
 function _interleaveMessagesWithDividers(
   messages: MessageData[],
   lastMessageRef: React.MutableRefObject<HTMLDivElement>,
+  dividerAriaLevel: number,
 ) {
   // Interleave dividers (e.g. dates, user names) with messages.
   const messagesWithDividers: React.ReactNode[] = [];
@@ -135,7 +141,11 @@ function _interleaveMessagesWithDividers(
       const messageDay = _formatDateForDivider(message.timestamp);
       if (currentDay !== messageDay) {
         messagesWithDividers.push(
-          <div key={`divider-${messageDay}`} className={cssClasses.DIVIDER_DATE}>
+          <div
+            key={`divider-${messageDay}`}
+            aria-level={dividerAriaLevel}
+            className={cssClasses.DIVIDER_DATE}
+          >
             {messageDay}
           </div>,
         );


### PR DESCRIPTION
# Jira
[CLASSE-1667](https://clever.atlassian.net/browse/CLASSE-1667)
[CLASSE-2095](https://clever.atlassian.net/browse/CLASSE-2095)

# Related PRs

blocks: https://github.com/Clever/launchpad/pull/5861

# Overview:

Add prop for aria-level for the date dividers in MessagingThreadHistory which indicate which day a message has been sent.

# Screenshots/GIFs:

Tested as part of local launchpad instance, to verify it works properly in-app.

![Screenshot 2025-01-30 at 11 59 39 AM](https://github.com/user-attachments/assets/0604531b-5ec9-47bd-9393-0cb63c402e57)

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[CLASSE-1985]: https://clever.atlassian.net/browse/CLASSE-1985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLASSE-2095]: https://clever.atlassian.net/browse/CLASSE-2095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CLASSE-1667]: https://clever.atlassian.net/browse/CLASSE-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ