### PR TITLE
allow react 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.231.0",
+  "version": "2.232.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -110,9 +110,9 @@
     "webpack-dev-server": "^3.11.2"
   },
   "peerDependencies": {
-    "@types/react": ">=16.0.0 <17.0.0",
-    "react": ">=16.0.0 <17.0.0",
-    "react-dom": ">=16.0.0 <17.0.0"
+    "@types/react": ">=16.0.0 <18.0.0",
+    "react": ">=16.0.0 <18.0.0",
+    "react-dom": ">=16.0.0 <18.0.0"
   },
   "scripts": {
     "dev-server": "NODE_OPTIONS=--max_old_space_size=4096 npx webpack serve --mode=development"


### PR DESCRIPTION
# Jira: [TKT-000](https://clever.atlassian.net/browse/TKT-000)

# Overview:
Bump react peer deps to allow react@17

https://legacy.reactjs.org/blog/2020/10/20/react-v17.html

# Screenshots/GIFs:

# Testing:

- [ ] Unit tests
- Manual tests:
  - [ ] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
