### PR TITLE
Auth 1868

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.230.0",
+  "version": "2.231.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.230.0",
+  "version": "2.231.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/ExpandableContainer/ExpandableContainer.tsx
+++ b/src/ExpandableContainer/ExpandableContainer.tsx
@@ -33,7 +33,12 @@ export const ExpandableContainer: React.FC<Props> = ({
 }) => {
   return (
     <FlexBox column className={classnames(cssClass.CONTAINER, className)}>
-      <Button className={cssClass.HEADER} type="linkPlain" onClick={onClick} aria-expanded={isExpanded}>
+      <Button
+        className={cssClass.HEADER}
+        type="linkPlain"
+        onClick={onClick}
+        aria-expanded={isExpanded}
+      >
         <FlexBox tabIndex={-1} alignItems="center">
           {title}
           <FlexItem grow />

--- a/src/ExpandableContainer/ExpandableContainer.tsx
+++ b/src/ExpandableContainer/ExpandableContainer.tsx
@@ -33,7 +33,7 @@ export const ExpandableContainer: React.FC<Props> = ({
 }) => {
   return (
     <FlexBox column className={classnames(cssClass.CONTAINER, className)}>
-      <Button className={cssClass.HEADER} type="linkPlain" onClick={onClick}>
+      <Button className={cssClass.HEADER} type="linkPlain" onClick={onClick} aria-expanded={isExpanded}>
         <FlexBox tabIndex={-1} alignItems="center">
           {title}
           <FlexItem grow />


### PR DESCRIPTION


# Jira: [AUTH-1868](https://clever.atlassian.net/jira/software/c/projects/AUTH/boards/267?selectedIssue=AUTH-1868)

# Overview:

Currently the `<ExpandableContainer />` the visually displays when the container has been expanded but doesn't indicate using ARIA when the `<ExpandableContainer />` has been expanded as shown in the video below:


https://github.com/user-attachments/assets/4472970e-8f18-49d5-9ef7-f9cb70a5ff06

The changes introduced in this PR makes it so that the expansion of a `<ExpandableContainer />` is _also_ denoted in its ARIA attributes.

The changes in this PR would are a precursor to fix the accessibility issue seen in MFA Settings. There will be another PR that makes use of this updated to component to fix the issue described in MFA Settings by accessibility pentesters.

# Screenshots/GIFs:

# Testing:

Tested locally `aria-expanded` is correctly set based on the components expanded state:


https://github.com/user-attachments/assets/d30eae98-7911-4516-8f3b-44f5353c29c9




- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [x] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component


[AUTH-1868]: https://clever.atlassian.net/browse/AUTH-1868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ