### PR TITLE
Add aria-label for textInput

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.228.0",
+  "version": "2.229.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -267,6 +267,9 @@ export class TextInput extends React.Component<Props, State> {
             type="button"
             className="TextInput--link"
             onClick={this.toggleHidden}
+            aria-label={
+              this.state.hidden ? `${showButtonText} <label>` : `${hideButtonText} <label>`
+            }
             onMouseDown={(event) => {
               // This prevents focus from jumping to the address bar or
               // the first element on voiceover-enabled iOS devices

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -268,7 +268,9 @@ export class TextInput extends React.Component<Props, State> {
             className="TextInput--link"
             onClick={this.toggleHidden}
             aria-label={
-              this.state.hidden ? `${showButtonText} <label>` : `${hideButtonText} <label>`
+              this.state.hidden
+                ? `${showButtonText} ${this.props.label}`
+                : `${hideButtonText} ${this.props.label}`
             }
             onMouseDown={(event) => {
               // This prevents focus from jumping to the address bar or


### PR DESCRIPTION
# Jira: [AUTH-1833](https://clever.atlassian.net/browse/AUTH-1883)

# Overview:
As part of this [ticket](https://clever.atlassian.net/browse/AUTH-1883), we need to update the TextInput component to include aria-label, with label name "Show <label> "or "Hide <label>".

# Screenshots/GIFs:

# Testing:
Tested locally
1. Hide 
    <img width="554" alt="image" src="https://github.com/user-attachments/assets/f383b499-494e-4fcd-bfbb-44bfac463c3b" />
2. Show
    <img width="562" alt="image" src="https://github.com/user-attachments/assets/277a8920-58a1-4931-98bf-f109963585ca" />


- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:
🧷 
- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[AUTH-1833]: https://clever.atlassian.net/browse/AUTH-1833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ