### PR TITLE
v2.229.1 - Improve accessibility for clickable Table rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.229.0",
+  "version": "2.229.1",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -436,6 +436,8 @@ export class Table extends React.Component<Props, State> {
                 onClick={(e) => onRowClick && onRowClick(e, rowIDFn(rowData), rowData)}
                 tabIndex={onRowClick ? 0 : undefined}
                 onMouseOver={(e) => onRowMouseOver && onRowMouseOver(e, rowIDFn(rowData), rowData)}
+                role={onRowClick ? "button" : undefined}
+                aria-label={onRowClick && rowData.ariaLabel ? rowData.ariaLabel : undefined}
               >
                 {columns.map(({ props: col }: { props: any }) => (
                   <Cell className={getCellClassName(col, rowData)} key={col.id} noWrap={col.noWrap}>


### PR DESCRIPTION
# Jira: [CLASSE-1710](https://clever.atlassian.net/browse/CLASSE-1710)

# Overview:

Table row changes for Table component:
- add role iff onRowClick defined
- add aria-label iff both onRowClick and data.ariaLabel defined

# Screenshots/GIFs:

## Before
![Screenshot 2025-04-14 at 12 11 33 PM](https://github.com/user-attachments/assets/20bda6ae-0029-4d7b-8b16-69c6916e771c)

## After
![Screenshot 2025-04-14 at 12 27 21 PM](https://github.com/user-attachments/assets/4b6f82c4-39f0-4f7d-a067-1763c4f831b2)

# Testing:

Tested in conjunction with local launchpad instance, per screenshots. Also sanity-checked that if the onclick and arialabel are omitted, the table doesn't look or behave any differently than before.

- [ ] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[CLASSE-1710]: https://clever.atlassian.net/browse/CLASSE-1710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ