### PR TITLE
Update focus trap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.232.0",
+  "version": "2.233.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.231.0",
+  "version": "2.232.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6114,20 +6114,20 @@
       "dev": true
     },
     "focus-trap": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-4.0.2.tgz",
-      "integrity": "sha512-HtLjfAK7Hp2qbBtLS6wEznID1mPT+48ZnP2nkHzgjpL4kroYHg0CdqJ5cTXk+UO5znAxF5fRUkhdyfgrhh8Lzw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-5.1.0.tgz",
+      "integrity": "sha512-CkB/nrO55069QAUjWFBpX6oc+9V90Qhgpe6fBWApzruMq5gnlh90Oo7iSSDK7pKiV5ugG6OY2AXM5mxcmL3lwQ==",
       "requires": {
-        "tabbable": "^3.1.2",
+        "tabbable": "^4.0.0",
         "xtend": "^4.0.1"
       }
     },
     "focus-trap-react": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-6.0.0.tgz",
-      "integrity": "sha512-mvEYxmP75PMx0vOqoIAmJHO/qUEvdTAdz6gLlEZyxxODnuKQdnKea2RWTYxghAPrV+ibiIq2o/GTSgQycnAjcw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-7.0.1.tgz",
+      "integrity": "sha512-12TxHtVntj/sCsT3bwB3pPK+3rACMFLO7LBfk4nKrw1HERRmO/oc0+woD9vZKffxo5zkxkz9amc9rou9reVnpA==",
       "requires": {
-        "focus-trap": "^4.0.2"
+        "focus-trap": "^5.1.0"
       }
     },
     "follow-redirects": {
@@ -13613,9 +13613,9 @@
       "dev": true
     },
     "tabbable": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.2.tgz",
-      "integrity": "sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-4.0.0.tgz",
+      "integrity": "sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ=="
     },
     "table": {
       "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "classnames": "~2.2.5",
     "core-js": "^2.4.1",
     "downshift": "6.1.3",
-    "focus-trap-react": "^6.0.0",
+    "focus-trap-react": "^7.0.1",
     "less": "^3.8.1",
     "linkify-it": "^3.0.2",
     "lodash": "^4.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-components",
-  "version": "2.232.0",
+  "version": "2.233.0",
   "description": "A library of helpful React components and less styles",
   "repository": {
     "type": "git",

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -92,6 +92,7 @@ export class Modal extends React.Component<Props, State> {
         <div className="Modal--window" style={windowStyle} role="dialog" aria-modal="true">
           <header className="Modal--header">
             <button
+              tabIndex={-1}
               className="Modal--close"
               onClick={this.props.closeModal}
               type="button"
@@ -110,7 +111,11 @@ export class Modal extends React.Component<Props, State> {
     );
     let modal;
     if (this.props.focusLocked) {
-      modal = <FocusTrap>{modalContent}</FocusTrap>;
+      modal = (
+        <FocusTrap focusTrapOptions={{ initialFocus: '[aria-label="close modal window"]' }}>
+          {modalContent}
+        </FocusTrap>
+      );
     } else {
       modal = modalContent;
     }


### PR DESCRIPTION
# Jira:

https://clever.atlassian.net/browse/DD-6430

# Overview:

Bump focus-trap-react to v7, which has min version of react 16

# Screenshots/GIFs:
https://github.com/user-attachments/assets/f91e6ba0-b309-4421-aed4-f9d6207d206e

# Testing:
ran locally and tested the focus trap


- [x] Unit tests
- Manual tests:
  - [x] Chrome
  - [ ] Safari
  - [ ] IE11

# Roll Out:

- Before merging:
  - [ ] Updated docs
  - [ ] Bumped version in `package.json`
    - Breaking change?
      - If it is a beta component run `npm version minor`
      - If the component is not in beta run `npm version major`
    - New component or backward-compatible component feature change? Run `npm version minor`
    - Only changing documentation? All good. Skip this step.
  - After creating a new component, make sure to add it to the Components List in `ComponentsView.jsx`. To do so:
    - [ ] Add a screenshot of the component in `docs/assets/img` with the format `<COMPONENT URL LINK>.png`
- After merging:
  - [ ] Deployed updated docs (`make deploy-docs`)
  - [ ] Posted in #eng if I made a breaking change to a beta component
